### PR TITLE
feat: 新增「蜂窝扇」二级菜单样式

### DIFF
--- a/WinPieGestures/ConfigManager.cs
+++ b/WinPieGestures/ConfigManager.cs
@@ -69,6 +69,7 @@ namespace WinPieGestures
         // Multi-Tier Sub-Wheel (多级轮盘与级联子菜单)
         public bool EnableMultiTier { get; set; } = true; // Multi-Tier feature toggle
         public double SubWheelRadiusRatio { get; set; } = 1.55; // Outer ring radius multiplier
+        public string SubmenuStyle { get; set; } = "Wheel"; // "Wheel" (outer sub-ring), "Fan" (honeycomb fan)
         
         public bool ShowText { get; set; } = true;
         public double WheelRadius { get; set; } = 138.0;

--- a/WinPieGestures/GestureController.cs
+++ b/WinPieGestures/GestureController.cs
@@ -22,6 +22,7 @@ namespace WinPieGestures
         private int _selectedSectorIndex = -1;
         private int _selectedSubSectorIndex = -1;
         private bool _lastEscapedState = false;
+        private int _lastSectorIndex = -1; // sector currently displayed (fan style keeps it while aiming at the fan)
 
         [DllImport("user32.dll")]
         [return: MarshalAs(UnmanagedType.Bool)]
@@ -392,24 +393,50 @@ namespace WinPieGestures
                     double sectorAngle = 360.0 / sectorCount;
                     sectorIndex = (int)Math.Floor((angle + (sectorAngle / 2.0)) / sectorAngle) % sectorCount;
 
-                    // Check if mouse moved into outer sub-tier zone
-                    if (multiTierEnabled && distance >= (wheelRadius + 6.0) && _activeProfile != null && sectorIndex >= 0 && sectorIndex < _activeProfile.Actions.Count)
+                    bool fanStyle = multiTierEnabled &&
+                        string.Equals(ConfigManager.CurrentConfig.SubmenuStyle, "Fan", StringComparison.OrdinalIgnoreCase);
+
+                    // Fan style: while the pointer aims within the fan's angular band of the currently
+                    // displayed sector, keep that sector (so the fan doesn't jump while reaching for a sub)
+                    if (fanStyle && _lastSectorIndex >= 0)
+                    {
+                        int displayed = _lastSectorIndex;
+                        double relAng = angle - displayed * sectorAngle;
+                        while (relAng < -180.0) relAng += 360.0;
+                        while (relAng > 180.0) relAng -= 360.0;
+                        if (Math.Abs(relAng) <= GetFanAngularHalfDeg())
+                        {
+                            sectorIndex = displayed;
+                        }
+                    }
+
+                    // Check if mouse moved into the sub-tier zone
+                    if (multiTierEnabled && _activeProfile != null && sectorIndex >= 0 && sectorIndex < _activeProfile.Actions.Count)
                     {
                         var parentAction = _activeProfile.Actions[sectorIndex];
                         if (parentAction != null && parentAction.SubActions != null && parentAction.SubActions.Count > 0)
                         {
-                            int subCount = parentAction.SubActions.Count;
-                            double parentCenterAngle = sectorIndex * sectorAngle;
-                            double parentStartAngle = parentCenterAngle - (sectorAngle / 2.0);
-
-                            double relAngle = angle - parentStartAngle;
-                            while (relAngle < 0) relAngle += 360.0;
-                            while (relAngle >= 360.0) relAngle -= 360.0;
-
-                            if (relAngle <= sectorAngle)
+                            if (fanStyle)
                             {
-                                int calculatedSub = (int)(relAngle / (sectorAngle / subCount));
-                                subSectorIndex = Math.Clamp(calculatedSub, 0, subCount - 1);
+                                // Honeycomb fan style: nearest sub item wins
+                                subSectorIndex = HitTestFanSubs(currentPoint, sectorIndex, sectorAngle);
+                            }
+                            else if (distance >= (wheelRadius + 6.0))
+                            {
+                                // Wheel style: outer sub-ring split by angle
+                                int subCount = parentAction.SubActions.Count;
+                                double parentCenterAngle = sectorIndex * sectorAngle;
+                                double parentStartAngle = parentCenterAngle - (sectorAngle / 2.0);
+
+                                double relAngle = angle - parentStartAngle;
+                                while (relAngle < 0) relAngle += 360.0;
+                                while (relAngle >= 360.0) relAngle -= 360.0;
+
+                                if (relAngle <= sectorAngle)
+                                {
+                                    int calculatedSub = (int)(relAngle / (sectorAngle / subCount));
+                                    subSectorIndex = Math.Clamp(calculatedSub, 0, subCount - 1);
+                                }
                             }
                         }
                     }
@@ -425,6 +452,7 @@ namespace WinPieGestures
             _selectedSectorIndex = sectorIndex;
             _selectedSubSectorIndex = subSectorIndex;
             _lastEscapedState = isEscaped;
+            _lastSectorIndex = sectorIndex;
 
             int targetSector = sectorIndex;
             int targetSubSector = subSectorIndex;
@@ -449,6 +477,55 @@ namespace WinPieGestures
 
             _radialWindow = new RadialWindow(center, profile);
             _radialWindow.Show();
+        }
+
+        /// <summary>
+        /// Fan style hit-test: nearest of the (up to 3) honeycomb fan items, in the same frame
+        /// the fan is rendered (positions relative to the gesture start).
+        /// </summary>
+        private int HitTestFanSubs(Point cursor, int sectorIndex, double sectorAngle)
+        {
+            if (_activeProfile == null || sectorIndex < 0 || sectorIndex >= _activeProfile.Actions.Count) return -1;
+            var action = _activeProfile.Actions[sectorIndex];
+            if (action == null || action.SubActions == null || action.SubActions.Count == 0) return -1;
+
+            double outer = ConfigManager.CurrentConfig.WheelRadius;
+            double inner = ConfigManager.CurrentConfig.InnerRadius;
+            double R = (inner + outer) / 2.0;
+            double itemR = (outer - inner) * 0.40;
+            double midRad = sectorIndex * sectorAngle * (Math.PI / 180.0);
+            double ux = Math.Cos(midRad), uy = Math.Sin(midRad);
+            double vx = -Math.Sin(midRad), vy = Math.Cos(midRad);
+
+            int subCount = Math.Min(RadialWindow.FanSubmenuSlotCount, action.SubActions.Count);
+            int hit = -1;
+            double best = double.MaxValue;
+            for (int i = 0; i < subCount; i++)
+            {
+                var (du, dv) = RadialWindow.GetFanSubOffset(i);
+                double px = _startPoint.X + ux * (du * R) + vx * (dv * R);
+                double py = _startPoint.Y + uy * (du * R) + vy * (dv * R);
+                double d = Math.Sqrt((cursor.X - px) * (cursor.X - px) + (cursor.Y - py) * (cursor.Y - py));
+                if (d <= itemR * 1.25 && d < best)
+                {
+                    best = d;
+                    hit = i;
+                }
+            }
+            return hit;
+        }
+
+        /// <summary>Half-width (degrees) of the fan's angular coverage around the sector axis.</summary>
+        private static double GetFanAngularHalfDeg()
+        {
+            double maxDev = 0.0;
+            for (int i = 0; i < RadialWindow.FanSubmenuSlotCount; i++)
+            {
+                var (du, dv) = RadialWindow.GetFanSubOffset(i);
+                double dev = Math.Atan2(Math.Abs(dv), Math.Abs(du)) * (180.0 / Math.PI);
+                if (dev > maxDev) maxDev = dev;
+            }
+            return maxDev + 4.0;
         }
 
         private void HideRadialUI()

--- a/WinPieGestures/I18n.cs
+++ b/WinPieGestures/I18n.cs
@@ -301,6 +301,34 @@ namespace WinPieGestures
                 [LanguageCode.En] = "Process Isolation & Activation Mode",
                 [LanguageCode.Ja] = "プロセス分離と有効化モード"
             },
+            ["SubmenuStyleTitle"] = new()
+            {
+                [LanguageCode.ZhCn] = "二级菜单样式 (Submenu Style)",
+                [LanguageCode.ZhTw] = "二級選單樣式 (Submenu Style)",
+                [LanguageCode.En] = "Submenu Style",
+                [LanguageCode.Ja] = "サブメニュースタイル (Submenu Style)"
+            },
+            ["SubmenuStyleDesc"] = new()
+            {
+                [LanguageCode.ZhCn] = "外圈子环：子动作沿选中扇区外侧环形展开（数量不限）；蜂窝扇：子动作以选中项为中心呈扇形排列（最多三项）。",
+                [LanguageCode.ZhTw] = "外圈子環：子動作沿選中扇區外側環形展開（數量不限）；蜂窩扇：子動作以選中項為中心呈扇形排列（最多三項）。",
+                [LanguageCode.En] = "Sub-Ring: sub actions expand as an outer ring along the selected sector (any count). Honeycomb Fan: sub actions fan out centered on the selected item (up to three).",
+                [LanguageCode.Ja] = "サブリング：選択セクターの外側にリング状に展開（数は任意）。ハニカムファン：選択項目を中心に扇形に展開（最大3つ）。"
+            },
+            ["SubmenuStyleWheel"] = new()
+            {
+                [LanguageCode.ZhCn] = "🌐 外圈子环 (Sub-Ring)",
+                [LanguageCode.ZhTw] = "🌐 外圈子環 (Sub-Ring)",
+                [LanguageCode.En] = "🌐 Sub-Ring",
+                [LanguageCode.Ja] = "🌐 サブリング (Sub-Ring)"
+            },
+            ["SubmenuStyleFan"] = new()
+            {
+                [LanguageCode.ZhCn] = "🍯 蜂窝扇 (Honeycomb Fan)",
+                [LanguageCode.ZhTw] = "🍯 蜂窩扇 (Honeycomb Fan)",
+                [LanguageCode.En] = "🍯 Honeycomb Fan",
+                [LanguageCode.Ja] = "🍯 ハニカムファン (Honeycomb Fan)"
+            },
             ["IsolationBlacklistRadio"] = new()
             {
                 [LanguageCode.ZhCn] = "🚫 排除黑名单模式 (默认：全局生效，仅在黑名单程序中放行右键)",

--- a/WinPieGestures/RadialWindow.xaml.cs
+++ b/WinPieGestures/RadialWindow.xaml.cs
@@ -101,7 +101,11 @@ namespace WinPieGestures
             double coreRadius = ConfigManager.CurrentConfig.CoreRadius;
             bool multiTier = ConfigManager.CurrentConfig.EnableMultiTier;
             double subRatio = ConfigManager.CurrentConfig.SubWheelRadiusRatio > 1.1 ? ConfigManager.CurrentConfig.SubWheelRadiusRatio : 1.55;
-            double maxRadius = multiTier ? (wheelRadius * subRatio + 25.0) : wheelRadius;
+            double ringMax = wheelRadius * subRatio + 25.0;
+            double fanMax = multiTier && string.Equals(ConfigManager.CurrentConfig.SubmenuStyle, "Fan", StringComparison.OrdinalIgnoreCase)
+                ? GetFanExtentRadius(wheelRadius, ConfigManager.CurrentConfig.InnerRadius) + 25.0
+                : 0.0;
+            double maxRadius = multiTier ? Math.Max(ringMax, fanMax) : wheelRadius;
 
             // Adjust window size dynamically based on max outer radius
             double winSize = maxRadius * 2.0 + 40.0; // Margin for shadow
@@ -686,6 +690,198 @@ namespace WinPieGestures
             this.BeginAnimation(UIElement.OpacityProperty, anim);
         }
 
+        // ================== SubmenuStyle "Fan" (honeycomb fan — optional alternate style) ==================
+
+        /// <summary>Fan style shows at most this many sub slots.</summary>
+        public const int FanSubmenuSlotCount = 3;
+
+        /// <summary>Fan offsets (in layout-radius units) in a radial/tangential frame: tip + upper/lower.</summary>
+        public static (double du, double dv) GetFanSubOffset(int index)
+        {
+            double ringR = Math.Sqrt(2.0 - Math.Sqrt(2.0)); // |selected-item to neighbor| in layout-radius units
+            switch (index)
+            {
+                case 0: return (1.0 + ringR * 0.5, ringR * 0.8660254038);   // upper
+                case 1: return (1.0 + ringR, 0.0);                           // tip
+                default: return (1.0 + ringR * 0.5, -ringR * 0.8660254038); // lower
+            }
+        }
+
+        /// <summary>Max radial extent of the fan (window sizing).</summary>
+        public static double GetFanExtentRadius(double outer, double inner)
+        {
+            double R = (outer + inner) / 2.0;
+            return GetFanSubOffset(1).du * R + (outer - inner) * 0.40;
+        }
+
+        private static Geometry CreateSubMenuGeometry(string shape, double cx, double cy, double radius, double angleRad)
+        {
+            string s = string.IsNullOrEmpty(shape) ? "Circle" : shape;
+            if (s.Equals("Circle", StringComparison.OrdinalIgnoreCase))
+            {
+                return new EllipseGeometry(new Point(cx, cy), radius, radius);
+            }
+            if (s.Equals("HexagonHive", StringComparison.OrdinalIgnoreCase))
+            {
+                var pts = new Point[6];
+                for (int i = 0; i < 6; i++)
+                {
+                    double ang = angleRad + i * (Math.PI / 3.0);
+                    pts[i] = new Point(cx + Math.Cos(ang) * radius, cy + Math.Sin(ang) * radius);
+                }
+                var hex = new StreamGeometry();
+                using (var ctx = hex.Open())
+                {
+                    ctx.BeginFigure(pts[0], isFilled: true, isClosed: true);
+                    for (int i = 1; i < 6; i++) ctx.LineTo(pts[i], isStroked: true, isSmoothJoin: false);
+                }
+                hex.Freeze();
+                return hex;
+            }
+            // Capsule / rounded-rect family: rounded rect rotated along the radial direction
+            double w = 2.0 * radius, h = 1.6 * radius, rr = h / 2.0;
+            var rect = new RectangleGeometry(new Rect(-w / 2.0, -h / 2.0, w, h), rr, rr);
+            var tf = new TransformGroup();
+            tf.Children.Add(new RotateTransform(angleRad * (180.0 / Math.PI)));
+            tf.Children.Add(new TranslateTransform(cx, cy));
+            rect.Transform = tf;
+            return rect;
+        }
+
+        private void RenderFanSubtier(int parentIndex)
+        {
+            ClearSubTier();
+
+            if (!ConfigManager.CurrentConfig.EnableMultiTier) return;
+            if (parentIndex < 0 || parentIndex >= _profile.Actions.Count) return;
+
+            var parentAction = _profile.Actions[parentIndex];
+            if (parentAction == null || parentAction.SubActions == null || parentAction.SubActions.Count == 0) return;
+
+            int n = _profile.SectorCount;
+            double sectorSize = 360.0 / n;
+            double cx = WheelCanvas.Width / 2.0;
+            double cy = WheelCanvas.Height / 2.0;
+
+            string shape = ConfigManager.CurrentConfig.Shape ?? "Original";
+            string layoutMode = ConfigManager.CurrentConfig.IconLayoutMode ?? "IconAndText";
+            bool showText = ConfigManager.CurrentConfig.ShowText && layoutMode != "IconOnly";
+
+            double outer = ConfigManager.CurrentConfig.WheelRadius;
+            double inner = ConfigManager.CurrentConfig.InnerRadius;
+            double R = (inner + outer) / 2.0;
+            double itemR = (outer - inner) * 0.40;
+            double midRad = parentIndex * sectorSize * (Math.PI / 180.0);
+            double ux = Math.Cos(midRad), uy = Math.Sin(midRad);
+            double vx = -Math.Sin(midRad), vy = Math.Cos(midRad);
+
+            var subActions = parentAction.SubActions;
+            int subCount = Math.Min(FanSubmenuSlotCount, subActions.Count);
+            _activeSubTierParentSector = parentIndex;
+
+            for (int j = 0; j < subCount; j++)
+            {
+                var (du, dv) = GetFanSubOffset(j);
+                double px = cx + ux * (du * R) + vx * (dv * R);
+                double py = cy + uy * (du * R) + vy * (dv * R);
+
+                Geometry geom = CreateSubMenuGeometry(shape, px, py, itemR, midRad);
+
+                var subPath = new Path
+                {
+                    Data = geom,
+                    Fill = _defaultSectorBrush,
+                    Stroke = _sectorBorderBrush,
+                    StrokeThickness = _borderThickness,
+                    Tag = $"sub_{parentIndex}_{j}",
+                    Opacity = 0.0
+                };
+                System.Windows.Controls.Panel.SetZIndex(subPath, 15);
+                WheelCanvas.Children.Add(subPath);
+                _subSectorPaths.Add(subPath);
+
+                double containerW = 66.0, containerH = 50.0;
+                var container = new Grid { Width = containerW, Height = containerH, Opacity = 0.0 };
+                var stackPanel = new StackPanel
+                {
+                    Orientation = System.Windows.Controls.Orientation.Vertical,
+                    HorizontalAlignment = System.Windows.HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center
+                };
+                container.Children.Add(stackPanel);
+
+                var subAction = subActions[j];
+                string actionText = subAction?.Name ?? "";
+                string actionType = subAction?.Type ?? "Hotkey";
+                string parameter = subAction?.Parameter ?? "";
+                string iconKey = subAction?.IconKey ?? "";
+                string customSvg = subAction?.CustomIconSvg ?? "";
+
+                FrameworkElement? iconElem = null;
+                double iconSize = 18.0;
+                if (layoutMode != "TextOnly")
+                {
+                    if (!string.IsNullOrEmpty(customSvg))
+                    {
+                        try
+                        {
+                            iconElem = new Path { Data = Geometry.Parse(customSvg), Fill = _textColorBrush, Stretch = Stretch.Uniform, Width = iconSize, Height = iconSize, Margin = new Thickness(0, 0, 0, showText ? 2 : 0), HorizontalAlignment = System.Windows.HorizontalAlignment.Center };
+                        }
+                        catch { }
+                    }
+                    if (iconElem == null && !string.IsNullOrEmpty(iconKey))
+                    {
+                        string? svg = IconHelper.GetSvgPathByKey(iconKey);
+                        if (!string.IsNullOrEmpty(svg))
+                        {
+                            iconElem = new Path { Data = Geometry.Parse(svg), Fill = _textColorBrush, Stretch = Stretch.Uniform, Width = iconSize, Height = iconSize, Margin = new Thickness(0, 0, 0, showText ? 2 : 0), HorizontalAlignment = System.Windows.HorizontalAlignment.Center };
+                        }
+                    }
+                    if (iconElem == null)
+                    {
+                        string? autoSvg = GetVectorIconPath(actionType, parameter);
+                        if (!string.IsNullOrEmpty(autoSvg))
+                        {
+                            iconElem = new Path { Data = Geometry.Parse(autoSvg), Fill = _textColorBrush, Stretch = Stretch.Uniform, Width = iconSize, Height = iconSize, Margin = new Thickness(0, 0, 0, showText ? 2 : 0), HorizontalAlignment = System.Windows.HorizontalAlignment.Center };
+                        }
+                    }
+                    if (iconElem != null) stackPanel.Children.Add(iconElem);
+                }
+
+                if (showText && !string.IsNullOrEmpty(actionText))
+                {
+                    var tb = new TextBlock
+                    {
+                        Text = actionText,
+                        Foreground = _textColorBrush,
+                        FontSize = 9.5,
+                        FontWeight = FontWeights.Medium,
+                        TextAlignment = TextAlignment.Center,
+                        TextWrapping = TextWrapping.Wrap,
+                        TextTrimming = TextTrimming.CharacterEllipsis,
+                        MaxWidth = containerW - 4.0,
+                        MaxHeight = 24,
+                        Margin = new Thickness(0, 1, 0, 0),
+                        Effect = (System.Windows.Media.Effects.Effect)Resources["TextShadow"]
+                    };
+                    stackPanel.Children.Add(tb);
+                }
+
+                Canvas.SetLeft(container, px - container.Width / 2.0);
+                Canvas.SetTop(container, py - container.Height / 2.0);
+                System.Windows.Controls.Panel.SetZIndex(container, 16);
+                WheelCanvas.Children.Add(container);
+                _subContentContainers.Add(container);
+
+                var fadeInAnim = new DoubleAnimation(0.0, 1.0, new Duration(TimeSpan.FromMilliseconds(110)))
+                {
+                    EasingFunction = new QuadraticEase { EasingMode = EasingMode.EaseOut }
+                };
+                subPath.BeginAnimation(UIElement.OpacityProperty, fadeInAnim);
+                container.BeginAnimation(UIElement.OpacityProperty, fadeInAnim);
+            }
+        }
+
         private void ClearSubTier()
         {
             foreach (var p in _subSectorPaths)
@@ -707,6 +903,14 @@ namespace WinPieGestures
             ClearSubTier();
 
             if (!ConfigManager.CurrentConfig.EnableMultiTier) return;
+
+            // Alternate style: honeycomb fan around the selected item
+            if (string.Equals(ConfigManager.CurrentConfig.SubmenuStyle, "Fan", StringComparison.OrdinalIgnoreCase))
+            {
+                RenderFanSubtier(parentIndex);
+                return;
+            }
+
             if (parentIndex < 0 || parentIndex >= _profile.Actions.Count) return;
 
             var parentAction = _profile.Actions[parentIndex];

--- a/WinPieGestures/SettingsWindow.xaml
+++ b/WinPieGestures/SettingsWindow.xaml
@@ -612,7 +612,7 @@
                 <!-- Version Footer -->
                 <StackPanel Grid.Row="2" Margin="0,15,0,5">
                     <Border Background="{DynamicResource NavTabActiveBgBrush}" CornerRadius="4" Padding="6,3" HorizontalAlignment="Left" Margin="0,0,0,4">
-                        <TextBlock x:Name="SidebarVersionText" Text="v1.4.5" FontSize="11" FontWeight="Bold" Foreground="{DynamicResource AccentPrimaryBrush}"/>
+                        <TextBlock x:Name="SidebarVersionText" Text="v1.5.2" FontSize="11" FontWeight="Bold" Foreground="{DynamicResource AccentPrimaryBrush}"/>
                     </Border>
                     <TextBlock Text="© 2026 StarPie" FontSize="10" Foreground="{DynamicResource TextMutedBrush}"/>
                 </StackPanel>
@@ -1691,7 +1691,7 @@
                                         <StackPanel Orientation="Horizontal">
                                             <TextBlock Text="StarPie" FontSize="18" FontWeight="Bold" Foreground="{DynamicResource TextPrimaryBrush}"/>
                                             <Border Background="{DynamicResource NavTabActiveBgBrush}" CornerRadius="4" Padding="6,2" Margin="8,0,0,0" VerticalAlignment="Center">
-                                                <TextBlock Text="v1.4.5" FontWeight="Bold" Foreground="{DynamicResource AccentPrimaryBrush}" FontSize="11"/>
+                                                <TextBlock Text="v1.5.2" FontWeight="Bold" Foreground="{DynamicResource AccentPrimaryBrush}" FontSize="11"/>
                                             </Border>
                                         </StackPanel>
                                         <TextBlock Text="高质感、极速现代 Windows 鼠标轮盘笔势工具" FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,4,0,0"/>

--- a/WinPieGestures/SettingsWindow.xaml
+++ b/WinPieGestures/SettingsWindow.xaml
@@ -1407,6 +1407,25 @@
                                     <TextBlock x:Name="MultiTierCardTitleText" Text="多级轮盘与级联子菜单 (Multi-Tier Sub-Wheels)" FontSize="14" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,0,0,8"/>
                                     <CheckBox x:Name="EnableMultiTierCheckBox" Content="启用多级轮盘与级联子菜单 (Multi-Tier)" Style="{StaticResource ToggleSwitchStyle}" Margin="0,0,0,6" Checked="EnableMultiTierCheckBox_Changed" Unchecked="EnableMultiTierCheckBox_Changed"/>
                                     <TextBlock x:Name="EnableMultiTierDescText" Text="开启后，若扇区配置了二级子动作，光标悬停时外圈将平滑展开扇形级联子菜单，向外划动即可精准触发子功能。点击下方各扇区右侧【⚙️ 级联】按钮可自由添加或编辑二级动作。" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" TextWrapping="Wrap" Margin="0,0,0,0"/>
+
+                                    <StackPanel x:Name="SubmenuStylePanel" Margin="0,12,0,0">
+                                        <Border BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="0,1,0,0" Padding="0,12,0,0">
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="*"/>
+                                                    <ColumnDefinition Width="200"/>
+                                                </Grid.ColumnDefinitions>
+                                                <StackPanel VerticalAlignment="Center" Margin="0,0,10,0">
+                                                    <TextBlock x:Name="SubmenuStyleTitleText" Text="二级菜单样式 (Submenu Style)" FontSize="12" FontWeight="Medium" Foreground="{DynamicResource TextPrimaryBrush}"/>
+                                                    <TextBlock x:Name="SubmenuStyleDescText" Text="外圈子环：子动作沿选中扇区外侧环形展开（数量不限）；蜂窝扇：子动作以选中项为中心呈扇形排列（最多三项）。" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,2,0,0" TextWrapping="Wrap"/>
+                                                </StackPanel>
+                                                <ComboBox x:Name="SubmenuStyleComboBox" Grid.Column="1" Style="{StaticResource FlatComboBoxStyle}" Height="32" VerticalAlignment="Center" SelectionChanged="SubmenuStyleComboBox_SelectionChanged">
+                                                    <ComboBoxItem x:Name="SubmenuStyleWheelItem" Tag="Wheel" Content="🌐 外圈子环 (Sub-Ring)"/>
+                                                    <ComboBoxItem x:Name="SubmenuStyleFanItem" Tag="Fan" Content="🍯 蜂窝扇 (Honeycomb Fan)"/>
+                                                </ComboBox>
+                                            </Grid>
+                                        </Border>
+                                    </StackPanel>
                                 </StackPanel>
                             </Border>
 

--- a/WinPieGestures/SettingsWindow.xaml.cs
+++ b/WinPieGestures/SettingsWindow.xaml.cs
@@ -209,6 +209,7 @@ namespace WinPieGestures
                 SetComboBoxSelectedValue(IconLayoutModeComboBox, ConfigManager.CurrentConfig.IconLayoutMode);
                 ShowTextCheckBox.IsChecked = ConfigManager.CurrentConfig.ShowText;
                 if (EnableMultiTierCheckBox != null) EnableMultiTierCheckBox.IsChecked = ConfigManager.CurrentConfig.EnableMultiTier;
+                SetComboBoxSelectedValue(SubmenuStyleComboBox, ConfigManager.CurrentConfig.SubmenuStyle ?? "Wheel");
 
                 // Center Core Pattern, Image & Visibility
                 ShowCoreIconCheckBox.IsChecked = ConfigManager.CurrentConfig.ShowCoreIcon;
@@ -473,6 +474,10 @@ namespace WinPieGestures
             if (CoreImagePerformanceTipText != null) CoreImagePerformanceTipText.Text = I18n.T("CoreImagePerformanceTip");
             if (EnableMultiTierCheckBox != null) EnableMultiTierCheckBox.Content = I18n.T("EnableMultiTier");
             if (EnableMultiTierDescText != null) EnableMultiTierDescText.Text = I18n.T("EnableMultiTierDesc");
+            if (SubmenuStyleTitleText != null) SubmenuStyleTitleText.Text = I18n.T("SubmenuStyleTitle");
+            if (SubmenuStyleDescText != null) SubmenuStyleDescText.Text = I18n.T("SubmenuStyleDesc");
+            if (SubmenuStyleWheelItem != null) SubmenuStyleWheelItem.Content = I18n.T("SubmenuStyleWheel");
+            if (SubmenuStyleFanItem != null) SubmenuStyleFanItem.Content = I18n.T("SubmenuStyleFan");
 
             // Tab 2: Gestures & Actions
             if (GesturesPageHeader != null) GesturesPageHeader.Text = I18n.T("GesturesHeader");
@@ -2399,6 +2404,20 @@ namespace WinPieGestures
             if (AppearanceSettingsGrid?.Visibility == Visibility.Visible)
             {
                 RenderLiveWheelPreview();
+            }
+        }
+
+        private void SubmenuStyleComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_isUpdatingUi || ConfigManager.CurrentConfig == null) return;
+            if (SubmenuStyleComboBox.SelectedItem is ComboBoxItem item && item.Tag is string style)
+            {
+                ConfigManager.CurrentConfig.SubmenuStyle = style;
+                ConfigManager.SaveConfig();
+                if (AppearanceSettingsGrid?.Visibility == Visibility.Visible)
+                {
+                    RenderLiveWheelPreview();
+                }
             }
         }
 

--- a/WinPieGestures/SubActionEditorWindow.xaml
+++ b/WinPieGestures/SubActionEditorWindow.xaml
@@ -15,6 +15,16 @@
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVis"/>
 
+        <!-- Local FlatComboBoxStyle: the window-scoped one in SettingsWindow is not visible here,
+             and a missing StaticResource would throw at runtime when sub-slot rows instantiate. -->
+        <Style x:Key="FlatComboBoxStyle" TargetType="{x:Type ComboBox}">
+            <Setter Property="Height" Value="30"/>
+            <Setter Property="Background" Value="{DynamicResource InputBackgroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource InputBorderBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+            <Setter Property="Padding" Value="6,2"/>
+        </Style>
+
         <Style x:Key="ModernButtonStyle" TargetType="Button">
             <Setter Property="Background" Value="{DynamicResource ButtonDefaultBgBrush}"/>
             <Setter Property="BorderBrush" Value="{DynamicResource ButtonDefaultBorderBrush}"/>

--- a/WinPieGestures/WinPieGestures.csproj
+++ b/WinPieGestures/WinPieGestures.csproj
@@ -13,9 +13,9 @@
     <Product>StarPie</Product>
     <Company>StarPie Studio</Company>
     <Description>StarPie - 现代化高颜值 Windows 鼠标轮盘笔势与效率管理系统</Description>
-    <Version>1.4.5</Version>
-    <AssemblyVersion>1.4.5.0</AssemblyVersion>
-    <FileVersion>1.4.5.0</FileVersion>
+    <Version>1.5.2</Version>
+    <AssemblyVersion>1.5.2.0</AssemblyVersion>
+    <FileVersion>1.5.2.0</FileVersion>
     <ServerGarbageCollection>false</ServerGarbageCollection>
     <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
   </PropertyGroup>


### PR DESCRIPTION
## 概述

在现有「多级轮盘 / 外圈子环」体系上，新增一个**可选的第二种二级菜单样式「蜂窝扇」**：
扇区的二级子动作以选中项为中心呈扇形排列（最多 3 项），与上游默认的「外圈子环」通过设置项一键切换，
共用同一套 `SubActions` 数据与级联编辑器，互不影响。

## 改动文件

- `ConfigManager.cs`：新增 `SubmenuStyle` 配置项（`Wheel` / `Fan`，默认 `Wheel`）
- `SettingsWindow.xaml(.cs)`：多级轮盘卡片新增「二级菜单样式」下拉，即时生效并持久化，四语言
- `RadialWindow.xaml.cs`：新增蜂窝扇渲染分支（三项扇形布局，圆 / 六边形 / 胶囊同构）、窗口尺寸自适应
- `GestureController.cs`：蜂窝扇命中逻辑 + 扇形角度带内不误切换扇区（避免拖向二级项时扇区跳变）

## 功能说明

设置 → 手势与动作 → 多级轮盘 → **二级菜单样式**，可选：
- 🌐 **外圈子环（Sub-Ring）**：上游默认行为，不变；
- 🍯 **蜂窝扇（Honeycomb Fan）**：子动作以选中项为中心呈扇形展开（最多三项），切到该样式后悬停任一扇区即可体验。

## 📷 演示
<img width="957" height="633" alt="Snipaste" src="https://github.com/user-attachments/assets/80ea2c7d-af96-45a4-825e-744842882b1d" />
<img width="720" height="480" alt="screenshots1" src="https://github.com/user-attachments/assets/e01d02bd-49c1-459f-a1eb-c5ace1957654" />
<img width="720" height="480" alt="screenshots2" src="https://github.com/user-attachments/assets/76ea4598-77a2-486d-a518-20def3337827" />
<img width="720" height="480" alt="screenshots3" src="https://github.com/user-attachments/assets/84b22c01-8e29-4d9b-8403-ad8a840b8d7a" />

## 测试

- [x] `dotnet build -c Release` 通过
- [x] 默认行为不变（默认仍为外圈子环）
- [x] 蜂窝扇切换、命中、触发

## 备注

- 默认 `SubmenuStyle = "Wheel"`，对现有用户零行为变化；
- 本 PR **未包含版本号变更**。
