### PR TITLE
fix: 修复开启全屏保护时显示桌面会导致手势失效

### DIFF
--- a/WinPieGestures/FullScreenHelper.cs
+++ b/WinPieGestures/FullScreenHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace WinPieGestures
 {
@@ -13,6 +14,9 @@ namespace WinPieGestures
 
         [DllImport("user32.dll")]
         private static extern IntPtr GetDesktopWindow();
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        private static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
 
         [DllImport("user32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
@@ -44,6 +48,23 @@ namespace WinPieGestures
 
         private const uint MONITOR_DEFAULTTONEAREST = 2;
 
+        private static bool IsDesktopShellWindow(IntPtr hWnd)
+        {
+            if (hWnd == GetShellWindow() || hWnd == GetDesktopWindow())
+            {
+                return true;
+            }
+
+            var className = new StringBuilder(256);
+            if (GetClassName(hWnd, className, className.Capacity) <= 0)
+            {
+                return false;
+            }
+
+            return string.Equals(className.ToString(), "Progman", StringComparison.Ordinal) ||
+                   string.Equals(className.ToString(), "WorkerW", StringComparison.Ordinal);
+        }
+
         /// <summary>
         /// Determines if the current active foreground window is in full-screen mode.
         /// </summary>
@@ -52,8 +73,9 @@ namespace WinPieGestures
             IntPtr hWnd = GetForegroundWindow();
             if (hWnd == IntPtr.Zero) return false;
 
-            // Exclude desktop background and shell manager
-            if (hWnd == GetShellWindow() || hWnd == GetDesktopWindow()) return false;
+            // Exclude the desktop and its WorkerW/Progman host windows. Win+D can make
+            // one of these hosts the foreground window, and their bounds cover the monitor.
+            if (IsDesktopShellWindow(hWnd)) return false;
 
             RECT windowRect;
             if (!GetWindowRect(hWnd, out windowRect)) return false;


### PR DESCRIPTION
## 修改概述

修复 Windows 桌面在执行“显示桌面”后可能被错误识别为全屏窗口的问题。

该问题会导致用户开启“全屏游戏/独占应用自动禁用手势”后，StarPie 在桌面上暂时无法触发。打开或切换到任意普通程序窗口后，手势才会恢复正常。

## 问题表现

开启以下选项后：

> 全屏游戏/独占应用自动禁用手势

<img width="1099" height="718" alt="PixPin_2026-08-31_14-15-45" src="https://github.com/user-attachments/assets/1d5c7f92-501d-41c2-a2e9-78ad2b40a447" />


执行“显示桌面”动作，会出现以下现象：

1. Windows 正常显示桌面；
2. StarPie 进程仍然处于运行状态；
3. 托盘图标没有退出；
4. 但在桌面上无法继续触发 StarPie 手势；
5. 打开或切换到任意普通程序窗口后，手势立即恢复。

关闭“全屏游戏/独占应用自动禁用手势”后，该问题不会出现。

https://github.com/user-attachments/assets/20b5ccd3-2f80-45b6-abda-7475e2bad3dc


## 问题原因

原有的全屏检测逻辑通过判断当前前台窗口是否覆盖整个显示器来确定是否处于全屏状态。

原有代码只排除了以下两种窗口：

- `GetShellWindow()` 返回的 Shell 窗口；
- `GetDesktopWindow()` 返回的桌面窗口。

执行 `Win + D` 显示桌面后，Windows 可能会将其他桌面宿主窗口设为前台窗口，例如：

- `Progman`
- `WorkerW`

这些窗口不一定等于 `GetShellWindow()` 或 `GetDesktopWindow()` 返回的句柄，但它们的窗口区域可能覆盖整个显示器。

因此，原有逻辑会将桌面宿主窗口误判为全屏应用，进而触发“全屏自动禁用手势”逻辑。

## 修改内容

本次修改包括：

- 增加对 Win32 `GetClassName()` 的调用；
- 新增 `IsDesktopShellWindow()` 辅助方法；
- 根据窗口类名识别桌面宿主窗口；
- 排除 `Progman` 桌面宿主窗口；
- 排除 `WorkerW` 桌面宿主窗口；
- 保留原有的显示器边界全屏检测逻辑；
- 不直接排除所有 `explorer.exe` 窗口，避免影响普通资源管理器窗口和真正的全屏场景。

## 修改后的预期行为

开启“全屏游戏/独占应用自动禁用手势”后：

- 在 Windows 桌面上仍然可以正常触发 StarPie；
- 执行“显示桌面”后，StarPie 不会暂时失效；
- 可以在桌面上再次触发“显示桌面”动作；
- 再次触发时，Windows 会通过原有的 `Win + D` 行为恢复之前的窗口；
- 真正的全屏应用和游戏仍然会正常禁用手势。

https://github.com/user-attachments/assets/e8f096f1-1292-456d-a44a-aa7028d20b19


## 版本信息提醒

在测试本次编译产物时，注意到编译产物的版本号为 `1.4.5`，而最新 GitHub Release 的版本为 `v1.5.2`，相关标签中的版本信息似乎也存在差异。

该问题与本次修复无关，不过还是建议在下次发布前同步一下项目文件、Git 标签、Release 名称和发布附件中的版本信息。