### PR TITLE
新增执行命令功能，可指定终端执行命令，可选是否保留终端窗口

### DIFF
--- a/WinPieGestures/ActionExecutor.cs
+++ b/WinPieGestures/ActionExecutor.cs
@@ -440,7 +440,7 @@ public static class ActionExecutor
 		}
 	}
 
-	/// <summary>Runs a command in the selected terminal (cmd / PowerShell / WSL / direct).</summary>
+	/// <summary>Runs a command in the selected terminal (cmd / PowerShell / WSL), with or without a window.</summary>
 	private static void ExecuteCommand(string command, string? terminal)
 	{
 		if (string.IsNullOrWhiteSpace(command))
@@ -448,34 +448,31 @@ public static class ActionExecutor
 			return;
 		}
 		string term = string.IsNullOrEmpty(terminal) ? "cmd" : terminal.Trim().ToLowerInvariant();
+		bool hidden = term.EndsWith("_hidden", StringComparison.OrdinalIgnoreCase);
+		string shell = hidden ? term.Substring(0, term.Length - "_hidden".Length) : term;
 		try
 		{
-			switch (term)
+			switch (shell)
 			{
 			case "powershell":
 				Process.Start(new ProcessStartInfo("powershell.exe", "-NoProfile -Command \"" + command + "\"")
 				{
-					UseShellExecute = false
+					UseShellExecute = false,
+					CreateNoWindow = hidden
 				});
 				break;
 			case "wsl":
 				Process.Start(new ProcessStartInfo("wsl.exe", "-- " + command)
 				{
-					UseShellExecute = false
-				});
-				break;
-			case "direct":
-			case "none":
-				Process.Start(new ProcessStartInfo
-				{
-					FileName = command,
-					UseShellExecute = true
+					UseShellExecute = false,
+					CreateNoWindow = hidden
 				});
 				break;
 			default:
 				Process.Start(new ProcessStartInfo("cmd.exe", "/c \"" + command + "\"")
 				{
-					UseShellExecute = false
+					UseShellExecute = false,
+					CreateNoWindow = hidden
 				});
 				break;
 			}

--- a/WinPieGestures/ActionExecutor.cs
+++ b/WinPieGestures/ActionExecutor.cs
@@ -455,7 +455,8 @@ public static class ActionExecutor
 			switch (shell)
 			{
 			case "powershell":
-				Process.Start(new ProcessStartInfo("powershell.exe", "-NoProfile -Command \"" + command + "\"")
+				// Visible: keep the window open (-NoExit). Hidden: run to completion.
+				Process.Start(new ProcessStartInfo("powershell.exe", (hidden ? "-NoProfile -Command \"" : "-NoProfile -NoExit -Command \"") + command + "\"")
 				{
 					UseShellExecute = false,
 					CreateNoWindow = hidden
@@ -469,7 +470,8 @@ public static class ActionExecutor
 				});
 				break;
 			default:
-				Process.Start(new ProcessStartInfo("cmd.exe", "/c \"" + command + "\"")
+				// Visible: keep the window open (/k). Hidden: /c so no lingering process.
+				Process.Start(new ProcessStartInfo("cmd.exe", (hidden ? "/c \"" : "/k \"") + command + "\"")
 				{
 					UseShellExecute = false,
 					CreateNoWindow = hidden

--- a/WinPieGestures/ActionExecutor.cs
+++ b/WinPieGestures/ActionExecutor.cs
@@ -450,19 +450,22 @@ public static class ActionExecutor
 		string term = string.IsNullOrEmpty(terminal) ? "cmd" : terminal.Trim().ToLowerInvariant();
 		bool hidden = term.EndsWith("_hidden", StringComparison.OrdinalIgnoreCase);
 		string shell = hidden ? term.Substring(0, term.Length - "_hidden".Length) : term;
+		// Escape embedded quotes for the cmd/PowerShell wrappers ("" is the escape inside Windows quoting)
+		string quoted = command.Replace("\"", "\"\"");
 		try
 		{
 			switch (shell)
 			{
 			case "powershell":
 				// Visible: keep the window open (-NoExit). Hidden: run to completion.
-				Process.Start(new ProcessStartInfo("powershell.exe", (hidden ? "-NoProfile -Command \"" : "-NoProfile -NoExit -Command \"") + command + "\"")
+				Process.Start(new ProcessStartInfo("powershell.exe", (hidden ? "-NoProfile -Command \"" : "-NoProfile -NoExit -Command \"") + quoted + "\"")
 				{
 					UseShellExecute = false,
 					CreateNoWindow = hidden
 				});
 				break;
 			case "wsl":
+				// WSL receives the raw command after "--"; no extra quoting needed
 				Process.Start(new ProcessStartInfo("wsl.exe", "-- " + command)
 				{
 					UseShellExecute = false,
@@ -471,7 +474,7 @@ public static class ActionExecutor
 				break;
 			default:
 				// Visible: keep the window open (/k). Hidden: /c so no lingering process.
-				Process.Start(new ProcessStartInfo("cmd.exe", (hidden ? "/c \"" : "/k \"") + command + "\"")
+				Process.Start(new ProcessStartInfo("cmd.exe", (hidden ? "/c \"" : "/k \"") + quoted + "\"")
 				{
 					UseShellExecute = false,
 					CreateNoWindow = hidden

--- a/WinPieGestures/ActionExecutor.cs
+++ b/WinPieGestures/ActionExecutor.cs
@@ -183,6 +183,9 @@ public static class ActionExecutor
 			case "Hotkey":
 				ExecuteHotkey(action.Parameter);
 				break;
+			case "Command":
+				ExecuteCommand(action.Parameter, action.CommandTerminal);
+				break;
 			case "Text":
 			case "String":
 				SendTextInput(action.Parameter);
@@ -434,6 +437,52 @@ public static class ActionExecutor
 			{
 			}
 			Process.Start(processStartInfo);
+		}
+	}
+
+	/// <summary>Runs a command in the selected terminal (cmd / PowerShell / WSL / direct).</summary>
+	private static void ExecuteCommand(string command, string? terminal)
+	{
+		if (string.IsNullOrWhiteSpace(command))
+		{
+			return;
+		}
+		string term = string.IsNullOrEmpty(terminal) ? "cmd" : terminal.Trim().ToLowerInvariant();
+		try
+		{
+			switch (term)
+			{
+			case "powershell":
+				Process.Start(new ProcessStartInfo("powershell.exe", "-NoProfile -Command \"" + command + "\"")
+				{
+					UseShellExecute = false
+				});
+				break;
+			case "wsl":
+				Process.Start(new ProcessStartInfo("wsl.exe", "-- " + command)
+				{
+					UseShellExecute = false
+				});
+				break;
+			case "direct":
+			case "none":
+				Process.Start(new ProcessStartInfo
+				{
+					FileName = command,
+					UseShellExecute = true
+				});
+				break;
+			default:
+				Process.Start(new ProcessStartInfo("cmd.exe", "/c \"" + command + "\"")
+				{
+					UseShellExecute = false
+				});
+				break;
+			}
+		}
+		catch (Exception ex)
+		{
+			MessageBox.Show("Failed to run command: " + ex.Message, "StarPie", MessageBoxButton.OK, MessageBoxImage.Hand);
 		}
 	}
 

--- a/WinPieGestures/ActionItem.cs
+++ b/WinPieGestures/ActionItem.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace WinPieGestures;
 
@@ -15,6 +15,9 @@ public class ActionItem
 	public string IconKey { get; set; } = "";
 
 	public string CustomIconSvg { get; set; } = "";
+
+	/// <summary>Terminal used to run a "Command" action: "cmd", "powershell", "wsl" or "direct".</summary>
+	public string CommandTerminal { get; set; } = "cmd";
 
 	public List<ActionItem> SubActions { get; set; } = new List<ActionItem>();
 

--- a/WinPieGestures/I18n.cs
+++ b/WinPieGestures/I18n.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 
@@ -583,6 +583,41 @@ public static class I18n
 			[LanguageCode.ZhTw] = "系統控制",
 			[LanguageCode.En] = "System",
 			[LanguageCode.Ja] = "システム"
+		};
+		dictionary["ActionTypeCommandShort"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "▶️ 运行命令",
+			[LanguageCode.ZhTw] = "▶️ 執行命令",
+			[LanguageCode.En] = "▶️ Run Command",
+			[LanguageCode.Ja] = "▶️ コマンド実行"
+		};
+		dictionary["TerminalCmd"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "CMD (命令提示符)",
+			[LanguageCode.ZhTw] = "CMD (命令提示字元)",
+			[LanguageCode.En] = "CMD",
+			[LanguageCode.Ja] = "CMD"
+		};
+		dictionary["TerminalPowerShell"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "PowerShell",
+			[LanguageCode.ZhTw] = "PowerShell",
+			[LanguageCode.En] = "PowerShell",
+			[LanguageCode.Ja] = "PowerShell"
+		};
+		dictionary["TerminalWsl"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "WSL (Linux 子系统)",
+			[LanguageCode.ZhTw] = "WSL (Linux 子系統)",
+			[LanguageCode.En] = "WSL",
+			[LanguageCode.Ja] = "WSL"
+		};
+		dictionary["TerminalDirect"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "直接运行 (无终端)",
+			[LanguageCode.ZhTw] = "直接執行 (無終端)",
+			[LanguageCode.En] = "Direct (no terminal)",
+			[LanguageCode.Ja] = "直接実行 (端末なし)"
 		};
 		dictionary["ProfileCardTitle"] = new Dictionary<LanguageCode, string>
 		{

--- a/WinPieGestures/I18n.cs
+++ b/WinPieGestures/I18n.cs
@@ -586,38 +586,52 @@ public static class I18n
 		};
 		dictionary["ActionTypeCommandShort"] = new Dictionary<LanguageCode, string>
 		{
-			[LanguageCode.ZhCn] = "▶️ 运行命令",
-			[LanguageCode.ZhTw] = "▶️ 執行命令",
-			[LanguageCode.En] = "▶️ Run Command",
-			[LanguageCode.Ja] = "▶️ コマンド実行"
+			[LanguageCode.ZhCn] = "运行命令",
+			[LanguageCode.ZhTw] = "執行命令",
+			[LanguageCode.En] = "Run Command",
+			[LanguageCode.Ja] = "コマンド実行"
 		};
 		dictionary["TerminalCmd"] = new Dictionary<LanguageCode, string>
 		{
-			[LanguageCode.ZhCn] = "CMD (命令提示符)",
-			[LanguageCode.ZhTw] = "CMD (命令提示字元)",
+			[LanguageCode.ZhCn] = "CMD",
+			[LanguageCode.ZhTw] = "CMD",
 			[LanguageCode.En] = "CMD",
 			[LanguageCode.Ja] = "CMD"
 		};
 		dictionary["TerminalPowerShell"] = new Dictionary<LanguageCode, string>
 		{
-			[LanguageCode.ZhCn] = "PowerShell",
-			[LanguageCode.ZhTw] = "PowerShell",
-			[LanguageCode.En] = "PowerShell",
-			[LanguageCode.Ja] = "PowerShell"
+			[LanguageCode.ZhCn] = "Powershell",
+			[LanguageCode.ZhTw] = "Powershell",
+			[LanguageCode.En] = "Powershell",
+			[LanguageCode.Ja] = "Powershell"
 		};
 		dictionary["TerminalWsl"] = new Dictionary<LanguageCode, string>
 		{
-			[LanguageCode.ZhCn] = "WSL (Linux 子系统)",
-			[LanguageCode.ZhTw] = "WSL (Linux 子系統)",
+			[LanguageCode.ZhCn] = "WSL",
+			[LanguageCode.ZhTw] = "WSL",
 			[LanguageCode.En] = "WSL",
 			[LanguageCode.Ja] = "WSL"
 		};
-		dictionary["TerminalDirect"] = new Dictionary<LanguageCode, string>
+		dictionary["TerminalCmdHidden"] = new Dictionary<LanguageCode, string>
 		{
-			[LanguageCode.ZhCn] = "直接运行 (无终端)",
-			[LanguageCode.ZhTw] = "直接執行 (無終端)",
-			[LanguageCode.En] = "Direct (no terminal)",
-			[LanguageCode.Ja] = "直接実行 (端末なし)"
+			[LanguageCode.ZhCn] = "CMD (无终端)",
+			[LanguageCode.ZhTw] = "CMD (無終端)",
+			[LanguageCode.En] = "CMD (no window)",
+			[LanguageCode.Ja] = "CMD (非表示)"
+		};
+		dictionary["TerminalPowerShellHidden"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "Powershell (无终端)",
+			[LanguageCode.ZhTw] = "Powershell (無終端)",
+			[LanguageCode.En] = "Powershell (no window)",
+			[LanguageCode.Ja] = "Powershell (非表示)"
+		};
+		dictionary["TerminalWslHidden"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "WSL (无终端)",
+			[LanguageCode.ZhTw] = "WSL (無終端)",
+			[LanguageCode.En] = "WSL (no window)",
+			[LanguageCode.Ja] = "WSL (非表示)"
 		};
 		dictionary["ProfileCardTitle"] = new Dictionary<LanguageCode, string>
 		{

--- a/WinPieGestures/IconHelper.cs
+++ b/WinPieGestures/IconHelper.cs
@@ -82,6 +82,13 @@ public static class IconHelper
 		{
 			new VectorIconItem
 			{
+				Key = "Command",
+				Category = "快捷工具",
+				DisplayName = "运行命令 (Command)",
+				SvgData = "M4,3H20A2,2 0 0,1 22,5V19A2,2 0 0,1 20,21H4A2,2 0 0,1 2,19V5A2,2 0 0,1 4,3M4,5V19H20V5H4M11,17L7,13L11,9L12.4,10.4L9.8,13L12.4,15.6L11,17M15,17H18V15H15V17Z"
+			},
+			new VectorIconItem
+			{
 				Key = "Copy",
 				Category = "编辑与剪贴板",
 				DisplayName = "复制 (Copy)",

--- a/WinPieGestures/RadialWindow.xaml.cs
+++ b/WinPieGestures/RadialWindow.xaml.cs
@@ -691,6 +691,8 @@ public partial class RadialWindow : Window
 			return IconHelper.GetSvgPathByKey("Folder");
 		case "Hotkey":
 			return "M19,15H5V5H19M19,3H5C3.89,3 3,3.89 3,5V15C3,16.1 3.89,17 5,17H19C20.1,17 21,16.1 21,15V5C21,3.89 20.1,3 19,3M2,18H22V20H2V18Z";
+		case "Command":
+			return IconHelper.GetSvgPathByKey("Command");
 		case "System":
 			if (!string.IsNullOrEmpty(parameter))
 			{

--- a/WinPieGestures/SettingsWindow.xaml
+++ b/WinPieGestures/SettingsWindow.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Window x:Class="WinPieGestures.SettingsWindow" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:local="clr-namespace:WinPieGestures" Title="StarPie 设置控制台 (Preferences)" Height="720" Width="1060" WindowStartupLocation="CenterScreen" Background="{DynamicResource WindowBackgroundBrush}" FontFamily="Segoe UI, Microsoft YaHei UI, Arial" UseLayoutRounding="True" SnapsToDevicePixels="True" TextOptions.TextFormattingMode="Display" TextOptions.TextRenderingMode="ClearType" RenderOptions.ClearTypeHint="Enabled" RenderOptions.BitmapScalingMode="HighQuality" Closing="Window_Closing">
   <FrameworkElement.Resources>
     <ResourceDictionary>
@@ -1498,6 +1498,14 @@
                                 </Button>
                               </Grid>
                               <ComboBox SelectedValuePath="Key" DisplayMemberPath="Value" Style="{StaticResource FlatComboBoxStyle}" Height="30" FontSize="11.5" SelectedValue="{Binding SelectedSystemPreset, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ItemsSource="{Binding Source={x:Static local:SlotViewModel.SystemPresets}}" Visibility="{Binding IsSystemType, Converter={StaticResource BoolToVis}}" />
+                              <Grid Visibility="{Binding IsCommandType, Converter={StaticResource BoolToVis}}">
+                                <Grid.ColumnDefinitions>
+                                  <ColumnDefinition Width="*"/>
+                                  <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Grid.Column="0" Text="{Binding Parameter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="30" Margin="0,0,4,0" FontSize="11" VerticalContentAlignment="Center" ToolTip="要运行的命令，如 ping -n 3 127.0.0.1"/>
+                                <ComboBox Grid.Column="1" Width="118" ItemsSource="{Binding Terminals}" SelectedValuePath="Tag" DisplayMemberPath="DisplayText" SelectedValue="{Binding CommandTerminal, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FlatComboBoxStyle}" Height="30" FontSize="11"/>
+                              </Grid>
                             </Grid>
                             <TextBox Grid.Column="5" Margin="0,0,6,0" Height="30" FontSize="11" ToolTip="启动参数 (如命令行参数或URL)" VerticalContentAlignment="Center" Text="{Binding Arguments, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding IsLaunchType}" />
                             <Button Grid.Column="6" Style="{StaticResource ModernButtonStyle}" Height="30" Padding="8,0" Margin="0,0,6,0" ToolTip="配置该扇区的二级级联子动作菜单" Content="{Binding SubActionButtonText}" Click="ManageSubActions_Click" />

--- a/WinPieGestures/SlotViewModel.cs
+++ b/WinPieGestures/SlotViewModel.cs
@@ -670,8 +670,6 @@ public class SlotViewModel : INotifyPropertyChanged
 
 	public bool IsCommandType => Type == "Command";
 
-	public string CommandLine => Parameter;
-
 	public string TestButtonText => I18n.T("BtnTest");
 
 	public event PropertyChangedEventHandler? PropertyChanged;

--- a/WinPieGestures/SlotViewModel.cs
+++ b/WinPieGestures/SlotViewModel.cs
@@ -652,7 +652,9 @@ public class SlotViewModel : INotifyPropertyChanged
 		new ActionTypeItem { Tag = "cmd", DisplayText = I18n.T("TerminalCmd") },
 		new ActionTypeItem { Tag = "powershell", DisplayText = I18n.T("TerminalPowerShell") },
 		new ActionTypeItem { Tag = "wsl", DisplayText = I18n.T("TerminalWsl") },
-		new ActionTypeItem { Tag = "direct", DisplayText = I18n.T("TerminalDirect") }
+		new ActionTypeItem { Tag = "cmd_hidden", DisplayText = I18n.T("TerminalCmdHidden") },
+		new ActionTypeItem { Tag = "powershell_hidden", DisplayText = I18n.T("TerminalPowerShellHidden") },
+		new ActionTypeItem { Tag = "wsl_hidden", DisplayText = I18n.T("TerminalWslHidden") }
 	};
 
 	/// <summary>Localized terminal options for Command actions.</summary>
@@ -661,7 +663,9 @@ public class SlotViewModel : INotifyPropertyChanged
 		new ActionTypeOption { Tag = "cmd", DisplayText = I18n.T("TerminalCmd") },
 		new ActionTypeOption { Tag = "powershell", DisplayText = I18n.T("TerminalPowerShell") },
 		new ActionTypeOption { Tag = "wsl", DisplayText = I18n.T("TerminalWsl") },
-		new ActionTypeOption { Tag = "direct", DisplayText = I18n.T("TerminalDirect") }
+		new ActionTypeOption { Tag = "cmd_hidden", DisplayText = I18n.T("TerminalCmdHidden") },
+		new ActionTypeOption { Tag = "powershell_hidden", DisplayText = I18n.T("TerminalPowerShellHidden") },
+		new ActionTypeOption { Tag = "wsl_hidden", DisplayText = I18n.T("TerminalWslHidden") }
 	};
 
 	public bool IsCommandType => Type == "Command";

--- a/WinPieGestures/SlotViewModel.cs
+++ b/WinPieGestures/SlotViewModel.cs
@@ -376,6 +376,7 @@ public class SlotViewModel : INotifyPropertyChanged
 			OnPropertyChanged("IsLaunchType");
 			OnPropertyChanged("IsFolderType");
 			OnPropertyChanged("IsSystemType");
+			OnPropertyChanged("IsCommandType");
 		}
 	}
 
@@ -391,6 +392,22 @@ public class SlotViewModel : INotifyPropertyChanged
 			{
 				Action.Parameter = value;
 				OnPropertyChanged("Parameter");
+			}
+		}
+	}
+
+	public string CommandTerminal
+	{
+		get
+		{
+			return Action.CommandTerminal ?? "cmd";
+		}
+		set
+		{
+			if (Action.CommandTerminal != value && !string.IsNullOrEmpty(value))
+			{
+				Action.CommandTerminal = value;
+				OnPropertyChanged("CommandTerminal");
 			}
 		}
 	}
@@ -590,6 +607,11 @@ public class SlotViewModel : INotifyPropertyChanged
 		},
 		new ActionTypeOption
 		{
+			Tag = "Command",
+			DisplayText = I18n.T("ActionTypeCommandShort")
+		},
+		new ActionTypeOption
+		{
 			Tag = "System",
 			DisplayText = I18n.T("ActionTypeSystemShort")
 		}
@@ -614,10 +636,37 @@ public class SlotViewModel : INotifyPropertyChanged
 		},
 		new ActionTypeItem
 		{
+			Tag = "Command",
+			DisplayText = I18n.T("ActionTypeCommandShort")
+		},
+		new ActionTypeItem
+		{
 			Tag = "System",
 			DisplayText = I18n.T("ActionTypeSystemShort")
 		}
 	};
+
+	/// <summary>Localized terminal options (shared by the sub-action editor).</summary>
+	public static List<ActionTypeItem> LocalizedTerminals => new List<ActionTypeItem>
+	{
+		new ActionTypeItem { Tag = "cmd", DisplayText = I18n.T("TerminalCmd") },
+		new ActionTypeItem { Tag = "powershell", DisplayText = I18n.T("TerminalPowerShell") },
+		new ActionTypeItem { Tag = "wsl", DisplayText = I18n.T("TerminalWsl") },
+		new ActionTypeItem { Tag = "direct", DisplayText = I18n.T("TerminalDirect") }
+	};
+
+	/// <summary>Localized terminal options for Command actions.</summary>
+	public List<ActionTypeOption> Terminals => new List<ActionTypeOption>
+	{
+		new ActionTypeOption { Tag = "cmd", DisplayText = I18n.T("TerminalCmd") },
+		new ActionTypeOption { Tag = "powershell", DisplayText = I18n.T("TerminalPowerShell") },
+		new ActionTypeOption { Tag = "wsl", DisplayText = I18n.T("TerminalWsl") },
+		new ActionTypeOption { Tag = "direct", DisplayText = I18n.T("TerminalDirect") }
+	};
+
+	public bool IsCommandType => Type == "Command";
+
+	public string CommandLine => Parameter;
 
 	public string TestButtonText => I18n.T("BtnTest");
 
@@ -641,6 +690,7 @@ public class SlotViewModel : INotifyPropertyChanged
 		I18n.LanguageChanged += delegate
 		{
 			OnPropertyChanged("ActionTypes");
+			OnPropertyChanged("Terminals");
 			OnPropertyChanged("TestButtonText");
 			OnPropertyChanged("IconDisplayText");
 			OnPropertyChanged("SubActionButtonText");

--- a/WinPieGestures/SubActionEditorWindow.xaml
+++ b/WinPieGestures/SubActionEditorWindow.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Window x:Class="WinPieGestures.SubActionEditorWindow" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:local="clr-namespace:WinPieGestures" Title="扇区级联子菜单管理 (Sub-Actions Editor)" Height="560" Width="850" WindowStartupLocation="CenterOwner" Background="{DynamicResource WindowBackgroundBrush}" ResizeMode="NoResize" WindowStyle="SingleBorderWindow" FontFamily="Segoe UI, Microsoft YaHei UI, Arial">
   <FrameworkElement.Resources>
     <ResourceDictionary>
@@ -82,6 +82,14 @@
                       </Button>
                     </Grid>
                     <ComboBox SelectedValuePath="Key" DisplayMemberPath="Value" Style="{StaticResource FlatComboBoxStyle}" Height="30" FontSize="11" SelectedValue="{Binding SelectedSystemPreset, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ItemsSource="{Binding Source={x:Static local:SlotViewModel.SystemPresets}}" Visibility="{Binding IsSystemType, Converter={StaticResource BoolToVis}}" />
+                    <Grid Visibility="{Binding IsCommandType, Converter={StaticResource BoolToVis}}">
+                      <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                      </Grid.ColumnDefinitions>
+                      <TextBox Grid.Column="0" Text="{Binding Parameter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="30" Margin="0,0,4,0" FontSize="11" VerticalContentAlignment="Center" ToolTip="要运行的命令，如 ping -n 3 127.0.0.1"/>
+                      <ComboBox Grid.Column="1" Width="112" ItemsSource="{Binding Terminals}" SelectedValuePath="Tag" DisplayMemberPath="DisplayText" SelectedValue="{Binding CommandTerminal, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FlatComboBoxStyle}" Height="30" FontSize="11"/>
+                    </Grid>
                   </Grid>
                   <TextBox Grid.Column="5" Margin="0,0,6,0" Height="30" FontSize="10.5" ToolTip="启动参数 (可选)" VerticalContentAlignment="Center" Text="{Binding Arguments, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding IsLaunchType}" />
                   <Button Grid.Column="6" Content="测试" Style="{StaticResource ModernButtonStyle}" Height="30" Margin="0,0,6,0" Padding="0" ToolTip="测试执行此子动作" Click="SubTest_Click" />

--- a/WinPieGestures/SubActionEditorWindow.xaml.cs
+++ b/WinPieGestures/SubActionEditorWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -40,7 +40,8 @@ public partial class SubActionEditorWindow : Window
 						Parameter = existingSubAction.Parameter,
 						Arguments = existingSubAction.Arguments,
 						IconKey = existingSubAction.IconKey,
-						CustomIconSvg = existingSubAction.CustomIconSvg
+						CustomIconSvg = existingSubAction.CustomIconSvg,
+						CommandTerminal = existingSubAction.CommandTerminal
 					}
 				});
 			}

--- a/WinPieGestures/SubSlotViewModel.cs
+++ b/WinPieGestures/SubSlotViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -58,6 +58,7 @@ public class SubSlotViewModel : INotifyPropertyChanged
 			OnPropertyChanged("IsLaunchType");
 			OnPropertyChanged("IsFolderType");
 			OnPropertyChanged("IsSystemType");
+			OnPropertyChanged("IsCommandType");
 		}
 	}
 
@@ -244,6 +245,27 @@ public class SubSlotViewModel : INotifyPropertyChanged
 	}
 
 	public bool IsSystemType => Type == "System";
+
+	public bool IsCommandType => Type == "Command";
+
+	/// <summary>Localized terminal options for Command actions.</summary>
+	public List<ActionTypeItem> Terminals => SlotViewModel.LocalizedTerminals;
+
+	public string CommandTerminal
+	{
+		get
+		{
+			return Action.CommandTerminal ?? "cmd";
+		}
+		set
+		{
+			if (Action.CommandTerminal != value && !string.IsNullOrEmpty(value))
+			{
+				Action.CommandTerminal = value;
+				OnPropertyChanged("CommandTerminal");
+			}
+		}
+	}
 
 	public List<ActionTypeItem> ActionTypes => SlotViewModel.LocalizedActionTypes;
 


### PR DESCRIPTION
## 概述
新增「运行命令」动作类型：扇区动作映射列表与级联子菜单（一、二级）均可使用，
命令可在可选终端中执行（CMD / Powershell / WSL，各含「无终端」静默变体）。

## 改动
- ActionItem：新增 `CommandTerminal`（终端选择，随配置持久化）
- 动作类型列表与级联编辑器：新增「运行命令」，子项同样支持
- 执行器：按终端拼装执行——CMD `/k`、Powershell `-NoExit -Command`（保留窗口）；
  「无终端」变体静默执行（CreateNoWindow + `/c`/`-Command`，不残留进程）
- 图标库：新增「运行命令 (Command)」矢量图标，动作默认显示终端图标
- 修复：级联编辑器打开时未拷贝 `CommandTerminal` 导致终端选择丢失

## 功能
- 打开指定文件夹: explorer file:
- 运行命令: fastfetch
- Windows特殊功能面板: regedit

## 演示
<img width="1047" height="692" alt="Snipaste" src="https://github.com/user-attachments/assets/aa51a426-5e1d-44e0-8576-9a19dc1392da" />
<img width="1532" height="791" alt="screenshots" src="https://github.com/user-attachments/assets/2e8c8394-9823-4da4-a642-69f0be41f78a" />

## 测试
- [x] 构建通过（0 错误）
- [x] 一级/二级「运行命令」均可配置与触发
- [x] CMD / Powershell 保留窗口；无终端变体静默
- [x] 级联编辑器保存后终端选择不回退