### PR TITLE
新增轮盘动作排序并优化手势拖拽流畅度

### DIFF
--- a/WinPieGestures/GestureController.cs
+++ b/WinPieGestures/GestureController.cs
@@ -23,9 +23,9 @@ public class GestureController
 
 	private Point _startPoint;
 
-	private bool _isWaitingForThreshold;
+	private volatile bool _isWaitingForThreshold;
 
-	private bool _isGestureActive;
+	private volatile bool _isGestureActive;
 
 	private WheelProfile? _activeProfile;
 
@@ -36,6 +36,25 @@ public class GestureController
 	private bool _lastEscapedState;
 
 	private bool _lastShowSubTier;
+
+	// Mouse hooks can outpace WPF rendering. Keep one pending visual update and
+	// overwrite it with the newest state instead of queueing every intermediate
+	// sector transition on the UI dispatcher.
+	private readonly object _uiUpdateSync = new object();
+
+	private long _gestureVersion;
+
+	private bool _highlightUpdateScheduled;
+
+	private int _pendingSectorIndex = -1;
+
+	private int _pendingSubSectorIndex = -1;
+
+	private bool _pendingEscape;
+
+	private bool _pendingShowSubTier;
+
+	private long _pendingGestureVersion;
 
 	[DllImport("user32.dll")]
 	[return: MarshalAs(UnmanagedType.Bool)]
@@ -53,6 +72,159 @@ public class GestureController
 			_keyboardHook.OnKeyDown += KeyboardHook_OnKeyDown;
 			_keyboardHook.OnKeyUp += KeyboardHook_OnKeyUp;
 		}
+	}
+
+	private long BeginGestureTracking()
+	{
+		lock (_uiUpdateSync)
+		{
+			_gestureVersion++;
+			_highlightUpdateScheduled = false;
+			_pendingSectorIndex = -1;
+			_pendingSubSectorIndex = -1;
+			_pendingEscape = false;
+			_pendingShowSubTier = false;
+			_pendingGestureVersion = _gestureVersion;
+			_selectedSectorIndex = -1;
+			_selectedSubSectorIndex = -1;
+			_lastEscapedState = false;
+			_lastShowSubTier = false;
+			return _gestureVersion;
+		}
+	}
+
+	private void CancelGestureTracking()
+	{
+		lock (_uiUpdateSync)
+		{
+			_gestureVersion++;
+			_highlightUpdateScheduled = false;
+			_pendingGestureVersion = _gestureVersion;
+		}
+	}
+
+	private (int Sector, int SubSector, WheelProfile? Profile, RadialWindow? Window) EndActiveGesture()
+	{
+		lock (_uiUpdateSync)
+		{
+			var result = (_selectedSectorIndex, _selectedSubSectorIndex, _activeProfile, _radialWindow);
+			_isGestureActive = false;
+			_isWaitingForThreshold = false;
+			_gestureVersion++;
+			_highlightUpdateScheduled = false;
+			_pendingGestureVersion = _gestureVersion;
+			return result;
+		}
+	}
+
+	private bool IsCurrentGesture(long version)
+	{
+		lock (_uiUpdateSync)
+		{
+			return version == _gestureVersion;
+		}
+	}
+
+	private long GetCurrentGestureVersion()
+	{
+		lock (_uiUpdateSync)
+		{
+			return _gestureVersion;
+		}
+	}
+
+	private void QueueHighlightUpdate(int sectorIndex, int subSectorIndex, bool isEscaped, bool showSubTier, long gestureVersion)
+	{
+		bool shouldSchedule;
+		lock (_uiUpdateSync)
+		{
+			if (!_isGestureActive || gestureVersion != _gestureVersion)
+			{
+				return;
+			}
+			if (sectorIndex == _selectedSectorIndex &&
+				subSectorIndex == _selectedSubSectorIndex &&
+				isEscaped == _lastEscapedState &&
+				showSubTier == _lastShowSubTier)
+			{
+				return;
+			}
+
+			_selectedSectorIndex = sectorIndex;
+			_selectedSubSectorIndex = subSectorIndex;
+			_lastEscapedState = isEscaped;
+			_lastShowSubTier = showSubTier;
+			_pendingSectorIndex = sectorIndex;
+			_pendingSubSectorIndex = subSectorIndex;
+			_pendingEscape = isEscaped;
+			_pendingShowSubTier = showSubTier;
+			_pendingGestureVersion = gestureVersion;
+			shouldSchedule = !_highlightUpdateScheduled;
+			_highlightUpdateScheduled = true;
+		}
+
+		if (!shouldSchedule)
+		{
+			return;
+		}
+
+		try
+		{
+			Application.Current.Dispatcher.BeginInvoke((Action)ApplyPendingHighlight, DispatcherPriority.Render);
+		}
+		catch
+		{
+			lock (_uiUpdateSync)
+			{
+				if (_pendingGestureVersion == gestureVersion)
+				{
+					_highlightUpdateScheduled = false;
+				}
+			}
+		}
+	}
+
+	private void ApplyPendingHighlight()
+	{
+		int targetSector;
+		int targetSubSector;
+		bool targetEscape;
+		bool targetShowSubTier;
+		long targetGestureVersion;
+		RadialWindow? radialWindow;
+
+		lock (_uiUpdateSync)
+		{
+			if (!_highlightUpdateScheduled)
+			{
+				return;
+			}
+			targetSector = _pendingSectorIndex;
+			targetSubSector = _pendingSubSectorIndex;
+			targetEscape = _pendingEscape;
+			targetShowSubTier = _pendingShowSubTier;
+			targetGestureVersion = _pendingGestureVersion;
+			if (!_isGestureActive || targetGestureVersion != _gestureVersion)
+			{
+				_highlightUpdateScheduled = false;
+				return;
+			}
+			radialWindow = _radialWindow;
+			// Keep the pending state until the activation callback creates the
+			// window. That callback calls this method again after Show().
+			if (radialWindow == null)
+			{
+				return;
+			}
+			_highlightUpdateScheduled = false;
+		}
+
+		if (!IsCurrentGesture(targetGestureVersion) || !ReferenceEquals(_radialWindow, radialWindow))
+		{
+			return;
+		}
+		radialWindow.SetOuterEscapeState(targetEscape);
+		radialWindow.HighlightSector(targetSector, targetSubSector, targetShowSubTier);
 	}
 
 	private bool CheckIsIsolated(out string processName)
@@ -96,9 +268,10 @@ public class GestureController
 			isProcessIsolated = isBlacklisted;
 		}
 
-		bool disableCtrl = ConfigManager.CurrentConfig.DisableOnCtrl && ((int)(Keyboard.GetKeyStates((Key)118) & KeyStates.Down) > 0 || (int)(Keyboard.GetKeyStates((Key)119) & KeyStates.Down) > 0);
-		bool disableShift = ConfigManager.CurrentConfig.DisableOnShift && ((int)(Keyboard.GetKeyStates((Key)116) & KeyStates.Down) > 0 || (int)(Keyboard.GetKeyStates((Key)117) & KeyStates.Down) > 0);
-		bool disableAlt = ConfigManager.CurrentConfig.DisableOnAlt && ((int)(Keyboard.GetKeyStates((Key)120) & KeyStates.Down) > 0 || (int)(Keyboard.GetKeyStates((Key)121) & KeyStates.Down) > 0);
+		ModifierKeys currentModifiers = KeyboardHook.GetCurrentModifiers();
+		bool disableCtrl = ConfigManager.CurrentConfig.DisableOnCtrl && currentModifiers.HasFlag(ModifierKeys.Control);
+		bool disableShift = ConfigManager.CurrentConfig.DisableOnShift && currentModifiers.HasFlag(ModifierKeys.Shift);
+		bool disableAlt = ConfigManager.CurrentConfig.DisableOnAlt && currentModifiers.HasFlag(ModifierKeys.Alt);
 		bool isModifierSuppressed = disableCtrl | disableShift | disableAlt;
 
 		bool isFullScreenSuppressed = false;
@@ -146,17 +319,16 @@ public class GestureController
 		{
 			if (CheckIsIsolated(out string _))
 			{
+				CancelGestureTracking();
 				_isWaitingForThreshold = false;
 				_isGestureActive = false;
 				e.Handled = false;
 				return;
 			}
 			_startPoint = e.Position;
+			BeginGestureTracking();
 			_isWaitingForThreshold = true;
 			_isGestureActive = false;
-			_selectedSectorIndex = -1;
-			_selectedSubSectorIndex = -1;
-			_lastEscapedState = false;
 			e.Handled = true;
 		}
 	}
@@ -170,6 +342,7 @@ public class GestureController
 		}
 		if (_isWaitingForThreshold)
 		{
+			CancelGestureTracking();
 			_isWaitingForThreshold = false;
 			string btn = triggerConfig.MouseButton ?? ConfigManager.CurrentConfig.TriggerButton ?? "RightButton";
 			((DispatcherObject)Application.Current).Dispatcher.BeginInvoke((Delegate)(Action)delegate
@@ -184,13 +357,14 @@ public class GestureController
 			{
 				return;
 			}
-			_isGestureActive = false;
-			int finalSector = _selectedSectorIndex;
-			int finalSubSector = _selectedSubSectorIndex;
-			WheelProfile finalProfile = _activeProfile;
+			var finalState = EndActiveGesture();
+			int finalSector = finalState.Sector;
+			int finalSubSector = finalState.SubSector;
+			WheelProfile? finalProfile = finalState.Profile;
+			RadialWindow? endedWindow = finalState.Window;
 			((DispatcherObject)Application.Current).Dispatcher.BeginInvoke((Delegate)(Action)delegate
 			{
-				HideRadialUI();
+				CloseGestureWindow(endedWindow);
 				if (finalProfile != null && finalSector >= 0 && finalSector < finalProfile.Actions.Count)
 				{
 					ActionItem actionItem = finalProfile.Actions[finalSector];
@@ -245,6 +419,7 @@ public class GestureController
 			}
 			if (CheckIsIsolated(out string _))
 			{
+				CancelGestureTracking();
 				_isWaitingForThreshold = false;
 				_isGestureActive = false;
 				e.Handled = false;
@@ -252,11 +427,9 @@ public class GestureController
 			}
 			GetCursorPos(out var lpPoint);
 			_startPoint = new Point((double)lpPoint.x, (double)lpPoint.y);
+			BeginGestureTracking();
 			_isWaitingForThreshold = true;
 			_isGestureActive = false;
-			_selectedSectorIndex = -1;
-			_selectedSubSectorIndex = -1;
-			_lastEscapedState = false;
 			e.Handled = true;
 		}
 	}
@@ -295,6 +468,7 @@ public class GestureController
 		}
 		if (_isWaitingForThreshold)
 		{
+			CancelGestureTracking();
 			_isWaitingForThreshold = false;
 			uint vk = ((triggerConfig.VkCode != 0) ? triggerConfig.VkCode : e.VkCode);
 			((DispatcherObject)Application.Current).Dispatcher.BeginInvoke((Delegate)(Action)delegate
@@ -309,13 +483,14 @@ public class GestureController
 			{
 				return;
 			}
-			_isGestureActive = false;
-			int finalSector = _selectedSectorIndex;
-			int finalSubSector = _selectedSubSectorIndex;
-			WheelProfile finalProfile = _activeProfile;
+			var finalState = EndActiveGesture();
+			int finalSector = finalState.Sector;
+			int finalSubSector = finalState.SubSector;
+			WheelProfile? finalProfile = finalState.Profile;
+			RadialWindow? endedWindow = finalState.Window;
 			((DispatcherObject)Application.Current).Dispatcher.BeginInvoke((Delegate)(Action)delegate
 			{
-				HideRadialUI();
+				CloseGestureWindow(endedWindow);
 				if (finalProfile != null && finalSector >= 0 && finalSector < finalProfile.Actions.Count)
 				{
 					ActionItem actionItem = finalProfile.Actions[finalSector];
@@ -369,12 +544,18 @@ public class GestureController
 				Point center = _startPoint;
 				WheelProfile profile = _activeProfile;
 				Point initialPos = e.Position;
+				long gestureVersion = GetCurrentGestureVersion();
+				// Publish the threshold-crossing position before the UI callback is
+				// queued. Later move events replace it with the newest state.
+				ProcessMove(initialPos);
 				((DispatcherObject)Application.Current).Dispatcher.BeginInvoke((Delegate)(Action)delegate
 				{
-					//IL_0007: Unknown result type (might be due to invalid IL or missing references)
-					//IL_001e: Unknown result type (might be due to invalid IL or missing references)
+					if (!_isGestureActive || !IsCurrentGesture(gestureVersion))
+					{
+						return;
+					}
 					ShowRadialUI(center, profile);
-					ProcessMove(initialPos);
+					ApplyPendingHighlight();
 				}, (DispatcherPriority)7, Array.Empty<object>());
 			}
 		}
@@ -472,45 +653,60 @@ if (ConfigManager.CurrentConfig.SubmenuStyle == "Fan")
 				}
 			}
 		}
-		if (num4 == _selectedSectorIndex && num5 == _selectedSubSectorIndex && flag == _lastEscapedState && flag2 == _lastShowSubTier)
-		{
-			return;
-		}
-		_selectedSectorIndex = num4;
-		_selectedSubSectorIndex = num5;
-		_lastEscapedState = flag;
-		_lastShowSubTier = flag2;
-		int targetSector = num4;
-		int targetSubSector = num5;
-		bool targetEscape = flag;
-		bool targetShowSub = flag2;
-		((DispatcherObject)Application.Current).Dispatcher.BeginInvoke((Delegate)(Action)delegate
-		{
-			if (_radialWindow != null)
-			{
-				_radialWindow.SetOuterEscapeState(targetEscape);
-				_radialWindow.HighlightSector(targetSector, targetSubSector, targetShowSub);
-			}
-		}, (DispatcherPriority)5, Array.Empty<object>());
+		QueueHighlightUpdate(num4, num5, flag, flag2, GetCurrentGestureVersion());
 	}
 
 	private void ShowRadialUI(Point center, WheelProfile profile)
 	{
 		//IL_0014: Unknown result type (might be due to invalid IL or missing references)
-		if (_radialWindow != null)
+		lock (_uiUpdateSync)
 		{
-			_radialWindow.Close();
+			if (_radialWindow != null)
+			{
+				_radialWindow.Close();
+			}
+			_radialWindow = new RadialWindow(center, profile);
+			_radialWindow.Show();
 		}
-		_radialWindow = new RadialWindow(center, profile);
-		_radialWindow.Show();
 	}
 
 	private void HideRadialUI()
 	{
-		if (_radialWindow != null)
+		lock (_uiUpdateSync)
 		{
-			_radialWindow.Close();
-			_radialWindow = null;
+			if (_radialWindow != null)
+			{
+				_radialWindow.Close();
+				_radialWindow = null;
+			}
+		}
+	}
+
+	private void CloseGestureWindow(RadialWindow? gestureWindow)
+	{
+		if (gestureWindow == null)
+		{
+			return;
+		}
+
+		lock (_uiUpdateSync)
+		{
+			if (ReferenceEquals(_radialWindow, gestureWindow))
+			{
+				gestureWindow.Close();
+				_radialWindow = null;
+				return;
+			}
+		}
+
+		// A newer gesture may already own the active window. Close only the
+		// completed gesture's stale window and leave the newer one untouched.
+		try
+		{
+			gestureWindow.Close();
+		}
+		catch
+		{
 		}
 	}
 

--- a/WinPieGestures/I18n.cs
+++ b/WinPieGestures/I18n.cs
@@ -703,6 +703,34 @@ public static class I18n
 			[LanguageCode.En] = "Assign actions and icons for each sector. Supports hotkeys (e.g. Ctrl+C), app launching, folder opening, and system actions.",
 			[LanguageCode.Ja] = "各方向の動作とアイコンを設定します。ショートカット（Ctrl+C等）、アプリ起動、フォルダー、システム制御に対応。"
 		};
+		dictionary["SectorActionListReorderHint"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "点击右侧功能卡的 ▲ / ▼ 箭头，将功能移动到相邻的轮盘位置槽。",
+			[LanguageCode.ZhTw] = "點擊右側功能卡的 ▲ / ▼ 箭頭，將功能移動到相鄰的輪盤位置槽。",
+			[LanguageCode.En] = "Click the ▲ / ▼ arrows on the right to move an action to an adjacent wheel-position slot.",
+			[LanguageCode.Ja] = "右側の▲ / ▼ボタンをクリックして、アクションを隣のホイール位置へ移動します。"
+		};
+		dictionary["SectorPositionSlot"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "轮盘位置槽",
+			[LanguageCode.ZhTw] = "輪盤位置槽",
+			[LanguageCode.En] = "Wheel position",
+			[LanguageCode.Ja] = "ホイール位置"
+		};
+		dictionary["SectorMoveUp"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "将此功能上移一个轮盘位置",
+			[LanguageCode.ZhTw] = "將此功能上移一個輪盤位置",
+			[LanguageCode.En] = "Move this action up one wheel position",
+			[LanguageCode.Ja] = "このアクションを1つ上のホイール位置へ移動"
+		};
+		dictionary["SectorMoveDown"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "将此功能下移一个轮盘位置",
+			[LanguageCode.ZhTw] = "將此功能下移一個輪盤位置",
+			[LanguageCode.En] = "Move this action down one wheel position",
+			[LanguageCode.Ja] = "このアクションを1つ下のホイール位置へ移動"
+		};
 		dictionary["IconPickerTitle"] = new Dictionary<LanguageCode, string>
 		{
 			[LanguageCode.ZhCn] = "选择动作矢量图标",

--- a/WinPieGestures/KeyboardHook.cs
+++ b/WinPieGestures/KeyboardHook.cs
@@ -74,7 +74,7 @@ public class KeyboardHook : IDisposable
 	private static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, nuint dwExtraInfo);
 
 	[DllImport("user32.dll")]
-	private static extern short GetKeyState(int nVirtKey);
+	private static extern short GetAsyncKeyState(int nVirtKey);
 
 	public KeyboardHook()
 	{
@@ -142,19 +142,19 @@ public class KeyboardHook : IDisposable
 		//IL_005c: Unknown result type (might be due to invalid IL or missing references)
 		//IL_005d: Unknown result type (might be due to invalid IL or missing references)
 		ModifierKeys val = (ModifierKeys)0;
-		if ((GetKeyState(17) & 0x8000) != 0)
+		if ((GetAsyncKeyState(17) & 0x8000) != 0)
 		{
 			val = (ModifierKeys)((int)val | 2);
 		}
-		if ((GetKeyState(16) & 0x8000) != 0)
+		if ((GetAsyncKeyState(16) & 0x8000) != 0)
 		{
 			val = (ModifierKeys)((int)val | 4);
 		}
-		if ((GetKeyState(18) & 0x8000) != 0)
+		if ((GetAsyncKeyState(18) & 0x8000) != 0)
 		{
 			val = (ModifierKeys)((int)val | 1);
 		}
-		if ((GetKeyState(91) & 0x8000) != 0 || (GetKeyState(92) & 0x8000) != 0)
+		if ((GetAsyncKeyState(91) & 0x8000) != 0 || (GetAsyncKeyState(92) & 0x8000) != 0)
 		{
 			val = (ModifierKeys)((int)val | 8);
 		}

--- a/WinPieGestures/MouseHook.cs
+++ b/WinPieGestures/MouseHook.cs
@@ -16,6 +16,18 @@ public class MouseHook
 		public int y;
 	}
 
+	[StructLayout(LayoutKind.Sequential)]
+	private struct MSG
+	{
+		public nint hwnd;
+		public uint message;
+		public nuint wParam;
+		public nint lParam;
+		public uint time;
+		public POINT pt;
+		public uint lPrivate;
+	}
+
 	private struct MSLLHOOKSTRUCT
 	{
 		public POINT pt;
@@ -51,6 +63,10 @@ public class MouseHook
 
 	private const int WM_XBUTTONUP = 524;
 
+	private const uint WM_QUIT = 18u;
+
+	private const uint PM_NOREMOVE = 0u;
+
 	private const uint MOUSEEVENTF_RIGHTDOWN = 8u;
 
 	private const uint MOUSEEVENTF_RIGHTUP = 16u;
@@ -71,9 +87,23 @@ public class MouseHook
 
 	private nint _hookId = IntPtr.Zero;
 
-	private bool _ignoreNextButtonDown;
+	private int _ignoreNextButtonDown;
 
-	private bool _ignoreNextButtonUp;
+	private int _ignoreNextButtonUp;
+
+	private readonly object _lifecycleSync = new object();
+
+	private Thread? _hookThread;
+
+	private uint _hookThreadId;
+
+	private ManualResetEventSlim? _hookReady;
+
+	private Exception? _hookStartException;
+
+	private volatile bool _stopRequested;
+
+	private int _isPaused;
 
 	private System.Threading.Timer? _healthCheckTimer;
 
@@ -81,7 +111,17 @@ public class MouseHook
 
 	private int _hookEventsCountSinceLastCheck;
 
-	public bool IsPaused { get; set; }
+	public bool IsPaused
+	{
+		get
+		{
+			return Volatile.Read(ref _isPaused) != 0;
+		}
+		set
+		{
+			Volatile.Write(ref _isPaused, value ? 1 : 0);
+		}
+	}
 
 	public event EventHandler<MouseEventArgs>? OnTriggerButtonDown;
 
@@ -130,6 +170,27 @@ public class MouseHook
 	[DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
 	private static extern nint GetModuleHandle(string lpModuleName);
 
+	[DllImport("kernel32.dll")]
+	private static extern uint GetCurrentThreadId();
+
+	[DllImport("user32.dll", SetLastError = true)]
+	[return: MarshalAs(UnmanagedType.Bool)]
+	private static extern bool PeekMessage(out MSG lpMsg, nint hWnd, uint wMsgFilterMin, uint wMsgFilterMax, uint wRemoveMsg);
+
+	[DllImport("user32.dll", SetLastError = true)]
+	private static extern int GetMessage(out MSG lpMsg, nint hWnd, uint wMsgFilterMin, uint wMsgFilterMax);
+
+	[DllImport("user32.dll")]
+	[return: MarshalAs(UnmanagedType.Bool)]
+	private static extern bool TranslateMessage(ref MSG lpMsg);
+
+	[DllImport("user32.dll")]
+	private static extern nint DispatchMessage(ref MSG lpMsg);
+
+	[DllImport("user32.dll", SetLastError = true)]
+	[return: MarshalAs(UnmanagedType.Bool)]
+	private static extern bool PostThreadMessage(uint idThread, uint msg, nuint wParam, nint lParam);
+
 	[DllImport("user32.dll")]
 	private static extern void mouse_event(uint dwFlags, uint dx, uint dy, uint dwData, uint dwExtraInfo);
 
@@ -144,30 +205,154 @@ public class MouseHook
 
 	public void Start()
 	{
-		if (_hookId == IntPtr.Zero)
+		ManualResetEventSlim ready;
+		lock (_lifecycleSync)
 		{
-			_hookId = SetHook(_proc);
-			if (_hookId == IntPtr.Zero)
+			if (_hookThread != null && _hookThread.IsAlive)
 			{
-				throw new Exception("Failed to set low-level mouse hook.");
+				return;
 			}
+			_stopRequested = false;
+			_hookStartException = null;
+			ready = new ManualResetEventSlim(initialState: false);
+			_hookReady = ready;
+			_hookThread = new Thread(HookThreadMain)
+			{
+				IsBackground = true,
+				Name = "StarPie.MouseHook",
+				Priority = ThreadPriority.AboveNormal
+			};
+			_hookThread.Start();
+		}
+
+		try
+		{
+			if (!ready.Wait(TimeSpan.FromSeconds(5)))
+			{
+				throw new TimeoutException("Timed out while starting the low-level mouse hook.");
+			}
+			Exception? startException;
+			lock (_lifecycleSync)
+			{
+				startException = _hookStartException;
+			}
+			if (startException != null)
+			{
+				throw new Exception("Failed to set low-level mouse hook.", startException);
+			}
+
 			_hookEventsCountSinceLastCheck = 0;
 			GetCursorPos(out _lastSystemCursorPos);
-			_healthCheckTimer = new System.Threading.Timer(CheckHookHealth, null, 3000, 3000);
+			lock (_lifecycleSync)
+			{
+				_healthCheckTimer ??= new System.Threading.Timer(CheckHookHealth, null, 3000, 3000);
+			}
+		}
+		catch
+		{
+			Stop();
+			throw;
 		}
 	}
 
 	public void Stop()
 	{
-		if (_healthCheckTimer != null)
+		System.Threading.Timer? healthCheckTimer;
+		Thread? hookThread;
+		uint hookThreadId;
+		lock (_lifecycleSync)
 		{
-			_healthCheckTimer.Dispose();
+			_stopRequested = true;
+			healthCheckTimer = _healthCheckTimer;
 			_healthCheckTimer = null;
+			hookThread = _hookThread;
+			hookThreadId = _hookThreadId;
 		}
-		if (_hookId != IntPtr.Zero)
+		healthCheckTimer?.Dispose();
+
+		if (hookThreadId != 0)
 		{
-			UnhookWindowsHookEx(_hookId);
-			_hookId = IntPtr.Zero;
+			PostThreadMessage(hookThreadId, WM_QUIT, 0u, IntPtr.Zero);
+		}
+
+		if (hookThread != null && hookThread.ManagedThreadId != Environment.CurrentManagedThreadId)
+		{
+			hookThread.Join(TimeSpan.FromSeconds(2));
+		}
+
+		lock (_lifecycleSync)
+		{
+			if (_hookThread == hookThread && (hookThread == null || !hookThread.IsAlive))
+			{
+				_hookThread = null;
+				_hookThreadId = 0;
+				_hookReady?.Dispose();
+				_hookReady = null;
+				_hookId = IntPtr.Zero;
+			}
+		}
+	}
+
+	private void HookThreadMain()
+	{
+		nint hookId = IntPtr.Zero;
+		uint threadId = GetCurrentThreadId();
+		lock (_lifecycleSync)
+		{
+			_hookThreadId = threadId;
+		}
+
+		try
+		{
+			// Force creation of this thread's message queue before Start() can
+			// post WM_QUIT during shutdown.
+			PeekMessage(out MSG _, IntPtr.Zero, 0u, 0u, PM_NOREMOVE);
+			hookId = SetHook(_proc);
+			if (hookId == IntPtr.Zero)
+			{
+				throw new InvalidOperationException("SetWindowsHookEx returned a null hook handle.");
+			}
+			lock (_lifecycleSync)
+			{
+				_hookId = hookId;
+			}
+			_hookReady?.Set();
+
+			MSG message;
+			while (!_stopRequested)
+			{
+				int result = GetMessage(out message, IntPtr.Zero, 0u, 0u);
+				if (result <= 0)
+				{
+					break;
+				}
+				TranslateMessage(ref message);
+				DispatchMessage(ref message);
+			}
+		}
+		catch (Exception ex)
+		{
+			lock (_lifecycleSync)
+			{
+				_hookStartException = ex;
+			}
+			_hookReady?.Set();
+		}
+		finally
+		{
+			if (hookId != IntPtr.Zero)
+			{
+				UnhookWindowsHookEx(hookId);
+			}
+			lock (_lifecycleSync)
+			{
+				if (_hookId == hookId)
+				{
+					_hookId = IntPtr.Zero;
+				}
+				_hookThreadId = 0;
+			}
+			_hookReady?.Set();
 		}
 	}
 
@@ -287,9 +472,8 @@ public class MouseHook
 			bool flag3 = flag2 && text == text2;
 			if (num2)
 			{
-				if (_ignoreNextButtonDown)
+				if (Interlocked.Exchange(ref _ignoreNextButtonDown, 0) != 0)
 				{
-					_ignoreNextButtonDown = false;
 					return CallNextHookEx(_hookId, nCode, wParam, lParam);
 				}
 				MouseEventArgs e4 = new MouseEventArgs(mSLLHOOKSTRUCT.pt.x, mSLLHOOKSTRUCT.pt.y);
@@ -301,9 +485,8 @@ public class MouseHook
 			}
 			else if (flag3)
 			{
-				if (_ignoreNextButtonUp)
+				if (Interlocked.Exchange(ref _ignoreNextButtonUp, 0) != 0)
 				{
-					_ignoreNextButtonUp = false;
 					return CallNextHookEx(_hookId, nCode, wParam, lParam);
 				}
 				MouseEventArgs e5 = new MouseEventArgs(mSLLHOOKSTRUCT.pt.x, mSLLHOOKSTRUCT.pt.y);
@@ -320,8 +503,8 @@ public class MouseHook
 	public void ReplayTriggerClick(string? triggerButton = null)
 	{
 		string text = triggerButton ?? ConfigManager.CurrentConfig?.TriggerButton ?? "RightButton";
-		_ignoreNextButtonDown = true;
-		_ignoreNextButtonUp = true;
+		Interlocked.Exchange(ref _ignoreNextButtonDown, 1);
+		Interlocked.Exchange(ref _ignoreNextButtonUp, 1);
 		switch (text)
 		{
 		case "MiddleButton":

--- a/WinPieGestures/RadialWindow.xaml.cs
+++ b/WinPieGestures/RadialWindow.xaml.cs
@@ -18,6 +18,33 @@ namespace WinPieGestures;
 
 public partial class RadialWindow : Window
 {
+	private sealed class SubTierVisuals
+	{
+		public List<System.Windows.Shapes.Path> Paths { get; }
+
+		public List<Grid> Containers { get; }
+
+		public List<TranslateTransform> PathTransforms { get; }
+
+		public List<TranslateTransform> ContainerTransforms { get; }
+
+		public List<double> Angles { get; }
+
+		public SubTierVisuals(
+			List<System.Windows.Shapes.Path> paths,
+			List<Grid> containers,
+			List<TranslateTransform> pathTransforms,
+			List<TranslateTransform> containerTransforms,
+			List<double> angles)
+		{
+			Paths = paths;
+			Containers = containers;
+			PathTransforms = pathTransforms;
+			ContainerTransforms = containerTransforms;
+			Angles = angles;
+		}
+	}
+
 	private int _currentHighlightedSector;
 
 	private int _currentHighlightedSubSector;
@@ -47,6 +74,8 @@ public partial class RadialWindow : Window
 	private readonly List<TranslateTransform> _subContainerTransforms;
 
 	private readonly List<double> _subSectorAngles;
+
+	private readonly Dictionary<int, SubTierVisuals> _subTierCache = new Dictionary<int, SubTierVisuals>();
 
 	private IRadialStyleRenderer _styleRenderer;
 
@@ -759,6 +788,7 @@ public partial class RadialWindow : Window
 			_isOuterEscaped = isEscaped;
 			DoubleAnimation animation = new DoubleAnimation
 			{
+				From = Opacity,
 				To = (isEscaped ? 0.38 : 1.0),
 				Duration = TimeSpan.FromMilliseconds(120.0),
 				EasingFunction = new QuadraticEase
@@ -772,13 +802,35 @@ public partial class RadialWindow : Window
 
 	private void ClearSubTier()
 	{
-		foreach (System.Windows.Shapes.Path subSectorPath in _subSectorPaths)
+		for (int i = 0; i < _subSectorPaths.Count; i++)
 		{
-			WheelCanvas.Children.Remove(subSectorPath);
+			System.Windows.Shapes.Path subSectorPath = _subSectorPaths[i];
+			subSectorPath.BeginAnimation(UIElement.OpacityProperty, null);
+			subSectorPath.Opacity = 0.0;
+			subSectorPath.Visibility = Visibility.Collapsed;
+			if (i < _subSectorTransforms.Count)
+			{
+				TranslateTransform transform = _subSectorTransforms[i];
+				transform.BeginAnimation(TranslateTransform.XProperty, null);
+				transform.BeginAnimation(TranslateTransform.YProperty, null);
+				transform.X = 0.0;
+				transform.Y = 0.0;
+			}
 		}
-		foreach (Grid subContentContainer in _subContentContainers)
+		for (int i = 0; i < _subContentContainers.Count; i++)
 		{
-			WheelCanvas.Children.Remove(subContentContainer);
+			Grid subContentContainer = _subContentContainers[i];
+			subContentContainer.BeginAnimation(UIElement.OpacityProperty, null);
+			subContentContainer.Opacity = 0.0;
+			subContentContainer.Visibility = Visibility.Collapsed;
+			if (i < _subContainerTransforms.Count)
+			{
+				TranslateTransform transform = _subContainerTransforms[i];
+				transform.BeginAnimation(TranslateTransform.XProperty, null);
+				transform.BeginAnimation(TranslateTransform.YProperty, null);
+				transform.X = 0.0;
+				transform.Y = 0.0;
+			}
 		}
 		_subSectorPaths.Clear();
 		_subContentContainers.Clear();
@@ -787,6 +839,50 @@ public partial class RadialWindow : Window
 		_subSectorAngles.Clear();
 		_activeSubTierParentSector = -1;
 		_currentHighlightedSubSector = -1;
+	}
+
+	private void ActivateCachedSubTier(int parentIndex, SubTierVisuals visuals)
+	{
+		_activeSubTierParentSector = parentIndex;
+		_subSectorPaths.AddRange(visuals.Paths);
+		_subContentContainers.AddRange(visuals.Containers);
+		_subSectorTransforms.AddRange(visuals.PathTransforms);
+		_subContainerTransforms.AddRange(visuals.ContainerTransforms);
+		_subSectorAngles.AddRange(visuals.Angles);
+
+		Duration duration = new Duration(TimeSpan.FromMilliseconds(110.0));
+		DoubleAnimation fadeIn = new DoubleAnimation(0.0, 1.0, duration)
+		{
+			EasingFunction = new QuadraticEase { EasingMode = EasingMode.EaseOut }
+		};
+		for (int i = 0; i < _subSectorPaths.Count; i++)
+		{
+			System.Windows.Shapes.Path path = _subSectorPaths[i];
+			path.Visibility = Visibility.Visible;
+			path.Opacity = 0.0;
+			path.BeginAnimation(UIElement.OpacityProperty, fadeIn.Clone());
+			if (i < _subSectorTransforms.Count)
+			{
+				_subSectorTransforms[i].BeginAnimation(TranslateTransform.XProperty, null);
+				_subSectorTransforms[i].BeginAnimation(TranslateTransform.YProperty, null);
+				_subSectorTransforms[i].X = 0.0;
+				_subSectorTransforms[i].Y = 0.0;
+			}
+		}
+		for (int i = 0; i < _subContentContainers.Count; i++)
+		{
+			Grid container = _subContentContainers[i];
+			container.Visibility = Visibility.Visible;
+			container.Opacity = 0.0;
+			container.BeginAnimation(UIElement.OpacityProperty, fadeIn.Clone());
+			if (i < _subContainerTransforms.Count)
+			{
+				_subContainerTransforms[i].BeginAnimation(TranslateTransform.XProperty, null);
+				_subContainerTransforms[i].BeginAnimation(TranslateTransform.YProperty, null);
+				_subContainerTransforms[i].X = 0.0;
+				_subContainerTransforms[i].Y = 0.0;
+			}
+		}
 	}
 
 	private void ShowSubTier(int parentIndex)
@@ -800,6 +896,11 @@ public partial class RadialWindow : Window
 		ActionItem actionItem = _profile.Actions[parentIndex];
 		if (actionItem == null || actionItem.SubActions == null || actionItem.SubActions.Count == 0)
 		{
+			return;
+		}
+		if (_subTierCache.TryGetValue(parentIndex, out SubTierVisuals? cachedVisuals))
+		{
+			ActivateCachedSubTier(parentIndex, cachedVisuals);
 			return;
 		}
 		int sectorCount = _profile.SectorCount;
@@ -1033,6 +1134,12 @@ public partial class RadialWindow : Window
 			scaleTransform2.BeginAnimation(ScaleTransform.ScaleYProperty, animation);
 			grid.BeginAnimation(UIElement.OpacityProperty, animation2);
 		}
+		_subTierCache[parentIndex] = new SubTierVisuals(
+			new List<System.Windows.Shapes.Path>(_subSectorPaths),
+			new List<Grid>(_subContentContainers),
+			new List<TranslateTransform>(_subSectorTransforms),
+			new List<TranslateTransform>(_subContainerTransforms),
+			new List<double>(_subSectorAngles));
 	}
 
 	public void HighlightSector(int index)
@@ -1072,11 +1179,11 @@ public partial class RadialWindow : Window
 		if (CoreScale != null)
 		{
 			double toValue = ((mainIndex == -1) ? 1.1 : 1.0);
-			CoreScale.BeginAnimation(ScaleTransform.ScaleXProperty, new DoubleAnimation(toValue, duration2)
+			CoreScale.BeginAnimation(ScaleTransform.ScaleXProperty, new DoubleAnimation(CoreScale.ScaleX, toValue, duration2)
 			{
 				EasingFunction = easingFunction
 			});
-			CoreScale.BeginAnimation(ScaleTransform.ScaleYProperty, new DoubleAnimation(toValue, duration2)
+			CoreScale.BeginAnimation(ScaleTransform.ScaleYProperty, new DoubleAnimation(CoreScale.ScaleY, toValue, duration2)
 			{
 				EasingFunction = easingFunction
 			});
@@ -1109,22 +1216,22 @@ public partial class RadialWindow : Window
 			Panel.SetZIndex(path, 0);
 			if (translateTransform != null)
 			{
-				translateTransform.BeginAnimation(TranslateTransform.XProperty, new DoubleAnimation(0.0, duration)
+				translateTransform.BeginAnimation(TranslateTransform.XProperty, new DoubleAnimation(translateTransform.X, 0.0, duration)
 				{
 					EasingFunction = easingFunction
 				});
-				translateTransform.BeginAnimation(TranslateTransform.YProperty, new DoubleAnimation(0.0, duration)
+				translateTransform.BeginAnimation(TranslateTransform.YProperty, new DoubleAnimation(translateTransform.Y, 0.0, duration)
 				{
 					EasingFunction = easingFunction
 				});
 			}
 			if (translateTransform2 != null)
 			{
-				translateTransform2.BeginAnimation(TranslateTransform.XProperty, new DoubleAnimation(0.0, duration)
+				translateTransform2.BeginAnimation(TranslateTransform.XProperty, new DoubleAnimation(translateTransform2.X, 0.0, duration)
 				{
 					EasingFunction = easingFunction
 				});
-				translateTransform2.BeginAnimation(TranslateTransform.YProperty, new DoubleAnimation(0.0, duration)
+				translateTransform2.BeginAnimation(TranslateTransform.YProperty, new DoubleAnimation(translateTransform2.Y, 0.0, duration)
 				{
 					EasingFunction = easingFunction
 				});
@@ -1160,22 +1267,22 @@ public partial class RadialWindow : Window
 			double toValue3 = Math.Sin(num4) * 5.5;
 			if (translateTransform3 != null)
 			{
-				translateTransform3.BeginAnimation(TranslateTransform.XProperty, new DoubleAnimation(toValue2, duration)
+				translateTransform3.BeginAnimation(TranslateTransform.XProperty, new DoubleAnimation(translateTransform3.X, toValue2, duration)
 				{
 					EasingFunction = easingFunction
 				});
-				translateTransform3.BeginAnimation(TranslateTransform.YProperty, new DoubleAnimation(toValue3, duration)
+				translateTransform3.BeginAnimation(TranslateTransform.YProperty, new DoubleAnimation(translateTransform3.Y, toValue3, duration)
 				{
 					EasingFunction = easingFunction
 				});
 			}
 			if (translateTransform4 != null)
 			{
-				translateTransform4.BeginAnimation(TranslateTransform.XProperty, new DoubleAnimation(toValue2, duration)
+				translateTransform4.BeginAnimation(TranslateTransform.XProperty, new DoubleAnimation(translateTransform4.X, toValue2, duration)
 				{
 					EasingFunction = easingFunction
 				});
-				translateTransform4.BeginAnimation(TranslateTransform.YProperty, new DoubleAnimation(toValue3, duration)
+				translateTransform4.BeginAnimation(TranslateTransform.YProperty, new DoubleAnimation(translateTransform4.Y, toValue3, duration)
 				{
 					EasingFunction = easingFunction
 				});
@@ -1240,22 +1347,22 @@ public partial class RadialWindow : Window
 				double toValue5 = Math.Sin(num5) * 4.0;
 				if (translateTransform5 != null)
 				{
-					translateTransform5.BeginAnimation(TranslateTransform.XProperty, new DoubleAnimation(toValue4, duration)
+					translateTransform5.BeginAnimation(TranslateTransform.XProperty, new DoubleAnimation(translateTransform5.X, toValue4, duration)
 					{
 						EasingFunction = easingFunction
 					});
-					translateTransform5.BeginAnimation(TranslateTransform.YProperty, new DoubleAnimation(toValue5, duration)
+					translateTransform5.BeginAnimation(TranslateTransform.YProperty, new DoubleAnimation(translateTransform5.Y, toValue5, duration)
 					{
 						EasingFunction = easingFunction
 					});
 				}
 				if (translateTransform6 != null)
 				{
-					translateTransform6.BeginAnimation(TranslateTransform.XProperty, new DoubleAnimation(toValue4, duration)
+					translateTransform6.BeginAnimation(TranslateTransform.XProperty, new DoubleAnimation(translateTransform6.X, toValue4, duration)
 					{
 						EasingFunction = easingFunction
 					});
-					translateTransform6.BeginAnimation(TranslateTransform.YProperty, new DoubleAnimation(toValue5, duration)
+					translateTransform6.BeginAnimation(TranslateTransform.YProperty, new DoubleAnimation(translateTransform6.Y, toValue5, duration)
 					{
 						EasingFunction = easingFunction
 					});
@@ -1279,22 +1386,22 @@ public partial class RadialWindow : Window
 				}
 				if (translateTransform5 != null && (translateTransform5.X != 0.0 || translateTransform5.Y != 0.0))
 				{
-					translateTransform5.BeginAnimation(TranslateTransform.XProperty, new DoubleAnimation(0.0, duration)
+					translateTransform5.BeginAnimation(TranslateTransform.XProperty, new DoubleAnimation(translateTransform5.X, 0.0, duration)
 					{
 						EasingFunction = easingFunction
 					});
-					translateTransform5.BeginAnimation(TranslateTransform.YProperty, new DoubleAnimation(0.0, duration)
+					translateTransform5.BeginAnimation(TranslateTransform.YProperty, new DoubleAnimation(translateTransform5.Y, 0.0, duration)
 					{
 						EasingFunction = easingFunction
 					});
 				}
 				if (translateTransform6 != null && (translateTransform6.X != 0.0 || translateTransform6.Y != 0.0))
 				{
-					translateTransform6.BeginAnimation(TranslateTransform.XProperty, new DoubleAnimation(0.0, duration)
+					translateTransform6.BeginAnimation(TranslateTransform.XProperty, new DoubleAnimation(translateTransform6.X, 0.0, duration)
 					{
 						EasingFunction = easingFunction
 					});
-					translateTransform6.BeginAnimation(TranslateTransform.YProperty, new DoubleAnimation(0.0, duration)
+					translateTransform6.BeginAnimation(TranslateTransform.YProperty, new DoubleAnimation(translateTransform6.Y, 0.0, duration)
 					{
 						EasingFunction = easingFunction
 					});
@@ -1556,6 +1663,11 @@ public partial class RadialWindow : Window
 		{
 			return;
 		}
+		if (_subTierCache.TryGetValue(parentIndex, out SubTierVisuals? cachedVisuals))
+		{
+			ActivateCachedSubTier(parentIndex, cachedVisuals);
+			return;
+		}
 		int sectorCount = _profile.SectorCount;
 		double sectorSize = 360.0 / (double)sectorCount;
 		double width = base.Width;
@@ -1811,6 +1923,12 @@ public partial class RadialWindow : Window
 			scaleTransform2.BeginAnimation(ScaleTransform.ScaleXProperty, doubleAnimation2);
 			scaleTransform2.BeginAnimation(ScaleTransform.ScaleYProperty, doubleAnimation2);
 		}
+		_subTierCache[parentIndex] = new SubTierVisuals(
+			new List<System.Windows.Shapes.Path>(_subSectorPaths),
+			new List<Grid>(_subContentContainers),
+			new List<TranslateTransform>(_subSectorTransforms),
+			new List<TranslateTransform>(_subContainerTransforms),
+			new List<double>(_subSectorAngles));
 	}
 
 }

--- a/WinPieGestures/SettingsWindow.xaml
+++ b/WinPieGestures/SettingsWindow.xaml
@@ -1443,75 +1443,110 @@
                 </UIElement.Effect>
                 <StackPanel>
                   <TextBlock Name="SectorActionListTitleText" Text="扇区动作映射列表" FontSize="14" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
-                  <TextBlock Name="SectorActionListDescText" Text="为每个方位指定触发动作与图标。支持热键组合（如 Ctrl+C）、启动本地程序与系统级操作。" FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,2,0,14" />
+                  <TextBlock Name="SectorActionListDescText" Text="为每个方位指定触发动作与图标。支持热键组合（如 Ctrl+C）、启动本地程序与系统级操作。" FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,2,0,2" />
+                  <TextBlock Name="SectorActionListReorderHintText" Text="点击右侧功能卡的 ▲ / ▼ 箭头，将功能移动到相邻的轮盘位置槽。" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,0,0,14" />
                   <ItemsControl Name="SlotsItemsControl">
                     <ItemsControl.ItemTemplate>
                       <DataTemplate>
-                        <Border Background="{DynamicResource SubtleCardBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="8" Padding="10,8" Margin="0,0,0,8">
-                          <Grid>
-                            <Grid.ColumnDefinitions>
-                              <ColumnDefinition Width="84" />
-                              <ColumnDefinition Width="74" />
-                              <ColumnDefinition Width="120" />
-                              <ColumnDefinition Width="102" />
-                              <ColumnDefinition Width="*" />
-                              <ColumnDefinition Width="68" />
-                              <ColumnDefinition Width="Auto" />
-                              <ColumnDefinition Width="Auto" />
-                            </Grid.ColumnDefinitions>
-                            <TextBlock FontWeight="SemiBold" Foreground="{DynamicResource AccentPrimaryBrush}" VerticalAlignment="Center" FontSize="11.5" Text="{Binding DirectionLabel}" />
-                            <Button Grid.Column="1" Style="{StaticResource ModernButtonStyle}" Height="30" Padding="4,0" Margin="0,0,6,0" ToolTip="点击选取矢量图标" Click="PickIcon_Click">
-                              <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center">
-                                <Path Width="14" Height="14" Stretch="Uniform" Fill="{DynamicResource AccentPrimaryBrush}" Margin="0,0,4,0" Data="{Binding VectorIconData}" Visibility="{Binding HasVectorIcon, Converter={StaticResource BoolToVis}}" />
-                                <TextBlock FontSize="11" Foreground="{DynamicResource TextPrimaryBrush}" TextTrimming="CharacterEllipsis" MaxWidth="46" Text="{Binding IconDisplayText}" />
-                              </StackPanel>
-                            </Button>
-                            <TextBox Grid.Column="2" Margin="0,0,6,0" Height="30" FontSize="12" VerticalContentAlignment="Center" Text="{Binding Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                            <ComboBox Grid.Column="3" SelectedValuePath="Tag" DisplayMemberPath="DisplayText" Style="{StaticResource FlatComboBoxStyle}" Height="30" Margin="0,0,6,0" FontSize="11.5" ItemsSource="{Binding ActionTypes}" SelectedValue="{Binding Type, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                            <Grid Column="4" Margin="0,0,6,0">
-                              <Grid Visibility="{Binding IsHotkeyType, Converter={StaticResource BoolToVis}}">
+                        <Grid Tag="SlotActionRow" Margin="0,0,0,8" Visibility="{Binding IsVisible, Converter={StaticResource BoolToVis}}">
+                          <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="92" />
+                            <ColumnDefinition Width="*" />
+                          </Grid.ColumnDefinitions>
+
+                          <Border Grid.Column="0" Margin="0,0,10,0" Padding="5" VerticalAlignment="Stretch" CornerRadius="8" Background="{DynamicResource SubtleCardBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" ToolTip="{Binding DirectionLabel}" AutomationProperties.Name="{Binding DirectionLabel}">
+                            <local:WheelPositionIndicator
+                              PositionIndex="{Binding PositionIndex}"
+                              SectorCount="{Binding SectorCount}"
+                              Width="64"
+                              Height="64"
+                              HorizontalAlignment="Center"
+                              VerticalAlignment="Center"
+                              IsHitTestVisible="False"
+                              AccentBrush="{DynamicResource AccentPrimaryBrush}"
+                              AccentTextBrush="{DynamicResource AccentTextBrush}"
+                              SectorBrush="{DynamicResource InputBackgroundBrush}"
+                              BorderBrush="{DynamicResource CardBorderBrush}"
+                              MutedBrush="{DynamicResource TextMutedBrush}"
+                              CenterBrush="{DynamicResource CardBackgroundBrush}" />
+                          </Border>
+
+                          <Border Grid.Column="1" Background="{DynamicResource SubtleCardBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="8" Padding="10,8">
+                            <Grid>
                               <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="86" />
+                                <ColumnDefinition Width="132" MinWidth="132" />
+                                <ColumnDefinition Width="136" MinWidth="136" />
                                 <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="68" />
                                 <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="58" />
                               </Grid.ColumnDefinitions>
-                              <local:HotkeyRecorderBox Height="30" FontSize="12" HotkeyText="{Binding Parameter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                              <Button Grid.Column="1" Content="⚙️ 拼装" Margin="4,0,0,0" Height="30" Padding="6,0" Cursor="Hand" ToolTip="打开快捷热键拼装组合器（支持 Alt+Tab、Win+Tab、Shift+Alt、多位连续数值等）" Click="HotkeyBuilderButton_Click" Style="{StaticResource ModernButtonStyle}" />
+
+                              <Button Grid.Column="0" Style="{StaticResource ModernButtonStyle}" Height="30" Padding="6,0" Margin="0,0,8,0" Click="PickIcon_Click" ToolTip="点击选取矢量图标">
+                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center">
+                                  <Path Width="14" Height="14" Stretch="Uniform" Fill="{DynamicResource AccentPrimaryBrush}" Margin="0,0,4,0" Data="{Binding VectorIconData}" Visibility="{Binding HasVectorIcon, Converter={StaticResource BoolToVis}}" />
+                                  <TextBlock Text="{Binding IconDisplayText}" FontSize="11" Foreground="{DynamicResource TextPrimaryBrush}" TextTrimming="CharacterEllipsis" MaxWidth="52" />
+                                </StackPanel>
+                              </Button>
+
+                              <TextBox Grid.Column="1" Text="{Binding Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,0" Height="30" FontSize="12" VerticalContentAlignment="Center" />
+
+                              <ComboBox Grid.Column="2" ItemsSource="{Binding ActionTypes}" SelectedValue="{Binding Type, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" SelectedValuePath="Tag" DisplayMemberPath="DisplayText" Style="{StaticResource FlatComboBoxStyle}" Height="30" Margin="0,0,8,0" FontSize="11.5" Padding="8,0" HorizontalContentAlignment="Left" ToolTip="{Binding Type}" />
+
+                              <Grid Grid.Column="3" Margin="0,0,8,0">
+                                <Grid Visibility="{Binding IsHotkeyType, Converter={StaticResource BoolToVis}}">
+                                  <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                  </Grid.ColumnDefinitions>
+                                  <local:HotkeyRecorderBox Height="30" FontSize="12" HotkeyText="{Binding Parameter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                  <Button Grid.Column="1" Content="⚙️ 拼装" Margin="4,0,0,0" Height="30" Padding="6,0" Cursor="Hand" ToolTip="打开快捷热键拼装组合器（支持 Alt+Tab、Win+Tab、Shift+Alt、多位连续数值等）" Click="HotkeyBuilderButton_Click" Style="{StaticResource ModernButtonStyle}" />
+                                </Grid>
+                                <Grid Visibility="{Binding IsLaunchType, Converter={StaticResource BoolToVis}}">
+                                  <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                  </Grid.ColumnDefinitions>
+                                  <TextBox IsReadOnly="True" Background="{DynamicResource InputBackgroundBrush}" Foreground="{DynamicResource TextSecondaryBrush}" Height="30" Margin="0,0,4,0" FontSize="11" VerticalContentAlignment="Center" ToolTip="选择的应用程序路径" Text="{Binding Parameter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                  <Button Grid.Column="1" Width="34" Style="{StaticResource ModernButtonStyle}" Height="30" ToolTip="选择应用程序或快捷方式..." Click="Browse_Click">
+                                    <TextBlock Text="📁" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                  </Button>
+                                </Grid>
+                                <Grid Visibility="{Binding IsFolderType, Converter={StaticResource BoolToVis}}">
+                                  <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                  </Grid.ColumnDefinitions>
+                                  <TextBox Background="{DynamicResource InputBackgroundBrush}" Foreground="{DynamicResource TextPrimaryBrush}" Height="30" Margin="0,0,4,0" FontSize="11" VerticalContentAlignment="Center" ToolTip="选择的本地文件夹路径" Text="{Binding Parameter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                  <Button Grid.Column="1" Width="34" Style="{StaticResource ModernButtonStyle}" Height="30" ToolTip="选择本地文件夹..." Click="BrowseFolder_Click">
+                                    <TextBlock Text="📂" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                  </Button>
+                                </Grid>
+                                <ComboBox SelectedValuePath="Key" DisplayMemberPath="Value" Style="{StaticResource FlatComboBoxStyle}" Height="30" FontSize="11.5" SelectedValue="{Binding SelectedSystemPreset, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ItemsSource="{Binding Source={x:Static local:SlotViewModel.SystemPresets}}" Visibility="{Binding IsSystemType, Converter={StaticResource BoolToVis}}" />
+                                <Grid Visibility="{Binding IsCommandType, Converter={StaticResource BoolToVis}}">
+                                  <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                  </Grid.ColumnDefinitions>
+                                  <TextBox Grid.Column="0" Text="{Binding Parameter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="30" Margin="0,0,4,0" FontSize="11" VerticalContentAlignment="Center" ToolTip="要运行的命令，如 ping -n 3 127.0.0.1" />
+                                  <ComboBox Grid.Column="1" Width="118" ItemsSource="{Binding Terminals}" SelectedValuePath="Tag" DisplayMemberPath="DisplayText" SelectedValue="{Binding CommandTerminal, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FlatComboBoxStyle}" Height="30" FontSize="11" />
+                                </Grid>
+                              </Grid>
+
+                              <TextBox Grid.Column="4" Margin="0,0,8,0" Height="30" FontSize="11" ToolTip="启动参数 (如命令行参数或URL)" VerticalContentAlignment="Center" Text="{Binding Arguments, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding IsLaunchType}" />
+                              <Button Grid.Column="5" Style="{StaticResource ModernButtonStyle}" Height="30" Padding="8,0" Margin="0,0,6,0" ToolTip="配置该扇区的二级级联子动作菜单" Content="{Binding SubActionButtonText}" Click="ManageSubActions_Click" />
+
+                              <StackPanel Grid.Column="6" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,6,0">
+                                <Button Width="28" Height="30" Padding="0" Margin="0,0,4,0" Style="{StaticResource ModernButtonStyle}" Content="▲" IsEnabled="{Binding CanMoveUp}" ToolTip="{Binding MoveUpToolTip}" Click="MoveSlotUp_Click" AutomationProperties.Name="{Binding MoveUpToolTip}" />
+                                <Button Width="28" Height="30" Padding="0" Style="{StaticResource ModernButtonStyle}" Content="▼" IsEnabled="{Binding CanMoveDown}" ToolTip="{Binding MoveDownToolTip}" Click="MoveSlotDown_Click" AutomationProperties.Name="{Binding MoveDownToolTip}" />
+                              </StackPanel>
+
+                              <Button Grid.Column="7" Style="{StaticResource ModernButtonStyle}" Height="30" Padding="10,0" Content="{Binding TestButtonText}" Click="Test_Click" />
                             </Grid>
-                              <Grid Visibility="{Binding IsLaunchType, Converter={StaticResource BoolToVis}}">
-                                <Grid.ColumnDefinitions>
-                                  <ColumnDefinition Width="*" />
-                                  <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <TextBox IsReadOnly="True" Background="{DynamicResource InputBackgroundBrush}" Foreground="{DynamicResource TextSecondaryBrush}" Height="30" Margin="0,0,4,0" FontSize="11" VerticalContentAlignment="Center" ToolTip="选择的应用程序路径" Text="{Binding Parameter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                                <Button Grid.Column="1" Width="34" Style="{StaticResource ModernButtonStyle}" Height="30" ToolTip="选择应用程序或快捷方式..." Click="Browse_Click">
-                                  <TextBlock Text="📁" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" />
-                                </Button>
-                              </Grid>
-                              <Grid Visibility="{Binding IsFolderType, Converter={StaticResource BoolToVis}}">
-                                <Grid.ColumnDefinitions>
-                                  <ColumnDefinition Width="*" />
-                                  <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <TextBox Background="{DynamicResource InputBackgroundBrush}" Foreground="{DynamicResource TextPrimaryBrush}" Height="30" Margin="0,0,4,0" FontSize="11" VerticalContentAlignment="Center" ToolTip="选择的本地文件夹路径" Text="{Binding Parameter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                                <Button Grid.Column="1" Width="34" Style="{StaticResource ModernButtonStyle}" Height="30" ToolTip="选择本地文件夹..." Click="BrowseFolder_Click">
-                                  <TextBlock Text="📂" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" />
-                                </Button>
-                              </Grid>
-                              <ComboBox SelectedValuePath="Key" DisplayMemberPath="Value" Style="{StaticResource FlatComboBoxStyle}" Height="30" FontSize="11.5" SelectedValue="{Binding SelectedSystemPreset, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ItemsSource="{Binding Source={x:Static local:SlotViewModel.SystemPresets}}" Visibility="{Binding IsSystemType, Converter={StaticResource BoolToVis}}" />
-                              <Grid Visibility="{Binding IsCommandType, Converter={StaticResource BoolToVis}}">
-                                <Grid.ColumnDefinitions>
-                                  <ColumnDefinition Width="*"/>
-                                  <ColumnDefinition Width="Auto"/>
-                                </Grid.ColumnDefinitions>
-                                <TextBox Grid.Column="0" Text="{Binding Parameter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="30" Margin="0,0,4,0" FontSize="11" VerticalContentAlignment="Center" ToolTip="要运行的命令，如 ping -n 3 127.0.0.1"/>
-                                <ComboBox Grid.Column="1" Width="118" ItemsSource="{Binding Terminals}" SelectedValuePath="Tag" DisplayMemberPath="DisplayText" SelectedValue="{Binding CommandTerminal, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FlatComboBoxStyle}" Height="30" FontSize="11"/>
-                              </Grid>
-                            </Grid>
-                            <TextBox Grid.Column="5" Margin="0,0,6,0" Height="30" FontSize="11" ToolTip="启动参数 (如命令行参数或URL)" VerticalContentAlignment="Center" Text="{Binding Arguments, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding IsLaunchType}" />
-                            <Button Grid.Column="6" Style="{StaticResource ModernButtonStyle}" Height="30" Padding="8,0" Margin="0,0,6,0" ToolTip="配置该扇区的二级级联子动作菜单" Content="{Binding SubActionButtonText}" Click="ManageSubActions_Click" />
-                            <Button Grid.Column="7" Style="{StaticResource ModernButtonStyle}" Height="30" Padding="10,0" Content="{Binding TestButtonText}" Click="Test_Click" />
-                          </Grid>
-                        </Border>
+                          </Border>
+                        </Grid>
                       </DataTemplate>
                     </ItemsControl.ItemTemplate>
                   </ItemsControl>

--- a/WinPieGestures/SettingsWindow.xaml.cs
+++ b/WinPieGestures/SettingsWindow.xaml.cs
@@ -237,6 +237,10 @@ public partial class SettingsWindow : Window
 
 	private DispatcherTimer? _autoSaveDebounceTimer;
 
+	private bool _isChangingSectorCount;
+
+	private bool _previewRenderPending;
+
 	public SettingsWindow()
 	{
 		_isUpdatingUi = true;
@@ -1019,6 +1023,10 @@ public partial class SettingsWindow : Window
 		{
 			SectorActionListDescText.Text = I18n.T("SectorActionListDesc");
 		}
+		if (SectorActionListReorderHintText != null)
+		{
+			SectorActionListReorderHintText.Text = I18n.T("SectorActionListReorderHint");
+		}
 		if (AdvancedPageHeader != null)
 		{
 			AdvancedPageHeader.Text = I18n.T("AdvancedHeader");
@@ -1447,6 +1455,10 @@ public partial class SettingsWindow : Window
 	{
 		SyncUiToConfigAndSave();
 		MemoryOptimizer.TrimMemory();
+		if (_isClosingFromTray)
+		{
+			DisposeSlotViewModels();
+		}
 		if (!_isClosingFromTray)
 		{
 			e.Cancel = true;
@@ -1505,80 +1517,165 @@ public partial class SettingsWindow : Window
 	{
 		try
 		{
-			_slotViewModels.Clear();
-			if (_selectedProfile == null)
+			WheelProfile? profile = _selectedProfile;
+			if (profile == null)
 			{
-				_selectedProfile = (ProfilesListBox?.SelectedItem as WheelProfile) ?? ConfigManager.CurrentConfig.Profiles.FirstOrDefault();
+				profile = ProfilesListBox?.SelectedItem as WheelProfile ?? ConfigManager.CurrentConfig.Profiles.FirstOrDefault();
+				_selectedProfile = profile;
 			}
-			if (_selectedProfile == null)
+
+			const int maxSectorCount = 12;
+			EnsureSlotViewModels(maxSectorCount);
+
+			if (profile == null)
 			{
+				for (int i = 0; i < _slotViewModels.Count; i++)
+				{
+					_slotViewModels[i].Update(i, 8, string.Empty, null, false);
+				}
 				return;
 			}
-			int num = _selectedProfile.SectorCount;
-			if (num != 4 && num != 8 && num != 12)
+
+			int count = NormalizeSectorCount(profile.SectorCount);
+			if (profile.SectorCount != count)
 			{
-				num = 8;
+				profile.SectorCount = count;
 			}
-			string[] array = num switch
+
+			string[] directions = count switch
 			{
-				4 => Directions4, 
-				12 => Directions12, 
-				_ => Directions8, 
+				4 => Directions4,
+				12 => Directions12,
+				_ => Directions8
 			};
-			if (_selectedProfile.Actions == null)
+
+			profile.Actions ??= new List<ActionItem>();
+			while (profile.Actions.Count < count)
 			{
-				_selectedProfile.Actions = new List<ActionItem>();
-			}
-			while (_selectedProfile.Actions.Count < num)
-			{
-				int count = _selectedProfile.Actions.Count;
-				if (num == 12 && count < DefaultPresets12.Length)
+				int index = profile.Actions.Count;
+				if (count == 12 && index < DefaultPresets12.Length)
 				{
-					ActionItem actionItem = DefaultPresets12[count];
-					_selectedProfile.Actions.Add(new ActionItem
+					ActionItem preset = DefaultPresets12[index];
+					profile.Actions.Add(new ActionItem
 					{
-						Type = actionItem.Type,
-						Name = actionItem.Name,
-						Parameter = actionItem.Parameter,
-						IconKey = actionItem.IconKey
+						Type = preset.Type,
+						Name = preset.Name,
+						Parameter = preset.Parameter,
+						IconKey = preset.IconKey
 					});
 				}
-				else if (num == 4 && count < DefaultPresets4.Length)
+				else if (count == 4 && index < DefaultPresets4.Length)
 				{
-					ActionItem actionItem2 = DefaultPresets4[count];
-					_selectedProfile.Actions.Add(new ActionItem
+					ActionItem preset = DefaultPresets4[index];
+					profile.Actions.Add(new ActionItem
 					{
-						Type = actionItem2.Type,
-						Name = actionItem2.Name,
-						Parameter = actionItem2.Parameter,
-						IconKey = actionItem2.IconKey
+						Type = preset.Type,
+						Name = preset.Name,
+						Parameter = preset.Parameter,
+						IconKey = preset.IconKey
 					});
 				}
 				else
 				{
-					_selectedProfile.Actions.Add(new ActionItem
+					profile.Actions.Add(new ActionItem
 					{
 						Type = "Hotkey",
-						Name = $"快捷动作 {count + 1}",
+						Name = $"快捷动作 {index + 1}",
 						Parameter = ""
 					});
 				}
 			}
-			for (int i = 0; i < num; i++)
+
+			for (int i = 0; i < _slotViewModels.Count; i++)
 			{
-				ActionItem action = _selectedProfile.Actions[i];
-				SlotViewModel item = new SlotViewModel(array[i], action);
-				_slotViewModels.Add(item);
+				ActionItem? action = i < profile.Actions.Count ? profile.Actions[i] : null;
+				bool isVisible = i < count;
+				string direction = isVisible ? directions[i] : string.Empty;
+				_slotViewModels[i].Update(i, count, direction, action, isVisible);
 			}
 		}
-		catch (Exception)
+		catch (Exception ex)
 		{
+			Debug.WriteLine($"[RefreshSlots Error]: {ex}");
+		}
+	}
+
+	private void DisposeSlotViewModels()
+	{
+		foreach (SlotViewModel slot in _slotViewModels)
+		{
+			slot.Dispose();
+		}
+	}
+
+	private static int NormalizeSectorCount(int sectorCount)
+	{
+		return sectorCount is 4 or 8 or 12 ? sectorCount : 8;
+	}
+
+	private void EnsureSlotViewModels(int count)
+	{
+		while (_slotViewModels.Count < count)
+		{
+			int positionIndex = _slotViewModels.Count;
+			_slotViewModels.Add(new SlotViewModel(
+				positionIndex,
+				8,
+				string.Empty,
+				new ActionItem
+				{
+					Type = "Hotkey",
+					Name = $"快捷动作 {positionIndex + 1}",
+					Parameter = ""
+				}));
+		}
+	}
+
+	private void MoveSlotUp_Click(object sender, RoutedEventArgs e)
+	{
+		MoveSlot(sender, -1);
+		e.Handled = true;
+	}
+
+	private void MoveSlotDown_Click(object sender, RoutedEventArgs e)
+	{
+		MoveSlot(sender, 1);
+		e.Handled = true;
+	}
+
+	private void MoveSlot(object sender, int offset)
+	{
+		if (sender is not FrameworkElement element ||
+			element.DataContext is not SlotViewModel slot ||
+			_selectedProfile?.Actions == null)
+		{
+			return;
+		}
+
+		int sourceIndex = _slotViewModels.IndexOf(slot);
+		int activeCount = NormalizeSectorCount(_selectedProfile.SectorCount);
+		int targetIndex = sourceIndex + offset;
+		if (sourceIndex < 0 || sourceIndex >= activeCount ||
+			targetIndex < 0 || targetIndex >= activeCount ||
+			targetIndex >= _selectedProfile.Actions.Count)
+		{
+			return;
+		}
+
+		(_selectedProfile.Actions[sourceIndex], _selectedProfile.Actions[targetIndex]) =
+			(_selectedProfile.Actions[targetIndex], _selectedProfile.Actions[sourceIndex]);
+
+		RefreshSlots();
+		SyncUiToConfigAndSave(true);
+		if (AppearanceSettingsGrid?.Visibility == Visibility.Visible)
+		{
+			ScheduleLiveWheelPreviewRender();
 		}
 	}
 
 	private void SectorCountRadio_Checked(object sender, RoutedEventArgs e)
 	{
-		if (_isUpdatingUi)
+		if (_isUpdatingUi || _isChangingSectorCount)
 		{
 			return;
 		}
@@ -1591,35 +1688,70 @@ public partial class SettingsWindow : Window
 			return;
 		}
 		int sectorCount = 8;
-		System.Windows.Controls.RadioButton sectorCount4Radio = SectorCount4Radio;
-		if (sectorCount4Radio != null && sectorCount4Radio.IsChecked == true)
+		if (SectorCount4Radio?.IsChecked == true)
 		{
 			sectorCount = 4;
 		}
-		else
+		else if (SectorCount8Radio?.IsChecked == true)
 		{
-			System.Windows.Controls.RadioButton sectorCount8Radio = SectorCount8Radio;
-			if (sectorCount8Radio != null && sectorCount8Radio.IsChecked == true)
+			sectorCount = 8;
+		}
+		else if (SectorCount12Radio?.IsChecked == true)
+		{
+			sectorCount = 12;
+		}
+
+		if (_selectedProfile.SectorCount == sectorCount)
+		{
+			return;
+		}
+
+		_isChangingSectorCount = true;
+		try
+		{
+			_isUpdatingUi = true;
+			try
 			{
-				sectorCount = 8;
+				_selectedProfile.SectorCount = sectorCount;
+				RefreshSlots();
 			}
-			else
+			finally
 			{
-				System.Windows.Controls.RadioButton sectorCount12Radio = SectorCount12Radio;
-				if (sectorCount12Radio != null && sectorCount12Radio.IsChecked == true)
+				_isUpdatingUi = false;
+			}
+
+			if (AppearanceSettingsGrid?.Visibility == Visibility.Visible)
+			{
+				ScheduleLiveWheelPreviewRender();
+			}
+			SyncUiToConfigAndSave();
+		}
+		finally
+		{
+			_isChangingSectorCount = false;
+		}
+	}
+
+	private void ScheduleLiveWheelPreviewRender()
+	{
+		if (_previewRenderPending || LiveWheelPreviewCanvas == null ||
+			AppearanceSettingsGrid?.Visibility != Visibility.Visible)
+		{
+			return;
+		}
+
+		_previewRenderPending = true;
+		Dispatcher.BeginInvoke(
+			new Action(() =>
+			{
+				_previewRenderPending = false;
+				if (!IsLoaded || AppearanceSettingsGrid?.Visibility != Visibility.Visible)
 				{
-					sectorCount = 12;
+					return;
 				}
-			}
-		}
-		_selectedProfile.SectorCount = sectorCount;
-		RefreshSlots();
-		Grid appearanceSettingsGrid = AppearanceSettingsGrid;
-		if (appearanceSettingsGrid != null && appearanceSettingsGrid.Visibility == Visibility.Visible)
-		{
-			RenderLiveWheelPreview();
-		}
-		SyncUiToConfigAndSave();
+				RenderLiveWheelPreview();
+			}),
+			DispatcherPriority.Render);
 	}
 
 	private void AddProfileButton_Click(object sender, RoutedEventArgs e)

--- a/WinPieGestures/SlotViewModel.cs
+++ b/WinPieGestures/SlotViewModel.cs
@@ -6,7 +6,7 @@ using System.Windows.Media;
 
 namespace WinPieGestures;
 
-public class SlotViewModel : INotifyPropertyChanged
+public class SlotViewModel : INotifyPropertyChanged, IDisposable
 {
 	public static readonly List<SystemPresetItem> SystemPresetList = new List<SystemPresetItem>
 	{
@@ -326,9 +326,19 @@ public class SlotViewModel : INotifyPropertyChanged
 
 	public static readonly Dictionary<string, string> SystemPresets = SystemPresetList.ToDictionary((SystemPresetItem x) => x.Key, (SystemPresetItem x) => x.FormattedDisplay);
 
-	public string DirectionLabel { get; }
+	public int PositionIndex { get; private set; }
 
-	public ActionItem Action { get; }
+	public int SectorCount { get; private set; }
+
+	public string DirectionLabel { get; private set; }
+
+	public ActionItem Action { get; private set; }
+
+	public bool IsVisible { get; private set; }
+
+	public bool CanMoveUp { get; private set; }
+
+	public bool CanMoveDown { get; private set; }
 
 	public string Name
 	{
@@ -672,6 +682,16 @@ public class SlotViewModel : INotifyPropertyChanged
 
 	public string TestButtonText => I18n.T("BtnTest");
 
+	public string PositionSlotLabel => I18n.T("SectorPositionSlot");
+
+	public string MoveUpToolTip => I18n.T("SectorMoveUp");
+
+	public string MoveDownToolTip => I18n.T("SectorMoveDown");
+
+	private readonly Action _languageChangedHandler;
+
+	private bool _isDisposed;
+
 	public event PropertyChangedEventHandler? PropertyChanged;
 
 	public void NotifySubActionsChanged()
@@ -680,8 +700,10 @@ public class SlotViewModel : INotifyPropertyChanged
 		OnPropertyChanged("SubActionButtonText");
 	}
 
-	public SlotViewModel(string directionLabel, ActionItem action)
+	public SlotViewModel(int positionIndex, int sectorCount, string directionLabel, ActionItem action)
 	{
+		PositionIndex = positionIndex;
+		SectorCount = sectorCount;
 		DirectionLabel = directionLabel;
 		Action = action ?? new ActionItem
 		{
@@ -689,14 +711,82 @@ public class SlotViewModel : INotifyPropertyChanged
 			Name = "快捷动作",
 			Parameter = ""
 		};
-		I18n.LanguageChanged += delegate
+		IsVisible = true;
+		CanMoveUp = positionIndex > 0;
+		CanMoveDown = positionIndex < sectorCount - 1;
+		_languageChangedHandler = HandleLanguageChanged;
+		I18n.LanguageChanged += _languageChangedHandler;
+	}
+
+	public SlotViewModel(string directionLabel, ActionItem action)
+		: this(0, 8, directionLabel, action)
+	{
+	}
+
+	public void Update(int positionIndex, int sectorCount, string directionLabel, ActionItem? action, bool isVisible)
+	{
+		PositionIndex = positionIndex;
+		SectorCount = sectorCount;
+		DirectionLabel = directionLabel ?? string.Empty;
+		Action = action ?? new ActionItem
 		{
-			OnPropertyChanged("ActionTypes");
-			OnPropertyChanged("Terminals");
-			OnPropertyChanged("TestButtonText");
-			OnPropertyChanged("IconDisplayText");
-			OnPropertyChanged("SubActionButtonText");
+			Type = "Hotkey",
+			Name = $"快捷动作 {positionIndex + 1}",
+			Parameter = ""
 		};
+		IsVisible = isVisible;
+		CanMoveUp = isVisible && positionIndex > 0;
+		CanMoveDown = isVisible && positionIndex < sectorCount - 1;
+
+		OnPropertyChanged(nameof(PositionIndex));
+		OnPropertyChanged(nameof(SectorCount));
+		OnPropertyChanged(nameof(DirectionLabel));
+		OnPropertyChanged(nameof(Action));
+		OnPropertyChanged(nameof(IsVisible));
+		OnPropertyChanged(nameof(CanMoveUp));
+		OnPropertyChanged(nameof(CanMoveDown));
+		OnPropertyChanged(nameof(Name));
+		OnPropertyChanged(nameof(Type));
+		OnPropertyChanged(nameof(Parameter));
+		OnPropertyChanged(nameof(Arguments));
+		OnPropertyChanged(nameof(IconKey));
+		OnPropertyChanged(nameof(CustomIconSvg));
+		OnPropertyChanged(nameof(IconDisplayText));
+		OnPropertyChanged(nameof(HasVectorIcon));
+		OnPropertyChanged(nameof(VectorIconData));
+		OnPropertyChanged(nameof(SelectedSystemPreset));
+		OnPropertyChanged(nameof(IsHotkeyType));
+		OnPropertyChanged(nameof(IsLaunchType));
+		OnPropertyChanged(nameof(IsFolderType));
+		OnPropertyChanged(nameof(IsSystemType));
+		OnPropertyChanged(nameof(SubActionCount));
+		OnPropertyChanged(nameof(SubActionButtonText));
+	}
+
+	private void HandleLanguageChanged()
+	{
+		if (_isDisposed)
+		{
+			return;
+		}
+		OnPropertyChanged(nameof(ActionTypes));
+		OnPropertyChanged(nameof(TestButtonText));
+		OnPropertyChanged(nameof(PositionSlotLabel));
+		OnPropertyChanged(nameof(MoveUpToolTip));
+		OnPropertyChanged(nameof(MoveDownToolTip));
+		OnPropertyChanged(nameof(IconDisplayText));
+		OnPropertyChanged(nameof(SubActionButtonText));
+	}
+
+	public void Dispose()
+	{
+		if (_isDisposed)
+		{
+			return;
+		}
+		_isDisposed = true;
+		I18n.LanguageChanged -= _languageChangedHandler;
+		PropertyChanged = null;
 	}
 
 	protected void OnPropertyChanged(string propertyName)

--- a/WinPieGestures/WheelPositionIndicator.cs
+++ b/WinPieGestures/WheelPositionIndicator.cs
@@ -1,0 +1,335 @@
+using System;
+using System.Windows;
+using System.Windows.Media;
+using Pen = System.Windows.Media.Pen;
+
+namespace WinPieGestures
+{
+    /// <summary>
+    /// Compact radial position cue used by the sector-action mapping list.
+    /// The selected sector is filled with the current accent color and carries
+    /// a larger directional arrow so the fixed destination slot is obvious
+    /// even when the action cards are reordered.
+    /// </summary>
+    public sealed class WheelPositionIndicator : FrameworkElement
+    {
+        public static readonly DependencyProperty PositionIndexProperty =
+            DependencyProperty.Register(
+                nameof(PositionIndex),
+                typeof(int),
+                typeof(WheelPositionIndicator),
+                new FrameworkPropertyMetadata(0, FrameworkPropertyMetadataOptions.AffectsRender));
+
+        public static readonly DependencyProperty SectorCountProperty =
+            DependencyProperty.Register(
+                nameof(SectorCount),
+                typeof(int),
+                typeof(WheelPositionIndicator),
+                new FrameworkPropertyMetadata(8, FrameworkPropertyMetadataOptions.AffectsRender));
+
+        public static readonly DependencyProperty AccentBrushProperty =
+            DependencyProperty.Register(
+                nameof(AccentBrush),
+                typeof(Brush),
+                typeof(WheelPositionIndicator),
+                new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsRender));
+
+        public static readonly DependencyProperty AccentTextBrushProperty =
+            DependencyProperty.Register(
+                nameof(AccentTextBrush),
+                typeof(Brush),
+                typeof(WheelPositionIndicator),
+                new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsRender));
+
+        public static readonly DependencyProperty SectorBrushProperty =
+            DependencyProperty.Register(
+                nameof(SectorBrush),
+                typeof(Brush),
+                typeof(WheelPositionIndicator),
+                new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsRender));
+
+        public static readonly DependencyProperty BorderBrushProperty =
+            DependencyProperty.Register(
+                nameof(BorderBrush),
+                typeof(Brush),
+                typeof(WheelPositionIndicator),
+                new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsRender));
+
+        public static readonly DependencyProperty MutedBrushProperty =
+            DependencyProperty.Register(
+                nameof(MutedBrush),
+                typeof(Brush),
+                typeof(WheelPositionIndicator),
+                new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsRender));
+
+        public static readonly DependencyProperty CenterBrushProperty =
+            DependencyProperty.Register(
+                nameof(CenterBrush),
+                typeof(Brush),
+                typeof(WheelPositionIndicator),
+                new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsRender));
+
+        public int PositionIndex
+        {
+            get => (int)GetValue(PositionIndexProperty);
+            set => SetValue(PositionIndexProperty, value);
+        }
+
+        public int SectorCount
+        {
+            get => (int)GetValue(SectorCountProperty);
+            set => SetValue(SectorCountProperty, value);
+        }
+
+        public Brush? AccentBrush
+        {
+            get => (Brush?)GetValue(AccentBrushProperty);
+            set => SetValue(AccentBrushProperty, value);
+        }
+
+        public Brush? AccentTextBrush
+        {
+            get => (Brush?)GetValue(AccentTextBrushProperty);
+            set => SetValue(AccentTextBrushProperty, value);
+        }
+
+        public Brush? SectorBrush
+        {
+            get => (Brush?)GetValue(SectorBrushProperty);
+            set => SetValue(SectorBrushProperty, value);
+        }
+
+        public Brush? BorderBrush
+        {
+            get => (Brush?)GetValue(BorderBrushProperty);
+            set => SetValue(BorderBrushProperty, value);
+        }
+
+        public Brush? MutedBrush
+        {
+            get => (Brush?)GetValue(MutedBrushProperty);
+            set => SetValue(MutedBrushProperty, value);
+        }
+
+        public Brush? CenterBrush
+        {
+            get => (Brush?)GetValue(CenterBrushProperty);
+            set => SetValue(CenterBrushProperty, value);
+        }
+
+        protected override void OnRender(DrawingContext drawingContext)
+        {
+            base.OnRender(drawingContext);
+
+            double width = ActualWidth;
+            double height = ActualHeight;
+            if (!double.IsFinite(width) || !double.IsFinite(height) || width <= 0 || height <= 0)
+            {
+                return;
+            }
+
+            try
+            {
+                int sectorCount = SectorCount is 4 or 8 or 12 ? SectorCount : 8;
+                int selectedIndex = PositionIndex % sectorCount;
+                if (selectedIndex < 0)
+                {
+                    selectedIndex += sectorCount;
+                }
+
+                double size = Math.Min(width, height);
+                if (!double.IsFinite(size) || size <= 0) return;
+
+                Point center = new(width / 2.0, height / 2.0);
+                double outerRadius = Math.Max(8.0, size / 2.0 - 3.0);
+                double innerRadius = Math.Max(3.0, outerRadius * 0.28);
+                double sectorSize = 360.0 / sectorCount;
+                double gap = Math.Min(2.6, sectorSize * 0.14);
+
+                Brush accent = ResolveBrush(AccentBrush, "AccentPrimaryBrush", Color.FromRgb(37, 99, 235));
+                Brush accentText = ResolveBrush(AccentTextBrush, "AccentTextBrush", Colors.White);
+                Brush sector = ResolveBrush(SectorBrush, "SubtleCardBrush", Color.FromRgb(248, 250, 252));
+                Brush border = ResolveBrush(BorderBrush, "CardBorderBrush", Color.FromRgb(226, 232, 240));
+                Brush muted = ResolveBrush(MutedBrush, "TextMutedBrush", Color.FromRgb(100, 116, 139));
+                Brush centerFill = ResolveBrush(CenterBrush, "CardBackgroundBrush", Colors.White);
+
+                // Resolve and clone each brush once per render. The previous
+                // implementation cloned brushes inside the sector loop, which
+                // created a burst of Freezable objects whenever the list was
+                // rebuilt. Freezing the render-only copies also keeps WPF's
+                // retained drawing data stable while rows are replaced.
+                Brush selectedFill = WithOpacity(accent, 0.32);
+                Brush neutralFill = WithOpacity(sector, 0.62);
+                Brush mutedMarker = WithOpacity(muted, 0.72);
+                Brush outerRing = WithOpacity(border, 0.9);
+                Brush accentDot = WithOpacity(accent, 0.9);
+                Pen selectedPen = CreatePen(accent, 1.35);
+                Pen neutralPen = CreatePen(border, 0.8);
+                Pen outerRingPen = CreatePen(outerRing, 0.85);
+
+                for (int i = 0; i < sectorCount; i++)
+                {
+                    bool isSelected = i == selectedIndex;
+                    double middleAngle = i * sectorSize;
+                    double startAngle = middleAngle - sectorSize / 2.0 + gap;
+                    double endAngle = middleAngle + sectorSize / 2.0 - gap;
+                    double sectorOuterRadius = isSelected ? outerRadius + 0.8 : outerRadius;
+                    Geometry geometry = CreateDonutSectorGeometry(center, innerRadius, sectorOuterRadius, startAngle, endAngle);
+
+                    drawingContext.DrawGeometry(isSelected ? selectedFill : neutralFill, isSelected ? selectedPen : neutralPen, geometry);
+
+                    if (!isSelected)
+                    {
+                        Point marker = PointOnCircle(center, outerRadius * 0.68, middleAngle);
+                        drawingContext.DrawEllipse(mutedMarker, null, marker, 1.15, 1.15);
+                    }
+                }
+
+                // A quiet outer ring keeps the indicator legible against light and dark cards.
+                drawingContext.DrawEllipse(null, outerRingPen, center, outerRadius, outerRadius);
+
+                Point selectedDirectionStart = PointOnCircle(center, innerRadius * 0.45, selectedIndex * sectorSize);
+                double arrowHeadLength = Math.Max(4.5, size * 0.14);
+                double arrowHeadWidth = Math.Max(2.5, size * 0.085);
+                double arrowTipRadius = outerRadius * 0.80;
+                Point selectedTip = PointOnCircle(center, arrowTipRadius, selectedIndex * sectorSize);
+                Point arrowBase = PointOnCircle(center, arrowTipRadius - arrowHeadLength, selectedIndex * sectorSize);
+                double angleRadians = selectedIndex * sectorSize * Math.PI / 180.0;
+                Vector perpendicular = new(-Math.Sin(angleRadians), Math.Cos(angleRadians));
+                Point leftWing = arrowBase + perpendicular * arrowHeadWidth;
+                Point rightWing = arrowBase - perpendicular * arrowHeadWidth;
+
+                Pen arrowPen = CreatePen(accentText, Math.Max(1.8, size * 0.045), PenLineCap.Round);
+                drawingContext.DrawLine(arrowPen, selectedDirectionStart, arrowBase);
+
+                StreamGeometry arrowHead = new();
+                using (StreamGeometryContext context = arrowHead.Open())
+                {
+                    context.BeginFigure(selectedTip, true, true);
+                    context.LineTo(leftWing, true, false);
+                    context.LineTo(rightWing, true, false);
+                }
+                arrowHead.Freeze();
+                drawingContext.DrawGeometry(accentText, null, arrowHead);
+
+                double centerRadius = Math.Max(3.5, innerRadius * 0.80);
+                drawingContext.DrawEllipse(centerFill, CreatePen(accent, 1.0), center, centerRadius, centerRadius);
+                drawingContext.DrawEllipse(accentDot, null, center, Math.Max(1.3, size * 0.035), Math.Max(1.3, size * 0.035));
+            }
+            catch (Exception ex)
+            {
+                // A malformed theme brush or an invalid visual-state value
+                // must not take down the settings window during a list reset.
+                System.Diagnostics.Debug.WriteLine($"[WheelPositionIndicator Render Error]: {ex.Message}");
+            }
+        }
+
+        private Brush ResolveBrush(Brush? configured, string resourceKey, Color fallback)
+        {
+            try
+            {
+                if (configured != null)
+                {
+                    return configured;
+                }
+
+                if (TryFindResource(resourceKey) is Brush resourceBrush)
+                {
+                    return resourceBrush;
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[WheelPositionIndicator Brush Error]: {ex.Message}");
+            }
+
+            var fallbackBrush = new SolidColorBrush(fallback);
+            fallbackBrush.Freeze();
+            return fallbackBrush;
+        }
+
+        private static Brush WithOpacity(Brush source, double opacity)
+        {
+            try
+            {
+                Brush clone = source.CloneCurrentValue();
+                clone.Opacity = Math.Clamp(opacity, 0.0, 1.0);
+                if (clone.CanFreeze) clone.Freeze();
+                return clone;
+            }
+            catch
+            {
+                var fallback = new SolidColorBrush(Colors.Transparent);
+                fallback.Freeze();
+                return fallback;
+            }
+        }
+
+        private static Pen CreatePen(Brush brush, double thickness, PenLineCap cap = PenLineCap.Flat)
+        {
+            var pen = new Pen(brush, Math.Max(0.1, double.IsFinite(thickness) ? thickness : 1.0))
+            {
+                StartLineCap = cap,
+                EndLineCap = cap,
+                LineJoin = PenLineJoin.Round
+            };
+            if (pen.CanFreeze) pen.Freeze();
+            return pen;
+        }
+
+        private static Point PointOnCircle(Point center, double radius, double angleDegrees)
+        {
+            double radians = angleDegrees * Math.PI / 180.0;
+            return new Point(
+                center.X + Math.Cos(radians) * radius,
+                center.Y + Math.Sin(radians) * radius);
+        }
+
+        private static Geometry CreateDonutSectorGeometry(
+            Point center,
+            double innerRadius,
+            double outerRadius,
+            double startAngle,
+            double endAngle)
+        {
+            if (!double.IsFinite(center.X) || !double.IsFinite(center.Y) ||
+                !double.IsFinite(innerRadius) || !double.IsFinite(outerRadius) ||
+                !double.IsFinite(startAngle) || !double.IsFinite(endAngle) ||
+                outerRadius <= 0 || innerRadius <= 0 || outerRadius <= innerRadius)
+            {
+                return Geometry.Empty;
+            }
+
+            Point outerStart = PointOnCircle(center, outerRadius, startAngle);
+            Point outerEnd = PointOnCircle(center, outerRadius, endAngle);
+            Point innerEnd = PointOnCircle(center, innerRadius, endAngle);
+            Point innerStart = PointOnCircle(center, innerRadius, startAngle);
+            bool isLargeArc = Math.Abs(endAngle - startAngle) > 180.0;
+
+            StreamGeometry geometry = new();
+            using (StreamGeometryContext context = geometry.Open())
+            {
+                context.BeginFigure(outerStart, true, true);
+                context.ArcTo(
+                    outerEnd,
+                    new Size(outerRadius, outerRadius),
+                    0,
+                    isLargeArc,
+                    SweepDirection.Clockwise,
+                    true,
+                    false);
+                context.LineTo(innerEnd, true, false);
+                context.ArcTo(
+                    innerStart,
+                    new Size(innerRadius, innerRadius),
+                    0,
+                    isLargeArc,
+                    SweepDirection.Counterclockwise,
+                    true,
+                    false);
+            }
+            geometry.Freeze();
+            return geometry;
+        }
+    }
+}


### PR DESCRIPTION
## 变更背景
为提升轮盘动作配置的可理解性和调整效率，在“手势与动作”页面增加扇区动作排序能力，并改善快速拖动轮盘时的视觉更新流畅度。

## 实现内容
- 在扇区动作映射列表中增加上移/下移箭头，可将功能移动到相邻轮盘位置槽。
- 将轮盘位置指示与功能编辑卡分离，使用轮盘分片高亮图标直观显示当前槽位。
- 完善 4/8/12 分片切换后的槽位可见性、按钮状态和数据刷新。
- 优化手势高亮更新调度，避免快速移动时积压过期 UI 更新。
- 保留并兼容上游 v1.5.6.dev 的“运行命令”动作和终端选择功能。

## 验证结果
- Release 构建通过：0 个错误（仅保留项目原有警告）。
- GUI 自动化测试：19/19 通过。
- 已使用同步上游后的测试版 EXE 手动确认排序、位置指示和手势操作正常。

## AI 自审
已检查上游合并冲突、WPF XAML 绑定、排序边界状态、4/8/12 分片切换以及命令动作兼容性，未发现阻断性问题。
