### PR TITLE
fix: 修复多显示器混合 DPI 环境下轮盘在副屏不居中的问题

### DIFF
--- a/WinPieGestures/GestureController.cs
+++ b/WinPieGestures/GestureController.cs
@@ -23,6 +23,12 @@ public class GestureController
 
 	private Point _startPoint;
 
+	// 手势起点所在显示器的 DPI 缩放系数,用于将物理像素位移归一化为 DIP,
+	// 保证多显示器混合 DPI 环境下滑动阈值与扇区命中判定一致。
+	private double _currentDpiScaleX = 1.0;
+
+	private double _currentDpiScaleY = 1.0;
+
 	private volatile bool _isWaitingForThreshold;
 
 	private volatile bool _isGestureActive;
@@ -326,6 +332,9 @@ public class GestureController
 				return;
 			}
 			_startPoint = e.Position;
+			var (scaleX, scaleY) = RadialWindow.GetMonitorDpiScale(_startPoint);
+			_currentDpiScaleX = scaleX;
+			_currentDpiScaleY = scaleY;
 			BeginGestureTracking();
 			_isWaitingForThreshold = true;
 			_isGestureActive = false;
@@ -427,6 +436,9 @@ public class GestureController
 			}
 			GetCursorPos(out var lpPoint);
 			_startPoint = new Point((double)lpPoint.x, (double)lpPoint.y);
+			var (dpiX, dpiY) = RadialWindow.GetMonitorDpiScale(_startPoint);
+			_currentDpiScaleX = dpiX;
+			_currentDpiScaleY = dpiY;
 			BeginGestureTracking();
 			_isWaitingForThreshold = true;
 			_isGestureActive = false;
@@ -530,9 +542,11 @@ public class GestureController
 		if (_isWaitingForThreshold)
 		{
 			Point position = e.Position;
-			double num = position.X - _startPoint.X;
+			double scaleX = (_currentDpiScaleX > 0.0) ? _currentDpiScaleX : 1.0;
+			double scaleY = (_currentDpiScaleY > 0.0) ? _currentDpiScaleY : 1.0;
+			double num = (position.X - _startPoint.X) / scaleX;
 			position = e.Position;
-			double num2 = position.Y - _startPoint.Y;
+			double num2 = (position.Y - _startPoint.Y) / scaleY;
 			double num3 = num * num + num2 * num2;
 			double dragThreshold = ConfigManager.CurrentConfig.DragThreshold;
 			if (num3 >= dragThreshold * dragThreshold)
@@ -567,8 +581,10 @@ public class GestureController
 
 	private void ProcessMove(Point currentPoint)
 	{
-		double num = currentPoint.X - _startPoint.X;
-		double num2 = currentPoint.Y - _startPoint.Y;
+		double moveScaleX = (_currentDpiScaleX > 0.0) ? _currentDpiScaleX : 1.0;
+		double moveScaleY = (_currentDpiScaleY > 0.0) ? _currentDpiScaleY : 1.0;
+		double num = (currentPoint.X - _startPoint.X) / moveScaleX;
+		double num2 = (currentPoint.Y - _startPoint.Y) / moveScaleY;
 		double num3 = Math.Sqrt(num * num + num2 * num2);
 		int num4 = -1;
 		int num5 = -1;
@@ -713,9 +729,11 @@ if (ConfigManager.CurrentConfig.SubmenuStyle == "Fan")
 	private int HitTestFanSubs(Point currentPoint, Point centerPoint, int parentIndex, int subCount)
 	{
 		if (parentIndex < 0 || subCount <= 0) return -1;
-		
-		double dx = currentPoint.X - centerPoint.X;
-		double dy = currentPoint.Y - centerPoint.Y;
+
+		double hitScaleX = (_currentDpiScaleX > 0.0) ? _currentDpiScaleX : 1.0;
+		double hitScaleY = (_currentDpiScaleY > 0.0) ? _currentDpiScaleY : 1.0;
+		double dx = (currentPoint.X - centerPoint.X) / hitScaleX;
+		double dy = (currentPoint.Y - centerPoint.Y) / hitScaleY;
 		double dist = Math.Sqrt(dx * dx + dy * dy);
 		
 		double outer = ConfigManager.CurrentConfig.WheelRadius;

--- a/WinPieGestures/RadialWindow.xaml.cs
+++ b/WinPieGestures/RadialWindow.xaml.cs
@@ -5,8 +5,10 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Interop;
 using System.Windows.Markup;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
@@ -18,6 +20,74 @@ namespace WinPieGestures;
 
 public partial class RadialWindow : Window
 {
+	[StructLayout(LayoutKind.Sequential)]
+	public struct POINT
+	{
+		public int x;
+		public int y;
+	}
+
+	private const uint MONITOR_DEFAULTTONEAREST = 2;
+	private const uint SWP_NOACTIVATE = 0x0010;
+	private const uint SWP_NOZORDER = 0x0004;
+
+	[DllImport("user32.dll")]
+	public static extern nint MonitorFromPoint(POINT pt, uint dwFlags);
+
+	[DllImport("SHCore.dll", SetLastError = true)]
+	public static extern int GetDpiForMonitor(nint hMonitor, int dpiType, out uint dpiX, out uint dpiY);
+
+	[DllImport("user32.dll", SetLastError = true)]
+	public static extern bool SetWindowPos(nint hWnd, nint hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+
+	/// <summary>
+	/// 获取指定物理像素坐标所在显示器的 DPI 缩放系数(多显示器混合 DPI 环境下逐屏获取)。
+	/// </summary>
+	public static (double scaleX, double scaleY) GetMonitorDpiScale(Point physicalPoint)
+	{
+		try
+		{
+			POINT pt = new POINT { x = (int)Math.Round(physicalPoint.X), y = (int)Math.Round(physicalPoint.Y) };
+			nint hMonitor = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
+			if (hMonitor != IntPtr.Zero)
+			{
+				if (GetDpiForMonitor(hMonitor, 0, out uint dpiX, out uint dpiY) == 0 && dpiX > 0 && dpiY > 0)
+				{
+					return (dpiX / 96.0, dpiY / 96.0);
+				}
+			}
+		}
+		catch
+		{
+		}
+		return (1.0, 1.0);
+	}
+
+	/// <summary>
+	/// 以物理像素将窗口居中到 _centerPoint(鼠标钩子返回的物理坐标)所在的显示器上。
+	/// 在 PerMonitorV2 DPI 感知下,SetWindowPos 直接使用物理像素,可正确定位到副屏。
+	/// </summary>
+	private void PositionWindowOnTargetMonitor()
+	{
+		nint handle = new WindowInteropHelper(this).Handle;
+		if (handle == IntPtr.Zero)
+		{
+			return;
+		}
+		var (scaleX, scaleY) = GetMonitorDpiScale(_centerPoint);
+		int physicalWidth = (int)Math.Round(base.Width * scaleX);
+		int physicalHeight = (int)Math.Round(base.Height * scaleY);
+		int physicalLeft = (int)Math.Round(_centerPoint.X - physicalWidth / 2.0);
+		int physicalTop = (int)Math.Round(_centerPoint.Y - physicalHeight / 2.0);
+		SetWindowPos(handle, IntPtr.Zero, physicalLeft, physicalTop, physicalWidth, physicalHeight, SWP_NOACTIVATE | SWP_NOZORDER);
+	}
+
+	protected override void OnSourceInitialized(EventArgs e)
+	{
+		base.OnSourceInitialized(e);
+		PositionWindowOnTargetMonitor();
+	}
+
 	private sealed class SubTierVisuals
 	{
 		public List<System.Windows.Shapes.Path> Paths { get; }
@@ -262,20 +332,7 @@ public partial class RadialWindow : Window
 		Panel.SetZIndex(CoreGrid, 5);
 		OuterEllipse.Width = wheelRadius * 2.0 + 8.0;
 		OuterEllipse.Height = wheelRadius * 2.0 + 8.0;
-		double num5 = 1.0;
-		double num6 = 1.0;
-		PresentationSource presentationSource = PresentationSource.FromVisual(this);
-		if (presentationSource?.CompositionTarget != null)
-		{
-			Matrix transformToDevice = presentationSource.CompositionTarget.TransformToDevice;
-			num5 = transformToDevice.M11;
-			transformToDevice = presentationSource.CompositionTarget.TransformToDevice;
-			num6 = transformToDevice.M22;
-		}
-		Point centerPoint = _centerPoint;
-		base.Left = centerPoint.X / num5 - base.Width / 2.0;
-		centerPoint = _centerPoint;
-		base.Top = centerPoint.Y / num6 - base.Height / 2.0;
+		PositionWindowOnTargetMonitor();
 		CoreEllipse.Fill = _coreBgBrush;
 		CoreEllipse.Stroke = _coreBorderBrush;
 		string text = ConfigManager.CurrentConfig.CoreBgImagePath ?? "";

--- a/WinPieGestures/ScreenEyedropperOverlay.cs
+++ b/WinPieGestures/ScreenEyedropperOverlay.cs
@@ -39,6 +39,19 @@ public partial class ScreenEyedropperOverlay : Window
 	[DllImport("user32.dll")]
 	private static extern bool GetCursorPos(out POINT lpPoint);
 
+	[DllImport("user32.dll")]
+	private static extern int GetSystemMetrics(int nIndex);
+
+	[DllImport("user32.dll", SetLastError = true)]
+	private static extern bool SetWindowPos(nint hWnd, nint hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+
+	private const int SM_XVIRTUALSCREEN = 76;
+	private const int SM_YVIRTUALSCREEN = 77;
+	private const int SM_CXVIRTUALSCREEN = 78;
+	private const int SM_CYVIRTUALSCREEN = 79;
+	private const uint SWP_NOACTIVATE = 0x0010;
+	private const uint SWP_NOZORDER = 0x0004;
+
 	public ScreenEyedropperOverlay()
 	{
 		base.WindowStyle = WindowStyle.None;
@@ -51,6 +64,19 @@ public partial class ScreenEyedropperOverlay : Window
 		base.Top = SystemParameters.VirtualScreenTop;
 		base.Width = SystemParameters.VirtualScreenWidth;
 		base.Height = SystemParameters.VirtualScreenHeight;
+		base.SourceInitialized += delegate
+		{
+			// 混合 DPI 多显示器下,SystemParameters 的 DIP 值与物理像素不一致,
+			// 用 Win32 物理像素强制铺满整个虚拟屏幕。
+			nint handle = new System.Windows.Interop.WindowInteropHelper(this).Handle;
+			if (handle != IntPtr.Zero)
+			{
+				SetWindowPos(handle, IntPtr.Zero,
+					GetSystemMetrics(SM_XVIRTUALSCREEN), GetSystemMetrics(SM_YVIRTUALSCREEN),
+					GetSystemMetrics(SM_CXVIRTUALSCREEN), GetSystemMetrics(SM_CYVIRTUALSCREEN),
+					SWP_NOACTIVATE | SWP_NOZORDER);
+			}
+		};
 		_loupeCanvas = new Canvas
 		{
 			IsHitTestVisible = false

--- a/WinPieGestures/WinPieGestures.csproj
+++ b/WinPieGestures/WinPieGestures.csproj
@@ -7,6 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>app_icon.ico</ApplicationIcon>
     <AssemblyName>StarPie</AssemblyName>
     <Title>StarPie</Title>

--- a/WinPieGestures/app.manifest
+++ b/WinPieGestures/app.manifest
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="StarPie.app" />
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 / 11 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <!-- Win10 1607+: Per-Monitor V2 DPI awareness -->
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <!-- Fallback for older Windows: Per-Monitor DPI aware -->
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+    </windowsSettings>
+  </application>
+</assembly>


### PR DESCRIPTION
## 问题现象

在 Windows 多显示器且各屏缩放比例不同的环境下(如主屏 2K/150% + 副屏 1080P/100%),按住鼠标右键滑动呼出轮盘时:

- **主屏**:轮盘正常在光标位置居中;
- **副屏**:轮盘未在光标处出现,偏移到错误位置甚至飞出屏幕可视区域。

## 根因分析

进程缺少 DPI 感知声明(app.manifest),Windows 将其视为 **DPI-unaware**:

- `WH_MOUSE_LL` 鼠标钩子坐标、`SetWindowPos` 等 Win32 API 的坐标均被系统**虚拟化到系统 DPI 空间**;
- 而 `GetDpiForMonitor` 返回的是显示器**真实物理 DPI**;
- 原 `RadialWindow_Loaded` 中 `Left = centerPoint.X / num5` 的换算只取了窗口当前(系统)缩放,两套坐标系混用。主屏上"系统缩放 == 主屏缩放"碰巧正确,副屏缩放不同即偏移。

## 修改内容

| 文件 | 改动 |
|---|---|
| `WinPieGestures/app.manifest` | 新增,声明 **PerMonitorV2** DPI 感知(含旧系统回退 `true/pm`)——核心修复,使钩子坐标、SetWindowPos、GetDpiForMonitor 统一为物理像素 |
| `WinPieGestures.csproj` | 引用该 manifest |
| `RadialWindow.xaml.cs` | 新增 `GetMonitorDpiScale()`(经 `MonitorFromPoint`+`GetDpiForMonitor` 逐屏取缩放)与 `PositionWindowOnTargetMonitor()`,在 `OnSourceInitialized` 与 `Loaded` 中通过 `SetWindowPos` 按物理像素将窗口居中到光标所在显示器 |
| `GestureController.cs` | 手势触发(鼠标/键盘两种触发路径)时记录所在屏幕 DPI 缩放,将滑动位移归一化为 DIP,保证 `DragThreshold`、扇区/子扇区命中判定在各屏幕上手感一致 |
| `ScreenEyedropperOverlay.cs` | 取色覆盖层改用 `GetSystemMetrics(SM_*VIRTUALSCREEN)`+`SetWindowPos` 按物理像素铺满虚拟屏,避免切换 PerMonitorV2 后在混合 DPI 下覆盖不全(预防回归) |

## 验证环境

- Windows 11,主屏 150% 缩放 + 副屏 100% 缩放(副屏排列在主屏侧方);
- 修复后副屏呼出轮盘在光标处正确居中,扇区命中距离感与主屏一致;
- 附带收益:全应用在各显示器上不再被系统位图拉伸,渲染更清晰。

```powershell
dotnet build WinPieGestures/WinPieGestures.csproj -c Release   # 0 错误
```
