### PR TITLE
feat: 选中扇区时在中心显示动作名称

### DIFF
--- a/WinPieGestures/AppConfig.cs
+++ b/WinPieGestures/AppConfig.cs
@@ -71,6 +71,8 @@ public class AppConfig
 
 	public bool ShowText { get; set; } = true;
 
+	public bool ShowSelectedActionText { get; set; }
+
 	public double WheelRadius { get; set; } = 138.0;
 
 	public double InnerRadius { get; set; } = 52.0;

--- a/WinPieGestures/I18n.cs
+++ b/WinPieGestures/I18n.cs
@@ -1347,6 +1347,20 @@ public static class I18n
 			[LanguageCode.En] = "Text Only",
 			[LanguageCode.Ja] = "文字のみ"
 		};
+		dictionary["ShowSectorActionText"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "在轮盘扇区中显示动作名称文字",
+			[LanguageCode.ZhTw] = "在輪盤扇區中顯示動作名稱文字",
+			[LanguageCode.En] = "Show action names in wheel sectors",
+			[LanguageCode.Ja] = "ホイールの扇形にアクション名を表示"
+		};
+		dictionary["ShowSelectedActionText"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "选中扇区时在中心显示动作名称",
+			[LanguageCode.ZhTw] = "選取扇區時在中心顯示動作名稱",
+			[LanguageCode.En] = "Show selected action name in the center",
+			[LanguageCode.Ja] = "選択中のアクション名を中央に表示"
+		};
 		dictionary["SectorIconSize"] = new Dictionary<LanguageCode, string>
 		{
 			[LanguageCode.ZhCn] = "图标大小 (Icon Size)",

--- a/WinPieGestures/RadialWindow.xaml
+++ b/WinPieGestures/RadialWindow.xaml
@@ -45,6 +45,14 @@
         </StackPanel>
         <Path Name="CoreExitIcon" Stretch="Uniform" HorizontalAlignment="Center" VerticalAlignment="Center" Width="16" Height="16" Data="M19,6.41 L17.59,5 L12,10.59 L6.41,5 L5,6.41 L10.59,12 L5,17.59 L6.41,19 L12,13.41 L17.59,19 L19,17.59 L13.41,12 L19,6.41" />
         <Ellipse Name="CoreCustomImageEllipse" Stretch="UniformToFill" HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="Collapsed" IsHitTestVisible="False" RenderOptions.BitmapScalingMode="HighQuality" RenderOptions.EdgeMode="Unspecified" />
+        <Ellipse Name="CoreSelectionOverlay" Fill="#70273045" Opacity="0.92" Stroke="#80FFFFFF" StrokeThickness="1.1" Visibility="Collapsed" IsHitTestVisible="False">
+          <Ellipse.Effect>
+            <BlurEffect Radius="7" RenderingBias="Performance" />
+          </Ellipse.Effect>
+        </Ellipse>
+        <StackPanel Name="CoreSelectionTextPanel" Width="150" Margin="6" HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="Collapsed" IsHitTestVisible="False">
+          <TextBlock Name="CoreSelectionText" Foreground="#FFFFFFFF" FontSize="13" FontWeight="SemiBold" HorizontalAlignment="Center" TextAlignment="Center" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" MaxHeight="54" Effect="{StaticResource TextShadow}" />
+        </StackPanel>
       </Grid>
     </Canvas>
   </Grid>

--- a/WinPieGestures/RadialWindow.xaml.cs
+++ b/WinPieGestures/RadialWindow.xaml.cs
@@ -203,6 +203,16 @@ public partial class RadialWindow : Window
 
 	private bool _isOuterEscaped;
 
+	private Visibility _defaultCoreExitIconVisibility = Visibility.Collapsed;
+
+	private Visibility _defaultCoreCustomImageVisibility = Visibility.Collapsed;
+
+	private double _defaultCoreExitIconOpacity = 1.0;
+
+	private double _defaultCoreCustomImageOpacity = 1.0;
+
+	private Effect? _defaultCoreCustomImageEffect;
+
 	public RadialWindow(Point centerPoint, WheelProfile profile)
 	{
 		//IL_00d0: Unknown result type (might be due to invalid IL or missing references)
@@ -462,6 +472,19 @@ public partial class RadialWindow : Window
 			CoreCustomImageEllipse.Visibility = Visibility.Collapsed;
 			CoreExitIcon.Visibility = Visibility.Collapsed;
 		}
+		_defaultCoreExitIconVisibility = CoreExitIcon.Visibility;
+		_defaultCoreCustomImageVisibility = CoreCustomImageEllipse.Visibility;
+		_defaultCoreExitIconOpacity = CoreExitIcon.Opacity;
+		_defaultCoreCustomImageOpacity = CoreCustomImageEllipse.Opacity;
+		_defaultCoreCustomImageEffect = CoreCustomImageEllipse.Effect;
+		CoreSelectionOverlay.Visibility = Visibility.Collapsed;
+		CoreSelectionTextPanel.Visibility = Visibility.Collapsed;
+		CoreSelectionTextPanel.Width = Math.Max(32.0, Math.Min(coreRadius * 1.75, 180.0));
+		CoreSelectionText.FontSize = Math.Max(8.0, Math.Min(16.0, coreRadius / 4.0));
+		CoreSelectionOverlay.Fill = CreateFrostedCoreBrush(_coreBgBrush);
+		CoreSelectionText.Foreground = _textColorBrush;
+		Panel.SetZIndex(CoreSelectionOverlay, 20);
+		Panel.SetZIndex(CoreSelectionTextPanel, 21);
 		RenderStyleDecorations();
 		RenderSectors();
 		Storyboard storyboard = new Storyboard();
@@ -1239,6 +1262,7 @@ public partial class RadialWindow : Window
 		_ = _currentHighlightedSubSector;
 		_ = _currentHighlightedSubSector;
 		_currentHighlightedSubSector = subIndex;
+		UpdateCoreSelectionDisplay(mainIndex, subIndex);
 		AppConfig currentConfig = ConfigManager.CurrentConfig;
 		double num = ((currentConfig == null || !(currentConfig.CustomAnimationDurationMs > 0.0)) ? ((double)(ConfigManager.CurrentConfig?.AnimationSpeed switch
 		{
@@ -1563,6 +1587,63 @@ public partial class RadialWindow : Window
 			ShadowDepth = 0.0,
 			Opacity = opacity
 		};
+	}
+
+	private void UpdateCoreSelectionDisplay(int mainIndex, int subIndex)
+	{
+		bool shouldShow = ConfigManager.CurrentConfig?.ShowSelectedActionText == true && mainIndex >= 0;
+		string selectedName = string.Empty;
+		if (shouldShow && mainIndex < _profile.Actions.Count)
+		{
+			ActionItem action = _profile.Actions[mainIndex];
+			if (subIndex >= 0 && action?.SubActions != null && subIndex < action.SubActions.Count)
+			{
+				selectedName = action.SubActions[subIndex]?.Name ?? string.Empty;
+			}
+			if (string.IsNullOrWhiteSpace(selectedName))
+			{
+				selectedName = action?.Name ?? string.Empty;
+			}
+		}
+
+		if (shouldShow && !string.IsNullOrWhiteSpace(selectedName))
+		{
+			CoreSelectionText.Text = selectedName;
+			CoreSelectionTextPanel.Visibility = Visibility.Visible;
+			CoreSelectionOverlay.Visibility = Visibility.Visible;
+			CoreExitIcon.Opacity = (CoreExitIcon.Visibility == Visibility.Visible) ? 0.18 : _defaultCoreExitIconOpacity;
+			CoreCustomImageEllipse.Opacity = _defaultCoreCustomImageOpacity;
+			CoreCustomImageEllipse.Effect = (CoreCustomImageEllipse.Visibility == Visibility.Visible)
+				? new BlurEffect { Radius = 5.5, RenderingBias = RenderingBias.Performance }
+				: _defaultCoreCustomImageEffect;
+			Panel.SetZIndex(CoreSelectionOverlay, 20);
+			Panel.SetZIndex(CoreSelectionTextPanel, 21);
+			return;
+		}
+
+		CoreSelectionTextPanel.Visibility = Visibility.Collapsed;
+		CoreSelectionOverlay.Visibility = Visibility.Collapsed;
+		CoreExitIcon.Visibility = _defaultCoreExitIconVisibility;
+		CoreCustomImageEllipse.Visibility = _defaultCoreCustomImageVisibility;
+		CoreExitIcon.Opacity = _defaultCoreExitIconOpacity;
+		CoreCustomImageEllipse.Opacity = _defaultCoreCustomImageOpacity;
+		CoreCustomImageEllipse.Effect = _defaultCoreCustomImageEffect;
+	}
+
+	private static Brush CreateFrostedCoreBrush(Brush baseBrush)
+	{
+		Color baseColor = (baseBrush as SolidColorBrush)?.Color ?? Color.FromRgb(36, 44, 60);
+		double luminance = (0.2126 * baseColor.R) + (0.7152 * baseColor.G) + (0.0722 * baseColor.B);
+		if (luminance >= 165.0)
+		{
+			return new SolidColorBrush(Color.FromArgb(88, byte.MaxValue, byte.MaxValue, byte.MaxValue));
+		}
+
+		return new SolidColorBrush(Color.FromArgb(
+			112,
+			(byte)Math.Min(255, baseColor.R + 48),
+			(byte)Math.Min(255, baseColor.G + 56),
+			(byte)Math.Min(255, baseColor.B + 72)));
 	}
 
 	private static Stretch ParseStretch(string? str)

--- a/WinPieGestures/SettingsWindow.xaml
+++ b/WinPieGestures/SettingsWindow.xaml
@@ -1211,7 +1211,10 @@
                       <Slider Name="SectorFontSizeSlider" Minimum="8" Maximum="18" Value="11.0" SmallChange="0.5" LargeChange="1.0" TickFrequency="0.5" IsSnapToTickEnabled="True" VerticalAlignment="Center" ValueChanged="SectorFontSizeSlider_ValueChanged" />
                       <TextBlock Name="SectorFontSizeLabel" Grid.Column="1" Text="11.0 px" FontWeight="Bold" Foreground="{DynamicResource AccentPrimaryBrush}" FontSize="12" HorizontalAlignment="Right" VerticalAlignment="Center" />
                     </Grid>
-                    <CheckBox Name="ShowTextCheckBox" Content="在轮盘扇区中显示动作名称文字" Style="{StaticResource ToggleSwitchStyle}" Margin="0,8,0,0" Checked="ShowTextCheckBox_Changed" Unchecked="ShowTextCheckBox_Changed" />
+                    <WrapPanel Margin="0,8,0,0">
+                      <CheckBox Name="ShowTextCheckBox" Content="在轮盘扇区中显示动作名称文字" Style="{StaticResource ToggleSwitchStyle}" Margin="0,0,30,10" Checked="ShowTextCheckBox_Changed" Unchecked="ShowTextCheckBox_Changed" />
+                      <CheckBox Name="ShowSelectedActionTextCheckBox" Content="选中扇区时在中心显示动作名称" Style="{StaticResource ToggleSwitchStyle}" Margin="0,0,0,10" Checked="ShowSelectedActionTextCheckBox_Changed" Unchecked="ShowSelectedActionTextCheckBox_Changed" />
+                    </WrapPanel>
                   </StackPanel>
                 </Border>
                 <Border Background="{DynamicResource CardBackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="12" Padding="18" Margin="0,12,0,0">

--- a/WinPieGestures/SettingsWindow.xaml.cs
+++ b/WinPieGestures/SettingsWindow.xaml.cs
@@ -99,6 +99,20 @@ public partial class SettingsWindow : Window
 
 	private System.Windows.Shapes.Path? _previewExitIcon;
 
+	private UIElement? _previewCoreIconElement;
+
+	private Visibility _previewCoreIconDefaultVisibility = Visibility.Collapsed;
+
+	private double _previewCoreIconDefaultOpacity = 1.0;
+
+	private Effect? _previewCoreIconDefaultEffect;
+
+	private bool _previewCoreUsesCustomImage;
+
+	private Ellipse? _previewCoreSelectionOverlay;
+
+	private TextBlock? _previewCoreSelectionText;
+
 	private int _lastHoveredSector = -2;
 
 	private int _lastHoveredSubIndex = -2;
@@ -462,6 +476,10 @@ public partial class SettingsWindow : Window
 		SetComboBoxSelectedValue(SubmenuStyleComboBox, ConfigManager.CurrentConfig.SubmenuStyle ?? "Wheel");
 		SetComboBoxSelectedValue(WheelFontFamilyComboBox, ConfigManager.CurrentConfig.WheelFontFamily ?? "Microsoft YaHei UI, Segoe UI");
 		ShowTextCheckBox.IsChecked = ConfigManager.CurrentConfig.ShowText;
+		if (ShowSelectedActionTextCheckBox != null)
+		{
+			ShowSelectedActionTextCheckBox.IsChecked = ConfigManager.CurrentConfig.ShowSelectedActionText;
+		}
 		if (EnableMultiTierCheckBox != null)
 		{
 			EnableMultiTierCheckBox.IsChecked = ConfigManager.CurrentConfig.EnableMultiTier;
@@ -928,6 +946,14 @@ public partial class SettingsWindow : Window
 		{
 			WheelFontFamilyTitleText.Text = I18n.T("WheelFontFamily");
 		}
+		if (ShowTextCheckBox != null)
+		{
+			ShowTextCheckBox.Content = I18n.T("ShowSectorActionText");
+		}
+		if (ShowSelectedActionTextCheckBox != null)
+		{
+			ShowSelectedActionTextCheckBox.Content = I18n.T("ShowSelectedActionText");
+		}
 		if (FindName("OlderMilestonesExpander") is Expander expander)
 		{
 			expander.Header = I18n.T("MilestonesOlderExpander");
@@ -1324,6 +1350,10 @@ public partial class SettingsWindow : Window
 			if (ShowTextCheckBox != null)
 			{
 				ConfigManager.CurrentConfig.ShowText = ShowTextCheckBox.IsChecked == true;
+			}
+			if (ShowSelectedActionTextCheckBox != null)
+			{
+				ConfigManager.CurrentConfig.ShowSelectedActionText = ShowSelectedActionTextCheckBox.IsChecked == true;
 			}
 			if (ShowCoreIconCheckBox != null)
 			{
@@ -3637,6 +3667,21 @@ public partial class SettingsWindow : Window
 		SyncUiToConfigAndSave();
 	}
 
+	private void ShowSelectedActionTextCheckBox_Changed(object sender, RoutedEventArgs e)
+	{
+		if (ShowSelectedActionTextCheckBox == null || ConfigManager.CurrentConfig == null || _isUpdatingUi)
+		{
+			return;
+		}
+
+		ConfigManager.CurrentConfig.ShowSelectedActionText = ShowSelectedActionTextCheckBox.IsChecked == true;
+		if (AppearanceSettingsGrid != null && AppearanceSettingsGrid.Visibility == Visibility.Visible)
+		{
+			RenderLiveWheelPreview();
+		}
+		SyncUiToConfigAndSave();
+	}
+
 	private void SectorIconSizeSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
 	{
 		if (SectorIconSizeSlider != null && SectorIconSizeLabel != null && ConfigManager.CurrentConfig != null && !_isUpdatingUi)
@@ -5173,6 +5218,13 @@ public partial class SettingsWindow : Window
 			_previewSubParentIndices.Clear();
 			_previewSubIndices.Clear();
 			_previewSubAngles.Clear();
+			_previewCoreIconElement = null;
+			_previewCoreIconDefaultVisibility = Visibility.Collapsed;
+			_previewCoreIconDefaultOpacity = 1.0;
+			_previewCoreIconDefaultEffect = null;
+			_previewCoreUsesCustomImage = false;
+			_previewCoreSelectionOverlay = null;
+			_previewCoreSelectionText = null;
 			_lastHoveredSector = -2;
 			_lastHoveredSubIndex = -2;
 			double num = 300.0 / 2.0;
@@ -5449,6 +5501,11 @@ public partial class SettingsWindow : Window
 				catch
 				{
 				}
+				_previewCoreIconElement = ellipse;
+				_previewCoreIconDefaultVisibility = ellipse.Visibility;
+				_previewCoreIconDefaultOpacity = ellipse.Opacity;
+				_previewCoreIconDefaultEffect = ellipse.Effect;
+				_previewCoreUsesCustomImage = true;
 				grid.Children.Add(ellipse);
 			}
 			else
@@ -5467,8 +5524,48 @@ public partial class SettingsWindow : Window
 					IsHitTestVisible = false,
 					Visibility = ((!ConfigManager.CurrentConfig.ShowCoreIcon) ? Visibility.Collapsed : Visibility.Visible)
 				};
+				_previewCoreIconElement = _previewExitIcon;
+				_previewCoreIconDefaultVisibility = _previewExitIcon.Visibility;
+				_previewCoreIconDefaultOpacity = _previewExitIcon.Opacity;
+				_previewCoreIconDefaultEffect = _previewExitIcon.Effect;
+				_previewCoreUsesCustomImage = false;
 				grid.Children.Add(_previewExitIcon);
 			}
+			_previewCoreSelectionOverlay = new Ellipse
+			{
+				Width = num10 * 2.0,
+				Height = num10 * 2.0,
+				Fill = CreateFrostedCoreBrush(_previewCoreBgBrush),
+				Opacity = 0.92,
+				Stroke = new SolidColorBrush(System.Windows.Media.Color.FromArgb(130, 255, 255, 255)),
+				StrokeThickness = 1.1,
+				Visibility = Visibility.Collapsed,
+				IsHitTestVisible = false,
+				Effect = new BlurEffect { Radius = 7.0, RenderingBias = RenderingBias.Performance }
+			};
+			grid.Children.Add(_previewCoreSelectionOverlay);
+			_previewCoreSelectionText = new TextBlock
+			{
+				Width = Math.Max(24.0, Math.Min(num10 * 1.75, 150.0)),
+				Foreground = _previewTextBrush,
+				FontSize = Math.Max(8.0, Math.Min(16.0, num10 / 4.0)),
+				FontWeight = FontWeights.SemiBold,
+				HorizontalAlignment = HorizontalAlignment.Center,
+				VerticalAlignment = VerticalAlignment.Center,
+				TextAlignment = TextAlignment.Center,
+				TextWrapping = TextWrapping.Wrap,
+				TextTrimming = TextTrimming.CharacterEllipsis,
+				MaxHeight = Math.Max(24.0, num10 * 1.15),
+				Visibility = Visibility.Collapsed,
+				IsHitTestVisible = false,
+				Effect = new DropShadowEffect
+				{
+					BlurRadius = 2.0,
+					ShadowDepth = 1.0,
+					Opacity = 0.4
+				}
+			};
+			grid.Children.Add(_previewCoreSelectionText);
 			_previewStyleRenderer.RenderDecorations(LiveWheelPreviewCanvas, grid, num, num2, num8, num10, 1);
 			int num19 = ((wheelProfile.SectorCount > 0) ? wheelProfile.SectorCount : 8);
 			double num20 = 360.0 / (double)num19;
@@ -5879,7 +5976,77 @@ public partial class SettingsWindow : Window
 			return Stretch.None;
 		}
 		return Stretch.UniformToFill;
-	}private void LiveWheelPreviewCanvas_MouseMove(object sender, System.Windows.Input.MouseEventArgs e)
+	}
+
+	private static System.Windows.Media.Brush CreateFrostedCoreBrush(System.Windows.Media.Brush baseBrush)
+	{
+		System.Windows.Media.Color baseColor = (baseBrush as SolidColorBrush)?.Color ?? System.Windows.Media.Color.FromRgb(36, 44, 60);
+		double luminance = (0.2126 * baseColor.R) + (0.7152 * baseColor.G) + (0.0722 * baseColor.B);
+		if (luminance >= 165.0)
+		{
+			return new SolidColorBrush(System.Windows.Media.Color.FromArgb(88, byte.MaxValue, byte.MaxValue, byte.MaxValue));
+		}
+
+		return new SolidColorBrush(System.Windows.Media.Color.FromArgb(
+			112,
+			(byte)Math.Min(255, baseColor.R + 48),
+			(byte)Math.Min(255, baseColor.G + 56),
+			(byte)Math.Min(255, baseColor.B + 72)));
+	}
+
+	private void UpdatePreviewCoreSelection(int mainIndex, int subIndex, WheelProfile? wheelProfile)
+	{
+		bool shouldShow = ConfigManager.CurrentConfig?.ShowSelectedActionText == true && mainIndex >= 0 && wheelProfile != null;
+		string selectedName = string.Empty;
+		if (shouldShow && wheelProfile!.Actions != null && mainIndex < wheelProfile.Actions.Count)
+		{
+			ActionItem action = wheelProfile.Actions[mainIndex];
+			if (subIndex >= 0 && subIndex < _previewSubIndices.Count && subIndex < _previewSubParentIndices.Count && _previewSubParentIndices[subIndex] == mainIndex)
+			{
+				int localSubIndex = _previewSubIndices[subIndex];
+				if (action?.SubActions != null && localSubIndex >= 0 && localSubIndex < action.SubActions.Count)
+				{
+					selectedName = action.SubActions[localSubIndex]?.Name ?? string.Empty;
+				}
+			}
+			if (string.IsNullOrWhiteSpace(selectedName))
+			{
+				selectedName = action?.Name ?? string.Empty;
+			}
+		}
+
+		if (shouldShow && !string.IsNullOrWhiteSpace(selectedName) && _previewCoreSelectionOverlay != null && _previewCoreSelectionText != null)
+		{
+			_previewCoreSelectionText.Text = selectedName;
+			_previewCoreSelectionOverlay.Visibility = Visibility.Visible;
+			_previewCoreSelectionText.Visibility = Visibility.Visible;
+			if (_previewCoreIconElement != null)
+			{
+				_previewCoreIconElement.Opacity = _previewCoreUsesCustomImage ? _previewCoreIconDefaultOpacity : 0.18;
+				_previewCoreIconElement.Effect = _previewCoreUsesCustomImage
+					? new BlurEffect { Radius = 5.5, RenderingBias = RenderingBias.Performance }
+					: _previewCoreIconDefaultEffect;
+			}
+			return;
+		}
+
+		if (_previewCoreSelectionOverlay != null)
+		{
+			_previewCoreSelectionOverlay.Visibility = Visibility.Collapsed;
+		}
+		if (_previewCoreSelectionText != null)
+		{
+			_previewCoreSelectionText.Visibility = Visibility.Collapsed;
+		}
+		if (_previewCoreIconElement != null)
+		{
+			_previewCoreIconElement.Visibility = _previewCoreIconDefaultVisibility;
+			_previewCoreIconElement.Opacity = _previewCoreIconDefaultOpacity;
+			_previewCoreIconElement.Effect = _previewCoreIconDefaultEffect;
+		}
+	}
+
+	private void LiveWheelPreviewCanvas_MouseMove(object sender, System.Windows.Input.MouseEventArgs e)
 	{
 		if (_previewSectorPaths.Count == 0 || ConfigManager.CurrentConfig == null)
 		{
@@ -5943,6 +6110,7 @@ public partial class SettingsWindow : Window
 			}
 			_lastHoveredSector = num15;
 			_lastHoveredSubIndex = num16;
+			UpdatePreviewCoreSelection(num15, num16, wheelProfile);
 
 			for (int num23 = 0; num23 < _previewSectorPaths.Count; num23++)
 			{
@@ -6084,6 +6252,7 @@ public partial class SettingsWindow : Window
 		{
 			_lastHoveredSector = -2;
 			_lastHoveredSubIndex = -2;
+			UpdatePreviewCoreSelection(-1, -1, _selectedProfile ?? ConfigManager.CurrentConfig?.Profiles.FirstOrDefault());
 			for (int i = 0; i < _previewSectorPaths.Count; i++)
 			{
 				System.Windows.Shapes.Path path = _previewSectorPaths[i];


### PR DESCRIPTION
关联 Issue #17。添加显示选中扇区功能文本的功能，优化纯图标模式下的使用体验。
## 变更说明
- 新增“选中扇区时在中心显示动作名称”开关。
- 选中一级或二级扇区时，在轮盘中央显示对应动作名称。
- 中央自定义图片上叠加半透明磨砂层，同时保留底图透出效果。
- 设置页面实时预览同步支持该功能。
- 补充简体中文、繁体中文、英文、日文文本。

## 预览


https://github.com/user-attachments/assets/5fc1e9e4-0486-4bb9-b545-77095a07be61



## 验证

自动化测试已完成，无阻断性错误