### PR TITLE
feat: 可选「长按触发键呼出面板」

### DIFF
--- a/WinPieGestures/AppConfig.cs
+++ b/WinPieGestures/AppConfig.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace WinPieGestures;
 
@@ -11,6 +11,12 @@ public class AppConfig
 	public TriggerConfig Trigger { get; set; } = new TriggerConfig();
 
 	public double DragThreshold { get; set; } = 25.0;
+
+	/// <summary>可选：长按触发按键（如右键）不动达到长按阈值后呼出轮盘，与拖动呼出共存。</summary>
+	public bool LongPressTrigger { get; set; }
+
+	/// <summary>长按响应时长（毫秒）。</summary>
+	public double LongPressDelayMs { get; set; } = 450.0;
 
 	public string AnimationSpeed { get; set; } = "Balanced";
 

--- a/WinPieGestures/GestureController.cs
+++ b/WinPieGestures/GestureController.cs
@@ -33,6 +33,11 @@ public class GestureController
 
 	private volatile bool _isGestureActive;
 
+	// 长按触发（可选）：按钮按下期间运行，拖动越过阈值或抬起时取消
+	private System.Windows.Threading.DispatcherTimer? _longPressTimer;
+
+	private bool _mouseTriggerDown;
+
 	private WheelProfile? _activeProfile;
 
 	private int _selectedSectorIndex = -1;
@@ -328,6 +333,8 @@ public class GestureController
 				CancelGestureTracking();
 				_isWaitingForThreshold = false;
 				_isGestureActive = false;
+				_mouseTriggerDown = false;
+				CancelLongPressTimer();
 				e.Handled = false;
 				return;
 			}
@@ -338,8 +345,59 @@ public class GestureController
 			BeginGestureTracking();
 			_isWaitingForThreshold = true;
 			_isGestureActive = false;
+			_mouseTriggerDown = true;
+			// 可选：长按不动超过阈值即呼出轮盘（与拖动呼出共存）
+			if (ConfigManager.CurrentConfig.LongPressTrigger)
+			{
+				StartLongPressTimer();
+			}
 			e.Handled = true;
 		}
+	}
+
+	/// <summary>启动长按触发计时（按下时，仅鼠标触发）。</summary>
+	private void StartLongPressTimer()
+	{
+		CancelLongPressTimer();
+		double delay = ConfigManager.CurrentConfig.LongPressDelayMs > 0.0 ? ConfigManager.CurrentConfig.LongPressDelayMs : 450.0;
+		_longPressTimer = new System.Windows.Threading.DispatcherTimer
+		{
+			Interval = TimeSpan.FromMilliseconds(delay)
+		};
+		_longPressTimer.Tick += LongPressTimer_Tick;
+		_longPressTimer.Start();
+	}
+
+	private void CancelLongPressTimer()
+	{
+		if (_longPressTimer != null)
+		{
+			_longPressTimer.Stop();
+			_longPressTimer.Tick -= LongPressTimer_Tick;
+			_longPressTimer = null;
+		}
+	}
+
+	/// <summary>长按达阈值：在按下处呼出轮盘（光标仍在中心，移动后再选择）。</summary>
+	private void LongPressTimer_Tick(object? sender, EventArgs e)
+	{
+		CancelLongPressTimer();
+		if (!_mouseTriggerDown || !_isWaitingForThreshold || _isGestureActive)
+		{
+			return;
+		}
+		_isWaitingForThreshold = false;
+		_isGestureActive = true;
+		string processName = ActiveWindowHelper.GetActiveWindowProcessName();
+		_activeProfile = ConfigManager.GetProfileForProcess(processName);
+		long gestureVersion = GetCurrentGestureVersion();
+		ProcessMove(_startPoint);
+		if (!_isGestureActive || !IsCurrentGesture(gestureVersion))
+		{
+			return;
+		}
+		ShowRadialUI(_startPoint, _activeProfile);
+		ApplyPendingHighlight();
 	}
 
 	private void Hook_OnTriggerButtonUp(object? sender, MouseEventArgs e)
@@ -349,6 +407,8 @@ public class GestureController
 		{
 			return;
 		}
+		_mouseTriggerDown = false;
+		CancelLongPressTimer();
 		if (_isWaitingForThreshold)
 		{
 			CancelGestureTracking();
@@ -553,6 +613,7 @@ public class GestureController
 			{
 				_isWaitingForThreshold = false;
 				_isGestureActive = true;
+				CancelLongPressTimer(); // 拖动先于长按触发
 				string activeWindowProcessName = ActiveWindowHelper.GetActiveWindowProcessName();
 				_activeProfile = ConfigManager.GetProfileForProcess(activeWindowProcessName);
 				Point center = _startPoint;

--- a/WinPieGestures/GestureController.cs
+++ b/WinPieGestures/GestureController.cs
@@ -33,8 +33,13 @@ public class GestureController
 
 	private volatile bool _isGestureActive;
 
-	// 长按触发（可选）：按钮按下期间运行，拖动越过阈值或抬起时取消
-	private System.Windows.Threading.DispatcherTimer? _longPressTimer;
+	// 长按触发（可选）：钩子跑在独立后台线程，用 System.Threading.Timer（不依赖线程 Dispatcher），
+	// 代数(Generation)防止旧回调触发到新手势；激活经主线程 Dispatcher 执行。
+	private System.Threading.Timer? _longPressTimer;
+
+	private int _longPressGeneration;
+
+	private readonly object _longPressLock = new object();
 
 	private bool _mouseTriggerDown;
 
@@ -360,44 +365,78 @@ public class GestureController
 	{
 		CancelLongPressTimer();
 		double delay = ConfigManager.CurrentConfig.LongPressDelayMs > 0.0 ? ConfigManager.CurrentConfig.LongPressDelayMs : 450.0;
-		_longPressTimer = new System.Windows.Threading.DispatcherTimer
+		int generation;
+		lock (_longPressLock)
 		{
-			Interval = TimeSpan.FromMilliseconds(delay)
-		};
-		_longPressTimer.Tick += LongPressTimer_Tick;
-		_longPressTimer.Start();
+			generation = ++_longPressGeneration;
+			_longPressTimer = new System.Threading.Timer(delegate
+			{
+				LongPressTimerCallback(generation);
+			}, null, TimeSpan.FromMilliseconds(delay), System.Threading.Timeout.InfiniteTimeSpan);
+		}
 	}
 
 	private void CancelLongPressTimer()
 	{
-		if (_longPressTimer != null)
+		lock (_longPressLock)
 		{
-			_longPressTimer.Stop();
-			_longPressTimer.Tick -= LongPressTimer_Tick;
-			_longPressTimer = null;
+			_longPressGeneration++;
+			if (_longPressTimer != null)
+			{
+				_longPressTimer.Dispose();
+				_longPressTimer = null;
+			}
 		}
 	}
 
-	/// <summary>长按达阈值：在按下处呼出轮盘（光标仍在中心，移动后再选择）。</summary>
-	private void LongPressTimer_Tick(object? sender, EventArgs e)
+	/// <summary>长按达阈值：在按下处呼出轮盘（光标仍在中心，移动后再选择）。线程池回调 → 主线程 UI。</summary>
+	private void LongPressTimerCallback(int generation)
 	{
-		CancelLongPressTimer();
+		lock (_longPressLock)
+		{
+			if (generation != _longPressGeneration)
+			{
+				return; // 已被取消/替换的旧回调
+			}
+			_longPressTimer = null;
+		}
 		if (!_mouseTriggerDown || !_isWaitingForThreshold || _isGestureActive)
 		{
 			return;
 		}
-		_isWaitingForThreshold = false;
-		_isGestureActive = true;
-		string processName = ActiveWindowHelper.GetActiveWindowProcessName();
-		_activeProfile = ConfigManager.GetProfileForProcess(processName);
-		long gestureVersion = GetCurrentGestureVersion();
-		ProcessMove(_startPoint);
-		if (!_isGestureActive || !IsCurrentGesture(gestureVersion))
+		try
 		{
-			return;
+			_isWaitingForThreshold = false;
+			_isGestureActive = true;
+			string processName = ActiveWindowHelper.GetActiveWindowProcessName();
+			WheelProfile profile = ConfigManager.GetProfileForProcess(processName);
+			long gestureVersion = GetCurrentGestureVersion();
+			Point startPoint = _startPoint;
+			((DispatcherObject)Application.Current).Dispatcher.BeginInvoke((Delegate)(Action)delegate
+			{
+				try
+				{
+					if (!_isGestureActive || !IsCurrentGesture(gestureVersion))
+					{
+						return;
+					}
+					ShowRadialUI(startPoint, profile);
+					ApplyPendingHighlight();
+				}
+				catch
+				{
+					// 激活失败：恢复状态，保证拖拽等其它触发途径不受影响
+					_isWaitingForThreshold = true;
+					_isGestureActive = false;
+				}
+			}, (DispatcherPriority)6, Array.Empty<object>());
 		}
-		ShowRadialUI(_startPoint, _activeProfile);
-		ApplyPendingHighlight();
+		catch
+		{
+			// 预检/分派失败：恢复状态
+			_isWaitingForThreshold = true;
+			_isGestureActive = false;
+		}
 	}
 
 	private void Hook_OnTriggerButtonUp(object? sender, MouseEventArgs e)

--- a/WinPieGestures/I18n.cs
+++ b/WinPieGestures/I18n.cs
@@ -990,6 +990,20 @@ public static class I18n
 			[LanguageCode.En] = "Supports one-click physical recording for all mouse buttons (Right, Middle, Side 1/2) and keyboard keys (CapsLock, ~, Space, Letters, F-keys) as well as combos (Alt+Drag, Ctrl+SideButton). Quick clicks naturally pass through native click events.",
 			[LanguageCode.Ja] = "すべてのマウスボタン（右、中央、サイド1/2）およびキーボード単キー（CapsLock、〜、スペース、ファンクションキー）やコンボ（Alt+ドラッグ、Ctrl+サイドキー）の物理録画に対応。短押しクリックは通常通り処理されます。"
 		};
+		dictionary["LongPressTriggerTitle"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "长按触发按键呼出面板 (可选)",
+			[LanguageCode.ZhTw] = "長按觸發按鍵呼叫面板 (可選)",
+			[LanguageCode.En] = "Long-press trigger to open the menu (optional)",
+			[LanguageCode.Ja] = "長押しでメニューを開く (任意)"
+		};
+		dictionary["LongPressTriggerDesc"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "按住触发键不动超过设定时长即呼出轮盘；未达时长松手仍为普通按键。与按住拖动呼出共存。",
+			[LanguageCode.ZhTw] = "按住觸發鍵不動超過設定時長即呼叫輪盤；未達時長鬆手仍為普通按鍵。與按住拖動呼叫共存。",
+			[LanguageCode.En] = "Hold the trigger key still for the configured duration to open the wheel. Releasing early still behaves as a normal key press. Coexists with the drag-to-open gesture.",
+			[LanguageCode.Ja] = "トリガーキーを一定時間押し続けるとホイールが開きます。時間前に離すと通常のキー操作になります。ドラッグで開く動作と共存できます。"
+		};
 		dictionary["BtnRecordTrigger"] = new Dictionary<LanguageCode, string>
 		{
 			[LanguageCode.ZhCn] = "\ud83d\udd34 点击录制触发键 / 组合键",

--- a/WinPieGestures/SettingsWindow.xaml
+++ b/WinPieGestures/SettingsWindow.xaml
@@ -536,6 +536,26 @@
                       <TextBlock Name="LiveSensorStatusText" Grid.Column="1" AutomationProperties.AutomationId="LiveSensorStatusText" Text="💡 硬件感知器已就绪：随时按下鼠标任意侧键、中键或键盘按键，此处将实时高亮反馈对应按键与键码。" FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}" VerticalAlignment="Center" TextWrapping="Wrap" />
                     </Grid>
                   </Border>
+                  <Border Background="{DynamicResource SubtleCardBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="8" Padding="12,10" Margin="0,10,0,0">
+                    <StackPanel>
+                      <CheckBox Name="LongPressTriggerCheckBox" Style="{StaticResource ToggleSwitchStyle}" Checked="LongPressTriggerCheckBox_Changed" Unchecked="LongPressTriggerCheckBox_Changed">
+                        <StackPanel Margin="6,0,0,0">
+                          <TextBlock Name="LongPressTriggerTitleText" Text="长按触发按键呼出面板 (可选)" FontWeight="Medium" Foreground="{DynamicResource TextPrimaryBrush}" />
+                          <TextBlock Name="LongPressTriggerDescText" Text="按住触发键不动超过设定时长即呼出轮盘；未达时长松手仍为普通按键。与按住拖动呼出共存。" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,2,0,0" TextWrapping="Wrap" />
+                        </StackPanel>
+                      </CheckBox>
+                      <StackPanel Name="LongPressDelayPanel" Margin="22,8,0,0">
+                        <Grid>
+                          <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="64" />
+                          </Grid.ColumnDefinitions>
+                          <Slider Name="LongPressDelaySlider" Minimum="200" Maximum="1000" Value="450" TickFrequency="50" IsSnapToTickEnabled="True" VerticalAlignment="Center" ValueChanged="LongPressDelaySlider_ValueChanged" />
+                          <TextBlock Name="LongPressDelayLabel" Grid.Column="1" Text="450 ms" FontWeight="Bold" Foreground="{DynamicResource AccentPrimaryBrush}" FontSize="13" HorizontalAlignment="Right" VerticalAlignment="Center" />
+                        </Grid>
+                      </StackPanel>
+                    </StackPanel>
+                  </Border>
                 </StackPanel>
               </Border>
               <Border Background="{DynamicResource CardBackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="12" Padding="20" Margin="0,0,0,14">

--- a/WinPieGestures/SettingsWindow.xaml.cs
+++ b/WinPieGestures/SettingsWindow.xaml.cs
@@ -340,6 +340,22 @@ public partial class SettingsWindow : Window
 		// Threshold & Outer Escape
 		ThresholdSlider.Value = ConfigManager.CurrentConfig.DragThreshold;
 		ThresholdValueLabel.Text = ConfigManager.CurrentConfig.DragThreshold.ToString("0");
+		if (LongPressTriggerCheckBox != null)
+		{
+			LongPressTriggerCheckBox.IsChecked = ConfigManager.CurrentConfig.LongPressTrigger;
+		}
+		if (LongPressDelaySlider != null)
+		{
+			LongPressDelaySlider.Value = ConfigManager.CurrentConfig.LongPressDelayMs > 0.0 ? ConfigManager.CurrentConfig.LongPressDelayMs : 450.0;
+		}
+		if (LongPressDelayLabel != null)
+		{
+			LongPressDelayLabel.Text = $"{LongPressDelaySlider.Value:0} ms";
+		}
+		if (LongPressDelayPanel != null)
+		{
+			LongPressDelayPanel.Visibility = ConfigManager.CurrentConfig.LongPressTrigger ? Visibility.Visible : Visibility.Collapsed;
+		}
 		if (EnableOuterEscapeCheckBox != null)
 		{
 			EnableOuterEscapeCheckBox.IsChecked = ConfigManager.CurrentConfig.EnableOuterEscapeCancel;
@@ -822,6 +838,14 @@ public partial class SettingsWindow : Window
 		if (TriggerPageHeader != null)
 		{
 			TriggerPageHeader.Text = I18n.T("TriggerHeader");
+		}
+		if (LongPressTriggerTitleText != null)
+		{
+			LongPressTriggerTitleText.Text = I18n.T("LongPressTriggerTitle");
+		}
+		if (LongPressTriggerDescText != null)
+		{
+			LongPressTriggerDescText.Text = I18n.T("LongPressTriggerDesc");
 		}
 		if (TriggerPageSubheader != null)
 		{
@@ -6420,6 +6444,35 @@ public partial class SettingsWindow : Window
 			}
 			SyncUiToConfigAndSave();
 		}
+	}
+
+	private void LongPressTriggerCheckBox_Changed(object sender, RoutedEventArgs e)
+	{
+		if (_isUpdatingUi || ConfigManager.CurrentConfig == null)
+		{
+			return;
+		}
+		bool enabled = LongPressTriggerCheckBox.IsChecked == true;
+		ConfigManager.CurrentConfig.LongPressTrigger = enabled;
+		if (LongPressDelayPanel != null)
+		{
+			LongPressDelayPanel.Visibility = enabled ? Visibility.Visible : Visibility.Collapsed;
+		}
+		SyncUiToConfigAndSave();
+	}
+
+	private void LongPressDelaySlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+	{
+		if (_isUpdatingUi || ConfigManager.CurrentConfig == null)
+		{
+			return;
+		}
+		ConfigManager.CurrentConfig.LongPressDelayMs = e.NewValue;
+		if (LongPressDelayLabel != null)
+		{
+			LongPressDelayLabel.Text = $"{e.NewValue:0} ms";
+		}
+		SyncUiToConfigAndSave();
 	}
 
 		private void HotkeyBuilderButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION

## 可选「长按触发键呼出面板」
- 新增 `AppConfig.LongPressTrigger` / `LongPressDelayMs`（默认关闭，200–1000ms）；
- 设置 → 触发与场景 → 「轮盘唤醒触发按键 & 组合键录制」卡片内新增开关 + 时长滑块；
- 行为：
  - 按住触发键**不动超过设定时长** → 在按下处呼出轮盘，无需拖动；
  - **与按住拖动呼出共存**（拖动越过阈值优先，自动取消长按计时）；
  - 未达时长松手 = 普通按键透传；
- 实现注意：鼠标钩子运行在**独立后台线程**，长按计时采用线程安全的 `System.Threading.Timer`，不影响既有拖拽触发。

## 改动文件
- `RadialWindow.xaml.cs`：`GetFanSubOffsetForShape` + 渲染/几何
- `GestureController.cs`：长按计时与激活、命中判定同步形态感知
- `AppConfig.cs`：长按配置字段
- `SettingsWindow.xaml(.cs)`：长按开关 + 时长滑块、加载/保存/本地化
- `I18n.cs`：长按相关词条 × 4 语言
- `SettingsWindow.xaml.cs`：预览改用形态感知偏移

## 测试
- [x] `dotnet build -c Release` 0 错误
- [x] 长按 0.5s 呼出；拖动仍正常；轻点仍透传右键；关闭后旧方式不受影响
- [x] 设置面板实时预览与真实轮盘一致