### PR TITLE
fix: 优化轮盘生命周期与任务栏快照刷新并发模型

### DIFF
--- a/WinPieGestures/GestureController.cs
+++ b/WinPieGestures/GestureController.cs
@@ -420,8 +420,10 @@ public class GestureController
 					{
 						return;
 					}
-					ShowRadialUI(startPoint, profile);
-					ApplyPendingHighlight();
+					if (ShowRadialUI(startPoint, profile, gestureVersion))
+					{
+						ApplyPendingHighlight();
+					}
 				}
 				catch
 				{
@@ -694,8 +696,10 @@ public class GestureController
 					{
 						return;
 					}
-					ShowRadialUI(center, profile);
-					ApplyPendingHighlight();
+					if (ShowRadialUI(center, profile, gestureVersion))
+					{
+						ApplyPendingHighlight();
+					}
 				}, (DispatcherPriority)7, Array.Empty<object>());
 			}
 		}
@@ -798,52 +802,77 @@ if (ConfigManager.CurrentConfig.SubmenuStyle == "Fan")
 		QueueHighlightUpdate(num4, num5, flag, flag2, GetCurrentGestureVersion());
 	}
 
-	private static int s_prefetchScheduled;
-
-	private void ShowRadialUI(Point center, WheelProfile profile)
+	private bool ShowRadialUI(Point center, WheelProfile profile, long gestureVersion)
 	{
-		// 线程池轻量预热任务栏槽位快照：防抖与非阻塞调度
+		// 预加载的线程调度与 single-flight 统一由 WindowTaskbarHelper 管理。
 		try
 		{
-			if (Interlocked.CompareExchange(ref s_prefetchScheduled, 1, 0) == 0)
-			{
-				ThreadPool.QueueUserWorkItem(delegate
-				{
-					try
-					{
-						WindowTaskbarHelper.Prefetch();
-					}
-					catch
-					{
-					}
-					finally
-					{
-						Interlocked.Exchange(ref s_prefetchScheduled, 0);
-					}
-				});
-			}
+			WindowTaskbarHelper.Prefetch();
 		}
 		catch
 		{
 		}
-		RadialWindow? oldWindow;
+
+		// 构造过程可能同步读取缓存图标，必须在手势状态锁外执行。
 		RadialWindow newWindow = new RadialWindow(center, profile);
+		RadialWindow? previousWindow;
+		bool shouldPublish;
 		lock (_uiUpdateSync)
 		{
-			oldWindow = _radialWindow;
-			_radialWindow = newWindow;
+			shouldPublish = _isGestureActive && gestureVersion == _gestureVersion;
+			previousWindow = shouldPublish ? _radialWindow : null;
+			if (shouldPublish)
+			{
+				_radialWindow = newWindow;
+			}
 		}
-		if (oldWindow != null)
+
+		if (!shouldPublish)
 		{
 			try
 			{
-				oldWindow.Close();
+				newWindow.Close();
+			}
+			catch
+			{
+			}
+			return false;
+		}
+
+		if (previousWindow != null)
+		{
+			try
+			{
+				previousWindow.Close();
 			}
 			catch
 			{
 			}
 		}
-		newWindow.Show();
+
+		try
+		{
+			newWindow.Show();
+			return true;
+		}
+		catch
+		{
+			lock (_uiUpdateSync)
+			{
+				if (ReferenceEquals(_radialWindow, newWindow))
+				{
+					_radialWindow = null;
+				}
+			}
+			try
+			{
+				newWindow.Close();
+			}
+			catch
+			{
+			}
+			throw;
+		}
 	}
 
 	private void HideRadialUI()

--- a/WinPieGestures/WindowTaskbarHelper.cs
+++ b/WinPieGestures/WindowTaskbarHelper.cs
@@ -189,7 +189,6 @@ public static class WindowTaskbarHelper
 		int MoveWindowToDesktop(nint topLevelWindow, ref Guid desktopId);
 	}
 
-	private static readonly IVirtualDesktopManager? s_vdm = CreateVdm();
 
 	private static IVirtualDesktopManager? CreateVdm()
 	{
@@ -211,6 +210,11 @@ public static class WindowTaskbarHelper
 	/// 过滤：可见、无 owner、非 WS_EX_TOOLWINDOW、排除 StarPie 自身、与所属显示器工作区相交（防离屏"托盘驻留"窗口）、当前虚拟桌面。
 	/// </summary>
 	public static List<nint> GetTaskbarWindows()
+	{
+		return GetTaskbarWindows(CreateVdm());
+	}
+
+	private static List<nint> GetTaskbarWindows(IVirtualDesktopManager? virtualDesktopManager)
 	{
 		List<nint> list = new List<nint>();
 		uint selfPid = SelfPid;
@@ -253,10 +257,10 @@ public static class WindowTaskbarHelper
 						}
 					}
 				}
-				if (s_vdm != null)
+				if (virtualDesktopManager != null)
 				{
 					int onCurrent = 0;
-					if (s_vdm.IsWindowOnCurrentVirtualDesktop(hWnd, out onCurrent) == 0 && onCurrent == 0)
+					if (virtualDesktopManager.IsWindowOnCurrentVirtualDesktop(hWnd, out onCurrent) == 0 && onCurrent == 0)
 					{
 						return true;
 					}
@@ -430,27 +434,67 @@ public static class WindowTaskbarHelper
 		return false;
 	}
 
-	/// <summary>候选运行窗口，按任务栏可见顺序排列（带 TTL 快照缓存：手势内只算一次）。</summary>
+	/// <summary>候选运行窗口，按任务栏可见顺序排列（带 TTL 快照缓存）。
+	/// 非阻塞刷新：已有线程计算时立即返回旧快照，UI 与动作线程不等待 UIA/COM 扫描。</summary>
 	public static List<nint> GetTaskbarOrderedWindows()
 	{
+		DateTime now = DateTime.UtcNow;
 		lock (s_snapshotLock)
 		{
-			if (s_snapshot != null && (DateTime.UtcNow - s_snapshotAt).TotalMilliseconds < SNAPSHOT_TTL_MS)
+			if (s_snapshot != null && (now - s_snapshotAt).TotalMilliseconds < SNAPSHOT_TTL_MS)
 			{
 				return s_snapshot;
 			}
-			s_procDescCache.Clear();
-			s_iconCache.Clear();
-			s_snapshot = ComputeOrderedWindows();
-			s_snapshotAt = DateTime.UtcNow;
-			return s_snapshot;
+		}
+
+		if (!System.Threading.Monitor.TryEnter(s_refreshLock))
+		{
+			lock (s_snapshotLock)
+			{
+				return s_snapshot ?? new List<nint>();
+			}
+		}
+
+		try
+		{
+			now = DateTime.UtcNow;
+			lock (s_snapshotLock)
+			{
+				if (s_snapshot != null && (now - s_snapshotAt).TotalMilliseconds < SNAPSHOT_TTL_MS)
+				{
+					return s_snapshot;
+				}
+			}
+
+			lock (s_procDescCache)
+			{
+				s_procDescCache.Clear();
+			}
+			lock (s_iconCache)
+			{
+				s_iconCache.Clear();
+			}
+
+			// COM 对象在本次刷新调用所在的线程中创建、使用，不再由任意首次调用者静态初始化并跨 Apartment 共享。
+			IVirtualDesktopManager? virtualDesktopManager = CreateVdm();
+			List<nint> computed = ComputeOrderedWindows(virtualDesktopManager);
+			lock (s_snapshotLock)
+			{
+				s_snapshot = computed;
+				s_snapshotAt = DateTime.UtcNow;
+				return s_snapshot;
+			}
+		}
+		finally
+		{
+			System.Threading.Monitor.Exit(s_refreshLock);
 		}
 	}
 
 	/// <summary>实际计算：只保留能对应到任务栏按钮的窗口（鬼窗口丢弃）；同进程多窗口聚合到同一按钮槽位、组内按句柄升序（稳定）。</summary>
-	private static List<nint> ComputeOrderedWindows()
+	private static List<nint> ComputeOrderedWindows(IVirtualDesktopManager? virtualDesktopManager)
 	{
-		List<nint> candidates = GetTaskbarWindows();
+		List<nint> candidates = GetTaskbarWindows(virtualDesktopManager);
 		if (candidates.Count == 0)
 		{
 			return candidates;
@@ -597,16 +641,43 @@ public static class WindowTaskbarHelper
 
 	// ---- 手势级快照缓存（一次手势内：所有槽位图标 + 激活共用一次枚举/UIA/进程读取）----
 	private static readonly object s_snapshotLock = new object();
+	private static readonly object s_refreshLock = new object();
 	private static List<nint>? s_snapshot;
 	private static DateTime s_snapshotAt;
+	private static int s_prefetchRunning;
 	private static readonly Dictionary<uint, string> s_procDescCache = new Dictionary<uint, string>();
 	private static readonly Dictionary<nint, BitmapSource> s_iconCache = new Dictionary<nint, BitmapSource>();
 	private const double SNAPSHOT_TTL_MS = 1500.0;
 
-	/// <summary>后台预热任务栏槽位快照（供下一次手势首帧直接命中缓存）。</summary>
+	/// <summary>在线程池 MTA 中调度一次任务栏快照预热；重复请求合并为一个后台刷新。</summary>
 	public static void Prefetch()
 	{
-		GetTaskbarOrderedWindows();
+		if (System.Threading.Interlocked.CompareExchange(ref s_prefetchRunning, 1, 0) != 0)
+		{
+			return;
+		}
+		try
+		{
+			System.Threading.ThreadPool.QueueUserWorkItem(delegate
+			{
+				try
+				{
+					GetTaskbarOrderedWindows();
+				}
+				catch
+				{
+				}
+				finally
+				{
+					System.Threading.Volatile.Write(ref s_prefetchRunning, 0);
+				}
+			});
+		}
+		catch
+		{
+			System.Threading.Volatile.Write(ref s_prefetchRunning, 0);
+			throw;
+		}
 	}
 
 	/// <summary>


### PR DESCRIPTION
# fix: 优化轮盘生命周期与任务栏快照刷新并发模型

## 背景

本 PR 基于 #43「响应卡滞优化」继续完善轮盘显示、MouseHook 和任务栏窗口预加载之间的并发关系。

原有流程中仍存在以下潜在问题：

1. `RadialWindow` 构造期间，用户可能已经结束当前手势或开始下一次手势，导致过期轮盘继续发布和显示；
2. UI、预加载线程和动作线程可能同时尝试刷新任务栏窗口快照；
3. 阻塞式刷新锁可能使调用线程等待 UI Automation、COM 和窗口枚举完成；
4. 静态 `IVirtualDesktopManager` 由首次访问线程初始化，可能在不同 STA/MTA 之间长期共享；
5. 预加载防重入位于 `GestureController`，无法统一约束其他调用入口。

## 主要修改

### 1. 增加手势版本保护

将 `ShowRadialUI` 调整为接收当前 `gestureVersion`，并在轮盘构造完成后再次确认：

- 当前手势仍处于活动状态；
- 当前版本与开始构造时的版本一致。

核心判断：

    shouldPublish =
        _isGestureActive &&
        gestureVersion == _gestureVersion;

如果构造期间手势已经结束或换代，则关闭新建窗口，不再发布过期轮盘。

同时，仅在轮盘成功发布后调用 `ApplyPendingHighlight()`。

### 2. 缩小 `_uiUpdateSync` 临界区

以下耗时或可能触发 WPF 布局、事件的操作均保持在锁外：

- `new RadialWindow(...)`
- `Window.Show()`
- `Window.Close()`
- SwitchWindow 图标读取
- 任务栏窗口枚举

`_uiUpdateSync` 仅用于：

- 手势版本校验；
- 活动状态检查；
- `_radialWindow` 引用交换；
- 高亮状态的原子更新。

这样可以避免 MouseHook 回调等待完整的轮盘构造或关闭过程。

### 3. 统一任务栏预加载调度

将预加载的 ThreadPool 调度与 single-flight 防重入统一移入 `WindowTaskbarHelper`。

核心逻辑：

    Interlocked.CompareExchange(
        ref s_prefetchRunning,
        1,
        0);

连续触发轮盘时，同一时间最多存在一个任务栏预加载任务，其他请求直接返回。

继续保留 #43 使用 ThreadPool/MTA 执行后台预加载的方向。

### 4. 拆分快照锁与刷新锁

职责划分：

- `s_snapshotLock`：负责快速读取和原子发布窗口快照；
- `s_refreshLock`：负责保证同一时间最多执行一次完整的 UIA、COM 和窗口枚举。

完整的 `ComputeOrderedWindows()` 不再占用快照发布锁。

### 5. 使用非阻塞刷新锁

通过 `Monitor.TryEnter()` 尝试取得刷新权：

    if (!Monitor.TryEnter(s_refreshLock))
    {
        return s_snapshot ?? new List<nint>();
    }

如果其他线程正在刷新：

- 当前线程不等待；
- 立即返回已有快照；
- 没有已有快照时返回空列表，由界面回退到默认图标。

这可以切断 UI 等待后台预加载的阻塞路径。

### 6. 移除静态虚拟桌面 COM 对象

移除静态对象：

    private static readonly
        IVirtualDesktopManager? s_vdm;

改为每次实际获得刷新权后，在本次刷新调用所在的线程中创建和使用局部对象：

    IVirtualDesktopManager? virtualDesktopManager =
        CreateVdm();

    List<nint> computed =
        ComputeOrderedWindows(virtualDesktopManager);

COM 对象不再由任意首次访问线程静态初始化，也不再跨 STA/MTA 长期共享。

最终只向其他线程发布普通的有序 HWND 快照：

    List<nint>

## 修改后的线程关系

    MouseHook 线程
      └─ 短暂使用 _uiUpdateSync
          不访问任务栏锁、UIA 或 COM

    WPF UI 线程
      ├─ 调度后台 Prefetch
      ├─ 锁外构造 RadialWindow
      ├─ 短暂使用 _uiUpdateSync 发布窗口引用
      └─ 刷新繁忙时立即使用旧快照

    ThreadPool MTA
      ├─ single-flight 执行任务栏预加载
      ├─ 非阻塞竞争 s_refreshLock
      ├─ 局部创建 VirtualDesktopManager
      └─ 完成后原子发布新快照

## 保留的 #43 优化

本次修改保留了 #43 中已有的：

- MouseHook/KeyboardHook 响应优化；
- KeyboardHook 独立后台线程；
- 动作后台执行；
- `StarPieExtraInfo` 输入事件标记；
- 修饰键异常时强制释放；
- `OpenProcess + QueryFullProcessImageName`；
- `WM_GETICON` 25ms 超时；
- 自动深度内存压缩移除；
- 日常内存回收温和化。

## 行为兼容性

本次修改不改变：

- 轮盘触发方式；
- 扇区选择规则；
- SwitchWindow 数字参数语义；
- 任务栏窗口排序规则；
- 动作配置格式；
- 动态窗口图标获取方式；
- 现有配置文件Dual结构。

刷新进行期间可能短暂使用旧窗口快照；首次没有快照时，窗口图标会暂时回退为默认图标。

## 编译验证

已通过 Release 编译
