### PR TITLE
feat: 轮盘一键平铺布局

### DIFF
--- a/WinPieGestures/ActionExecutor.cs
+++ b/WinPieGestures/ActionExecutor.cs
@@ -250,6 +250,9 @@ public static class ActionExecutor
 			case "SwitchWindow":
 				ExecuteSwitchWindow(action.Parameter);
 				break;
+			case "Tile":
+				WindowTiler.ExecuteTile(action.Parameter);
+				break;
 			case "Text":
 			case "String":
 				SendTextInput(action.Parameter);

--- a/WinPieGestures/ActionExecutor.cs
+++ b/WinPieGestures/ActionExecutor.cs
@@ -253,6 +253,18 @@ public static class ActionExecutor
 			case "Tile":
 				WindowTiler.ExecuteTile(action.Parameter);
 				break;
+			case "TileRestore":
+				WindowTiler.RestoreLastLayout();
+				break;
+			case "MoveMonitor":
+				WindowTiler.MoveWindowToNextMonitor();
+				break;
+			case "ToggleTopmost":
+				WindowTiler.ToggleWindowTopmost(action.Parameter);
+				break;
+			case "WindowOpacity":
+				WindowTiler.SetWindowOpacity(action.Parameter);
+				break;
 			case "Text":
 			case "String":
 				SendTextInput(action.Parameter);

--- a/WinPieGestures/App.xaml.cs
+++ b/WinPieGestures/App.xaml.cs
@@ -217,6 +217,14 @@ public partial class App : Application
 			return;
 		}
 		AppLogger.LogInfo("=== StarPie Exiting ===");
+		// 退出前自动还原所有窗口到首次平铺前的样式
+		try
+		{
+			WindowTiler.RestoreLastLayout();
+		}
+		catch
+		{
+		}
 		try
 		{
 			_waitHandleRegistration?.Unregister(null);

--- a/WinPieGestures/AppConfig.cs
+++ b/WinPieGestures/AppConfig.cs
@@ -43,6 +43,9 @@ public class AppConfig
 	/// <summary>平铺是否包含最小化窗口（true=还原后参与平铺）。</summary>
 	public bool TileIncludeMinimized { get; set; }
 
+	/// <summary>平铺"循环切换"参与范围：布局 key 逗号分隔（空=全部布局参与循环）。</summary>
+	public string TileCycleLayouts { get; set; } = "";
+
 	public string AnimationSpeed { get; set; } = "Balanced";
 
 	public double CustomAnimationDurationMs { get; set; } = 80.0;

--- a/WinPieGestures/AppConfig.cs
+++ b/WinPieGestures/AppConfig.cs
@@ -37,6 +37,12 @@ public class AppConfig
 
 	public ActionItem CancelAction { get; set; } = new ActionItem { Type = "Hotkey", Name = "取消动作", Parameter = "" };
 
+	/// <summary>平铺排除名单：进程 exe 名（不含扩展名），逗号/分号分隔。</summary>
+	public string TileExcludeProcesses { get; set; } = "";
+
+	/// <summary>平铺是否包含最小化窗口（true=还原后参与平铺）。</summary>
+	public bool TileIncludeMinimized { get; set; }
+
 	public string AnimationSpeed { get; set; } = "Balanced";
 
 	public double CustomAnimationDurationMs { get; set; } = 80.0;

--- a/WinPieGestures/AppConfig.cs
+++ b/WinPieGestures/AppConfig.cs
@@ -32,6 +32,11 @@ public class AppConfig
 	/// <summary>手势段灵敏度：最小段长（像素）。越大越难把中途小拐弯误识别为方向段。</summary>
 	public double GestureSegmentSensitivity { get; set; } = 16.0;
 
+	/// <summary>取消（回到轮盘中心松手且未选中任何动作）后执行的自定义动作；默认关闭=仅关面板不执行。</summary>
+	public bool EnableCancelAction { get; set; }
+
+	public ActionItem CancelAction { get; set; } = new ActionItem { Type = "Hotkey", Name = "取消动作", Parameter = "" };
+
 	public string AnimationSpeed { get; set; } = "Balanced";
 
 	public double CustomAnimationDurationMs { get; set; } = 80.0;

--- a/WinPieGestures/GestureController.cs
+++ b/WinPieGestures/GestureController.cs
@@ -882,6 +882,18 @@ public class GestureController
 						}
 					}
 				}
+				if (targetAction == null)
+				{
+					// 仅"外甩取消"（释放时处于外甩状态且未选中任何动作）时执行自定义取消动作；
+					// 回到中心取消按钮松手仍为默认静默关闭。
+					ActionItem? cancelAction = ConfigManager.CurrentConfig?.CancelAction;
+					if (_lastEscapedState &&
+						ConfigManager.CurrentConfig?.EnableCancelAction == true &&
+						cancelAction != null && !string.IsNullOrEmpty(cancelAction.Type))
+					{
+						targetAction = cancelAction;
+					}
+				}
 				if (targetAction != null)
 				{
 					ActionExecutor.EnqueueAction(targetAction);
@@ -1019,6 +1031,18 @@ public class GestureController
 						{
 							targetAction = actionItem;
 						}
+					}
+				}
+				if (targetAction == null)
+				{
+					// 仅"外甩取消"（释放时处于外甩状态且未选中任何动作）时执行自定义取消动作；
+					// 回到中心取消按钮松手仍为默认静默关闭。
+					ActionItem? cancelAction = ConfigManager.CurrentConfig?.CancelAction;
+					if (_lastEscapedState &&
+						ConfigManager.CurrentConfig?.EnableCancelAction == true &&
+						cancelAction != null && !string.IsNullOrEmpty(cancelAction.Type))
+					{
+						targetAction = cancelAction;
 					}
 				}
 				if (targetAction != null)

--- a/WinPieGestures/GestureMappingViewModel.cs
+++ b/WinPieGestures/GestureMappingViewModel.cs
@@ -83,6 +83,7 @@ public class GestureMappingViewModel : INotifyPropertyChanged
 				OnPropertyChanged(nameof(IsSystemType));
 				OnPropertyChanged(nameof(IsCommandType));
 				OnPropertyChanged(nameof(IsSwitchWindowType));
+				OnPropertyChanged(nameof(IsTileType));
 			}
 		}
 	}
@@ -98,6 +99,39 @@ public class GestureMappingViewModel : INotifyPropertyChanged
 	public bool IsCommandType => Type == "Command";
 
 	public bool IsSwitchWindowType => Type == "SwitchWindow";
+
+	public bool IsTileType => Type == "Tile";
+
+	/// <summary>平铺布局下拉（key → 显示名）。</summary>
+	public List<ActionTypeOption> TileLayoutOptions
+	{
+		get
+		{
+			List<ActionTypeOption> list = new List<ActionTypeOption>();
+			foreach (string key in WindowTiler.LayoutKeys)
+			{
+				list.Add(new ActionTypeOption { Tag = key, DisplayText = WindowTiler.LayoutDisplayName(key) });
+			}
+			return list;
+		}
+	}
+
+	/// <summary>平铺布局（写入 Parameter）。</summary>
+	public string TileLayout
+	{
+		get
+		{
+			return Mapping.Action.Parameter ?? "";
+		}
+		set
+		{
+			if (Mapping.Action.Parameter != value)
+			{
+				Mapping.Action.Parameter = value;
+				OnPropertyChanged(nameof(TileLayout));
+			}
+		}
+	}
 
 	/// <summary>命令动作的终端选项。</summary>
 	public List<ActionTypeItem> Terminals => SlotViewModel.LocalizedTerminals;

--- a/WinPieGestures/GestureMappingViewModel.cs
+++ b/WinPieGestures/GestureMappingViewModel.cs
@@ -109,7 +109,8 @@ public class GestureMappingViewModel : INotifyPropertyChanged
 		{
 			List<ActionTypeOption> list = new List<ActionTypeOption>
 			{
-				new ActionTypeOption { Tag = WindowTiler.CycleParam, DisplayText = "🔄 " + I18n.T("TileCycleLabel") }
+				new ActionTypeOption { Tag = WindowTiler.CycleParam, DisplayText = "🔄 " + I18n.T("TileCycleLabel") },
+				new ActionTypeOption { Tag = WindowTiler.RestoreParam, DisplayText = "⏪ " + I18n.T("TileRestoreAllLabel") }
 			};
 			foreach (string key in WindowTiler.LayoutKeys)
 			{

--- a/WinPieGestures/GestureMappingViewModel.cs
+++ b/WinPieGestures/GestureMappingViewModel.cs
@@ -107,7 +107,10 @@ public class GestureMappingViewModel : INotifyPropertyChanged
 	{
 		get
 		{
-			List<ActionTypeOption> list = new List<ActionTypeOption>();
+			List<ActionTypeOption> list = new List<ActionTypeOption>
+			{
+				new ActionTypeOption { Tag = WindowTiler.CycleParam, DisplayText = "🔄 " + I18n.T("TileCycleLabel") }
+			};
 			foreach (string key in WindowTiler.LayoutKeys)
 			{
 				list.Add(new ActionTypeOption { Tag = key, DisplayText = WindowTiler.LayoutDisplayName(key) });

--- a/WinPieGestures/GestureMappingViewModel.cs
+++ b/WinPieGestures/GestureMappingViewModel.cs
@@ -110,6 +110,7 @@ public class GestureMappingViewModel : INotifyPropertyChanged
 			List<ActionTypeOption> list = new List<ActionTypeOption>
 			{
 				new ActionTypeOption { Tag = WindowTiler.CycleParam, DisplayText = "🔄 " + I18n.T("TileCycleLabel") },
+				new ActionTypeOption { Tag = WindowTiler.CycleBackParam, DisplayText = "⬅️ " + I18n.T("TileCycleBackLabel") },
 				new ActionTypeOption { Tag = WindowTiler.RestoreParam, DisplayText = "⏪ " + I18n.T("TileRestoreAllLabel") }
 			};
 			foreach (string key in WindowTiler.LayoutKeys)

--- a/WinPieGestures/I18n.cs
+++ b/WinPieGestures/I18n.cs
@@ -1074,6 +1074,62 @@ public static class I18n
 			[LanguageCode.En] = "Enable custom outer-escape cancel action",
 			[LanguageCode.Ja] = "外側スワイプキャンセル時のカスタム動作を有効化"
 		};
+		dictionary["ActionTypeTileShort"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "平铺窗口",
+			[LanguageCode.ZhTw] = "平鋪視窗",
+			[LanguageCode.En] = "Tile Windows",
+			[LanguageCode.Ja] = "ウィンドウを並べる"
+		};
+		dictionary["TileLayout2L"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "左右对半",
+			[LanguageCode.ZhTw] = "左右對半",
+			[LanguageCode.En] = "Left-Right",
+			[LanguageCode.Ja] = "左右分割"
+		};
+		dictionary["TileLayout2T"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "上下对半",
+			[LanguageCode.ZhTw] = "上下對半",
+			[LanguageCode.En] = "Top-Bottom",
+			[LanguageCode.Ja] = "上下分割"
+		};
+		dictionary["TileLayout3L12"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "左大列 + 右上/右下",
+			[LanguageCode.ZhTw] = "左大列 + 右上/右下",
+			[LanguageCode.En] = "Big Left + Right Two",
+			[LanguageCode.Ja] = "左大＋右二"
+		};
+		dictionary["TileLayout3R21"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "右大列 + 左上/左下",
+			[LanguageCode.ZhTw] = "右大列 + 左上/左下",
+			[LanguageCode.En] = "Big Right + Left Two",
+			[LanguageCode.Ja] = "右大＋左二"
+		};
+		dictionary["TileLayout3R"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "三等分竖列",
+			[LanguageCode.ZhTw] = "三等分豎列",
+			[LanguageCode.En] = "Three Columns",
+			[LanguageCode.Ja] = "3等分列"
+		};
+		dictionary["TileLayout4G"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "四宫格 2×2",
+			[LanguageCode.ZhTw] = "四宮格 2×2",
+			[LanguageCode.En] = "2×2 Grid",
+			[LanguageCode.Ja] = "2×2 グリッド"
+		};
+		dictionary["TileLayout6G"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "六宫格 3×2",
+			[LanguageCode.ZhTw] = "六宮格 3×2",
+			[LanguageCode.En] = "3×2 Grid",
+			[LanguageCode.Ja] = "3×2 グリッド"
+		};
 		dictionary["GestureMappingTitleText"] = new Dictionary<LanguageCode, string>
 		{
 			[LanguageCode.ZhCn] = "手势图样映射",

--- a/WinPieGestures/I18n.cs
+++ b/WinPieGestures/I18n.cs
@@ -1193,6 +1193,13 @@ public static class I18n
 			[LanguageCode.En] = "Tiling exclusion list (process exe names, comma-separated, e.g. notepad,spotify):",
 			[LanguageCode.Ja] = "並べる対象外のプロセス（exe名、カンマ区切り例 notepad,spotify）："
 		};
+		dictionary["TileRestoreAllLabel"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "还原所有窗口（回到平铺前）",
+			[LanguageCode.ZhTw] = "還原所有視窗（回到平鋪前）",
+			[LanguageCode.En] = "Restore all windows (pre-tile state)",
+			[LanguageCode.Ja] = "すべてのウィンドウを元に戻す（並べる前の状態）"
+		};
 		dictionary["GestureMappingTitleText"] = new Dictionary<LanguageCode, string>
 		{
 			[LanguageCode.ZhCn] = "手势图样映射",

--- a/WinPieGestures/I18n.cs
+++ b/WinPieGestures/I18n.cs
@@ -1130,6 +1130,69 @@ public static class I18n
 			[LanguageCode.En] = "3×2 Grid",
 			[LanguageCode.Ja] = "3×2 グリッド"
 		};
+		dictionary["ActionTypeTileRestoreShort"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "恢复上次平铺",
+			[LanguageCode.ZhTw] = "還原上次平鋪",
+			[LanguageCode.En] = "Restore Tiles",
+			[LanguageCode.Ja] = "前の配置に戻す"
+		};
+		dictionary["ActionTypeMoveMonitorShort"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "窗口移到下一屏",
+			[LanguageCode.ZhTw] = "視窗移到下一螢幕",
+			[LanguageCode.En] = "Move to Next Monitor",
+			[LanguageCode.Ja] = "次のモニターへ移動"
+		};
+		dictionary["ActionTypeTopmostShort"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "窗口置顶/取消置顶",
+			[LanguageCode.ZhTw] = "視窗置頂/取消置頂",
+			[LanguageCode.En] = "Toggle Always-on-Top",
+			[LanguageCode.Ja] = "最前面表示の切替"
+		};
+		dictionary["ActionTypeOpacityShort"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "窗口透明度",
+			[LanguageCode.ZhTw] = "視窗透明度",
+			[LanguageCode.En] = "Window Opacity",
+			[LanguageCode.Ja] = "ウィンドウの透明度"
+		};
+		dictionary["TileCycleLabel"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "循环切换布局",
+			[LanguageCode.ZhTw] = "循環切換佈局",
+			[LanguageCode.En] = "Cycle layouts",
+			[LanguageCode.Ja] = "レイアウトを順番に切替"
+		};
+		dictionary["TileGlobalTitleText"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "平铺窗口设置",
+			[LanguageCode.ZhTw] = "平鋪視窗設定",
+			[LanguageCode.En] = "Tiling Settings",
+			[LanguageCode.Ja] = "タイリング設定"
+		};
+		dictionary["TileGlobalDescText"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "「平铺窗口」动作的全局行为。",
+			[LanguageCode.ZhTw] = "「平鋪視窗」動作的全域行為。",
+			[LanguageCode.En] = "Global behaviour of the Tile Windows action.",
+			[LanguageCode.Ja] = "「ウィンドウを並べる」アクションの全体挙動です。"
+		};
+		dictionary["TileMinimizeText"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "包含最小化窗口（还原后参与平铺）",
+			[LanguageCode.ZhTw] = "包含最小化視窗（還原後參與平鋪）",
+			[LanguageCode.En] = "Include minimized windows (restore into the layout)",
+			[LanguageCode.Ja] = "最小化ウィンドウも含める（復元して配置）"
+		};
+		dictionary["TileExcludeText"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "平铺排除名单（进程 exe 名，逗号分隔，如 notepad,spotify）：",
+			[LanguageCode.ZhTw] = "平鋪排除名單（程序 exe 名，逗號分隔，如 notepad,spotify）：",
+			[LanguageCode.En] = "Tiling exclusion list (process exe names, comma-separated, e.g. notepad,spotify):",
+			[LanguageCode.Ja] = "並べる対象外のプロセス（exe名、カンマ区切り例 notepad,spotify）："
+		};
 		dictionary["GestureMappingTitleText"] = new Dictionary<LanguageCode, string>
 		{
 			[LanguageCode.ZhCn] = "手势图样映射",

--- a/WinPieGestures/I18n.cs
+++ b/WinPieGestures/I18n.cs
@@ -1235,6 +1235,48 @@ public static class I18n
 			[LanguageCode.En] = "Master Bottom + Stack",
 			[LanguageCode.Ja] = "マスター下＋スタック"
 		};
+		dictionary["TileLayoutMO"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "单窗全屏 (Monocle)",
+			[LanguageCode.ZhTw] = "單窗全螢幕 (Monocle)",
+			[LanguageCode.En] = "Monocle",
+			[LanguageCode.Ja] = "モノクル（全画面）"
+		};
+		dictionary["TileLayoutHS"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "上主 50% + 下栈 (H-Stack)",
+			[LanguageCode.ZhTw] = "上主 50% + 下棧 (H-Stack)",
+			[LanguageCode.En] = "Master Top + Stack (H-Stack)",
+			[LanguageCode.Ja] = "上マスター＋下スタック"
+		};
+		dictionary["TileLayoutVS"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "左主 50% + 右栈 (V-Stack)",
+			[LanguageCode.ZhTw] = "左主 50% + 右棧 (V-Stack)",
+			[LanguageCode.En] = "Master Left + Stack (V-Stack)",
+			[LanguageCode.Ja] = "左マスター＋右スタック"
+		};
+		dictionary["TileLayoutCOL"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "等宽竖列 (Columns)",
+			[LanguageCode.ZhTw] = "等寬豎列 (Columns)",
+			[LanguageCode.En] = "Columns",
+			[LanguageCode.Ja] = "等幅カラム"
+		};
+		dictionary["TileLayoutBSP"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "二叉分割 (BSP)",
+			[LanguageCode.ZhTw] = "二叉分割 (BSP)",
+			[LanguageCode.En] = "Binary Split (BSP)",
+			[LanguageCode.Ja] = "二分木分割 (BSP)"
+		};
+		dictionary["TileLayoutAG"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "自适应网格 (A-Grid)",
+			[LanguageCode.ZhTw] = "自適應網格 (A-Grid)",
+			[LanguageCode.En] = "Auto Grid",
+			[LanguageCode.Ja] = "自動グリッド"
+		};
 		dictionary["TileCycleRangeText"] = new Dictionary<LanguageCode, string>
 		{
 			[LanguageCode.ZhCn] = "循环切换范围（布局 key 逗号分隔，空=全部，如 2L,2T,4G,ML）：",

--- a/WinPieGestures/I18n.cs
+++ b/WinPieGestures/I18n.cs
@@ -1053,6 +1053,27 @@ public static class I18n
 			[LanguageCode.En] = "Gesture segment sensitivity:",
 			[LanguageCode.Ja] = "ジェスチャー感度："
 		};
+		dictionary["CancelActionTitleText"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "外甩取消时执行的动作",
+			[LanguageCode.ZhTw] = "外甩取消時執行的動作",
+			[LanguageCode.En] = "Action on Outer-Escape Cancel",
+			[LanguageCode.Ja] = "外側スワイプキャンセル時の動作"
+		};
+		dictionary["CancelActionDescText"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "仅当通过「外甩取消」（向外甩出且未选中任何动作）时执行这个自定义动作；回到中心取消按钮松手仍为默认静默关闭。",
+			[LanguageCode.ZhTw] = "僅當透過「外甩取消」（向外甩出且未選中任何動作）時執行這個自訂動作；回到中心取消按鈕鬆手仍為預設靜默關閉。",
+			[LanguageCode.En] = "Only when you cancel by flinging outward (nothing selected) does this custom action run; releasing over the center cancel button still just closes the menu silently.",
+			[LanguageCode.Ja] = "外側へフリックしてキャンセルした場合（何も選択していない）のみカスタムアクションを実行します。中央のキャンセルで離すと従来通りサイレントクローズします。"
+		};
+		dictionary["CancelActionEnableText"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "启用自定义外甩取消动作",
+			[LanguageCode.ZhTw] = "啟用自訂外甩取消動作",
+			[LanguageCode.En] = "Enable custom outer-escape cancel action",
+			[LanguageCode.Ja] = "外側スワイプキャンセル時のカスタム動作を有効化"
+		};
 		dictionary["GestureMappingTitleText"] = new Dictionary<LanguageCode, string>
 		{
 			[LanguageCode.ZhCn] = "手势图样映射",

--- a/WinPieGestures/I18n.cs
+++ b/WinPieGestures/I18n.cs
@@ -1200,6 +1200,48 @@ public static class I18n
 			[LanguageCode.En] = "Restore all windows (pre-tile state)",
 			[LanguageCode.Ja] = "すべてのウィンドウを元に戻す（並べる前の状態）"
 		};
+		dictionary["TileCycleBackLabel"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "循环返回",
+			[LanguageCode.ZhTw] = "循環返回",
+			[LanguageCode.En] = "Cycle previous",
+			[LanguageCode.Ja] = "前のレイアウトへ"
+		};
+		dictionary["TileLayoutML"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "主窗居左 + 右栈",
+			[LanguageCode.ZhTw] = "主窗居左 + 右棧",
+			[LanguageCode.En] = "Master Left + Stack",
+			[LanguageCode.Ja] = "マスター左＋スタック"
+		};
+		dictionary["TileLayoutMR"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "主窗居右 + 左栈",
+			[LanguageCode.ZhTw] = "主窗居右 + 左棧",
+			[LanguageCode.En] = "Master Right + Stack",
+			[LanguageCode.Ja] = "マスター右＋スタック"
+		};
+		dictionary["TileLayoutMT"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "主窗居上 + 下栈",
+			[LanguageCode.ZhTw] = "主窗居上 + 下棧",
+			[LanguageCode.En] = "Master Top + Stack",
+			[LanguageCode.Ja] = "マスター上＋スタック"
+		};
+		dictionary["TileLayoutMB"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "主窗居下 + 上栈",
+			[LanguageCode.ZhTw] = "主窗居下 + 上棧",
+			[LanguageCode.En] = "Master Bottom + Stack",
+			[LanguageCode.Ja] = "マスター下＋スタック"
+		};
+		dictionary["TileCycleRangeText"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "循环切换范围（布局 key 逗号分隔，空=全部，如 2L,2T,4G,ML）：",
+			[LanguageCode.ZhTw] = "循環切換範圍（佈局 key 逗號分隔，空=全部，如 2L,2T,4G,ML）：",
+			[LanguageCode.En] = "Cycle range (layout keys, comma-separated; empty = all, e.g. 2L,2T,4G,ML):",
+			[LanguageCode.Ja] = "循環切替範囲（レイアウトキーをカンマ区切り。空=全て。例 2L,2T,4G,ML）："
+		};
 		dictionary["GestureMappingTitleText"] = new Dictionary<LanguageCode, string>
 		{
 			[LanguageCode.ZhCn] = "手势图样映射",

--- a/WinPieGestures/IconHelper.cs
+++ b/WinPieGestures/IconHelper.cs
@@ -89,6 +89,13 @@ public static class IconHelper
 			},
 			new VectorIconItem
 			{
+				Key = "Tile",
+				Category = "窗口管理",
+				DisplayName = "平铺窗口 (Tile)",
+				SvgData = "M3,3H11V11H3Z M13,3H21V11H13Z M3,13H11V21H3Z M13,13H21V21H13Z"
+			},
+			new VectorIconItem
+			{
 				Key = "Copy",
 				Category = "编辑与剪贴板",
 				DisplayName = "复制 (Copy)",

--- a/WinPieGestures/SettingsWindow.xaml
+++ b/WinPieGestures/SettingsWindow.xaml
@@ -1897,8 +1897,26 @@
                   </CheckBox>
                   <TextBlock Name="TileExcludeText" Text="平铺排除名单（进程 exe 名，逗号分隔，如 notepad,spotify）：" FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,0,0,6" />
                   <TextBox Name="TileExcludeProcessesTextBox" Height="32" FontSize="12" VerticalContentAlignment="Center" Padding="8,0" TextChanged="TileExcludeProcessesTextBox_TextChanged" />
-                  <TextBlock Name="TileCycleRangeText" Text="循环切换范围（布局 key 逗号分隔，空=全部）：" FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,10,0,6" />
-                  <TextBox Name="TileCycleLayoutsTextBox" Height="32" FontSize="12" VerticalContentAlignment="Center" Padding="8,0" TextChanged="TileCycleLayoutsTextBox_TextChanged" />
+                  <TextBlock Name="TileCycleRangeText" Text="循环切换布局（勾选参与项，▲▼ 调顺序；不勾任何项=全部参与）：" FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,10,0,6" />
+                  <Grid>
+                    <Grid.ColumnDefinitions>
+                      <ColumnDefinition Width="*" />
+                      <ColumnDefinition Width="42" />
+                    </Grid.ColumnDefinitions>
+                    <ListBox Name="TileCycleListBox" Height="168" SelectionMode="Single" BorderThickness="0" Background="Transparent" ScrollViewer.VerticalScrollBarVisibility="Auto">
+                      <ListBox.ItemTemplate>
+                        <DataTemplate>
+                          <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay}" Content="{Binding Display}" FontSize="12" Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
+                        </DataTemplate>
+                      </ListBox.ItemTemplate>
+                    </ListBox>
+                    <StackPanel Grid.Column="1" Margin="6,0,0,0">
+                      <Button Content="▲" Height="28" Width="36" Padding="0" FontSize="11" Style="{StaticResource ModernButtonStyle}" Click="TileCycleUp_Click" ToolTip="上移" />
+                      <Button Content="▼" Height="28" Width="36" Padding="0" FontSize="11" Margin="0,4,0,0" Style="{StaticResource ModernButtonStyle}" Click="TileCycleDown_Click" ToolTip="下移" />
+                      <Button Content="全" Height="26" Width="36" Padding="0" FontSize="10" Margin="0,6,0,0" Style="{StaticResource ModernButtonStyle}" Click="TileCycleAll_Click" ToolTip="全部参与循环" />
+                      <Button Content="空" Height="26" Width="36" Padding="0" FontSize="10" Margin="0,4,0,0" Style="{StaticResource ModernButtonStyle}" Click="TileCycleNone_Click" ToolTip="清空（等效全部参与）" />
+                    </StackPanel>
+                  </Grid>
                 </StackPanel>
               </Border>
             </StackPanel>

--- a/WinPieGestures/SettingsWindow.xaml
+++ b/WinPieGestures/SettingsWindow.xaml
@@ -766,6 +766,59 @@
                       </StackPanel>
                     </Border>
                   </StackPanel>
+                  <Border BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="0,1,0,0" Padding="0,12,0,0">
+                    <StackPanel>
+                      <TextBlock Name="CancelActionTitleText" Text="外甩取消时执行的动作" FontSize="13.5" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
+                      <TextBlock Name="CancelActionDescText" Text="外甩取消（未选中任何动作）时可执行一个自定义动作代替静默关闭；需先开启上方「顺势外甩取消」。回到中心取消仍为静默关闭，不受此影响。" FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,2,0,8" TextWrapping="Wrap" />
+                      <CheckBox Name="EnableCancelActionCheckBox" Style="{StaticResource ToggleSwitchStyle}" Margin="0,0,0,8" Checked="EnableCancelActionCheckBox_Changed" Unchecked="EnableCancelActionCheckBox_Changed">
+                        <StackPanel Margin="6,0,0,0">
+                          <TextBlock Name="CancelActionEnableText" Text="外甩取消时执行自定义动作" FontWeight="Medium" Foreground="{DynamicResource TextPrimaryBrush}" />
+                          <TextBlock Text="关闭则外甩取消仍为静默关闭。" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,2,0,0" />
+                        </StackPanel>
+                      </CheckBox>
+                      <ContentControl Name="CancelActionEditorHost">
+                        <Grid>
+                          <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="110" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="90" />
+                          </Grid.ColumnDefinitions>
+                          <ComboBox Grid.Column="0" Height="30" FontSize="11" ItemsSource="{Binding ActionTypes}" SelectedValuePath="Tag" DisplayMemberPath="DisplayText" SelectedValue="{Binding Type, Mode=TwoWay}" Style="{StaticResource FlatComboBoxStyle}" />
+                          <Grid Grid.Column="1" Margin="4,0,0,0">
+                            <local:HotkeyRecorderBox Height="30" FontSize="11" HotkeyText="{Binding Parameter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Visibility="{Binding IsHotkeyType, Converter={StaticResource BoolToVis}}" />
+                            <Grid Visibility="{Binding IsLaunchType, Converter={StaticResource BoolToVis}}">
+                              <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="36" />
+                              </Grid.ColumnDefinitions>
+                              <TextBox Text="{Binding Parameter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="30" FontSize="11" VerticalContentAlignment="Center" IsReadOnly="True" />
+                              <Button Grid.Column="1" Content="📁" Height="30" Width="34" Margin="4,0,0,0" Padding="0" FontSize="12" Style="{StaticResource ModernButtonStyle}" Click="GestureBrowse_Click" ToolTip="选择应用程序..." />
+                            </Grid>
+                            <Grid Visibility="{Binding IsFolderType, Converter={StaticResource BoolToVis}}">
+                              <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="36" />
+                              </Grid.ColumnDefinitions>
+                              <TextBox Text="{Binding Parameter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="30" FontSize="11" VerticalContentAlignment="Center" />
+                              <Button Grid.Column="1" Content="📂" Height="30" Width="34" Margin="4,0,0,0" Padding="0" FontSize="12" Style="{StaticResource ModernButtonStyle}" Click="GestureBrowseFolder_Click" ToolTip="选择本地文件夹..." />
+                            </Grid>
+                            <ComboBox SelectedValuePath="Key" DisplayMemberPath="Value" Style="{StaticResource FlatComboBoxStyle}" Height="30" FontSize="11" SelectedValue="{Binding SelectedSystemPreset, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ItemsSource="{Binding Source={x:Static local:SlotViewModel.SystemPresets}}" Visibility="{Binding IsSystemType, Converter={StaticResource BoolToVis}}" />
+                            <Grid Visibility="{Binding IsCommandType, Converter={StaticResource BoolToVis}}">
+                              <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="112" />
+                              </Grid.ColumnDefinitions>
+                              <TextBox Text="{Binding Parameter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="30" FontSize="11" VerticalContentAlignment="Center" />
+                              <ComboBox Grid.Column="1" Width="108" Margin="4,0,0,0" ItemsSource="{Binding Terminals}" SelectedValuePath="Tag" DisplayMemberPath="DisplayText" SelectedValue="{Binding CommandTerminal, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FlatComboBoxStyle}" Height="30" FontSize="10" />
+                            </Grid>
+                            <TextBox Text="{Binding NthWindowIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="30" FontSize="11" VerticalContentAlignment="Center" Visibility="{Binding IsSwitchWindowType, Converter={StaticResource BoolToVis}}" />
+                          </Grid>
+                          <TextBox Grid.Column="2" Height="30" FontSize="11" Margin="4,0,0,0" VerticalContentAlignment="Center" Text="{Binding Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ToolTip="名称（可选）" />
+                        </Grid>
+                      </ContentControl>
+                      <Button Name="TestCancelActionButton" Content="🧪 测试" Height="30" Padding="12,0" Margin="0,8,0,0" HorizontalAlignment="Left" Style="{StaticResource ModernButtonStyle}" Click="TestCancelAction_Click" />
+                    </StackPanel>
+                  </Border>
                 </StackPanel>
               </Border>
               <Border Background="{DynamicResource CardBackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="12" Padding="20" Margin="0,0,0,14">

--- a/WinPieGestures/SettingsWindow.xaml
+++ b/WinPieGestures/SettingsWindow.xaml
@@ -813,7 +813,14 @@
                               <ComboBox Grid.Column="1" Width="108" Margin="4,0,0,0" ItemsSource="{Binding Terminals}" SelectedValuePath="Tag" DisplayMemberPath="DisplayText" SelectedValue="{Binding CommandTerminal, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FlatComboBoxStyle}" Height="30" FontSize="10" />
                             </Grid>
                             <TextBox Text="{Binding NthWindowIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="30" FontSize="11" VerticalContentAlignment="Center" Visibility="{Binding IsSwitchWindowType, Converter={StaticResource BoolToVis}}" />
-                            <ComboBox SelectedValuePath="Tag" DisplayMemberPath="DisplayText" ItemsSource="{Binding TileLayoutOptions}" SelectedValue="{Binding TileLayout, Mode=TwoWay}" Style="{StaticResource FlatComboBoxStyle}" Height="30" FontSize="11" Visibility="{Binding IsTileType, Converter={StaticResource BoolToVis}}" ToolTip="平铺布局预设" />
+                              <Grid Visibility="{Binding IsTileType, Converter={StaticResource BoolToVis}}">
+                                <Grid.ColumnDefinitions>
+                                  <ColumnDefinition Width="*" />
+                                  <ColumnDefinition Width="34" />
+                                </Grid.ColumnDefinitions>
+                                <ComboBox SelectedValuePath="Tag" DisplayMemberPath="DisplayText" ItemsSource="{Binding TileLayoutOptions}" SelectedValue="{Binding TileLayout, Mode=TwoWay}" Style="{StaticResource FlatComboBoxStyle}" Height="30" FontSize="11" ToolTip="平铺布局预设（含循环切换）" />
+                                <Button Grid.Column="1" Content="⇅" Height="30" Width="32" Margin="4,0,0,0" Padding="0" FontSize="12" Style="{StaticResource ModernButtonStyle}" Click="TilePresetSubs_Click" ToolTip="一键生成 7 个子布局：级联菜单即布局选择器" />
+                              </Grid>
                           </Grid>
                           <TextBox Grid.Column="2" Height="30" FontSize="11" Margin="4,0,0,0" VerticalContentAlignment="Center" Text="{Binding Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ToolTip="名称（可选）" />
                         </Grid>
@@ -1873,6 +1880,23 @@
                       </DataTemplate>
                     </ItemsControl.ItemTemplate>
                   </ItemsControl>
+                </StackPanel>
+              </Border>
+            <Border Background="{DynamicResource CardBackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="12" Padding="20" Margin="0,0,0,14">
+                <UIElement.Effect>
+                  <DropShadowEffect BlurRadius="12" ShadowDepth="1" Color="#000000" Opacity="0.03" />
+                </UIElement.Effect>
+                <StackPanel>
+                  <TextBlock Name="TileGlobalTitleText" Text="平铺窗口设置" FontSize="14" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
+                  <TextBlock Name="TileGlobalDescText" Text="「平铺窗口」动作的全局行为。" FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,2,0,10" TextWrapping="Wrap" />
+                  <CheckBox Name="TileIncludeMinimizedCheckBox" Style="{StaticResource ToggleSwitchStyle}" Margin="0,4,0,10" Checked="TileIncludeMinimizedCheckBox_Changed" Unchecked="TileIncludeMinimizedCheckBox_Changed">
+                    <StackPanel Margin="6,0,0,0">
+                      <TextBlock Name="TileMinimizeText" Text="包含最小化窗口（还原后参与平铺）" FontWeight="Medium" Foreground="{DynamicResource TextPrimaryBrush}" />
+                      <TextBlock Text="默认关闭：最小化窗口不参与，仅排布可见窗口。" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,2,0,0" />
+                    </StackPanel>
+                  </CheckBox>
+                  <TextBlock Name="TileExcludeText" Text="平铺排除名单（进程 exe 名，逗号分隔，如 notepad,spotify）：" FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,0,0,6" />
+                  <TextBox Name="TileExcludeProcessesTextBox" Height="32" FontSize="12" VerticalContentAlignment="Center" Padding="8,0" TextChanged="TileExcludeProcessesTextBox_TextChanged" />
                 </StackPanel>
               </Border>
             </StackPanel>

--- a/WinPieGestures/SettingsWindow.xaml
+++ b/WinPieGestures/SettingsWindow.xaml
@@ -701,6 +701,7 @@
                                   <ComboBox Grid.Column="1" Width="108" Margin="4,0,0,0" ItemsSource="{Binding Terminals}" SelectedValuePath="Tag" DisplayMemberPath="DisplayText" SelectedValue="{Binding CommandTerminal, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FlatComboBoxStyle}" Height="30" FontSize="10" />
                                 </Grid>
                                 <TextBox Text="{Binding NthWindowIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="30" FontSize="11" VerticalContentAlignment="Center" Visibility="{Binding IsSwitchWindowType, Converter={StaticResource BoolToVis}}" ToolTip="任务栏第 N 个应用（同 Win+N 槽位语义）" />
+                                <ComboBox SelectedValuePath="Tag" DisplayMemberPath="DisplayText" ItemsSource="{Binding TileLayoutOptions}" SelectedValue="{Binding TileLayout, Mode=TwoWay}" Style="{StaticResource FlatComboBoxStyle}" Height="30" FontSize="11" Visibility="{Binding IsTileType, Converter={StaticResource BoolToVis}}" ToolTip="平铺布局预设" />
                               </Grid>
                               <TextBox Grid.Column="3" Height="30" FontSize="11" Margin="4,0,0,0" VerticalContentAlignment="Center" Text="{Binding Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ToolTip="名称（显示自定义，可留空）" />
                               <Button Grid.Column="4" Content="测试" Height="30" Margin="4,0,0,0" Padding="4,0" FontSize="11" Style="{StaticResource ModernButtonStyle}" Click="TestGesture_Click" />
@@ -812,6 +813,7 @@
                               <ComboBox Grid.Column="1" Width="108" Margin="4,0,0,0" ItemsSource="{Binding Terminals}" SelectedValuePath="Tag" DisplayMemberPath="DisplayText" SelectedValue="{Binding CommandTerminal, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FlatComboBoxStyle}" Height="30" FontSize="10" />
                             </Grid>
                             <TextBox Text="{Binding NthWindowIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="30" FontSize="11" VerticalContentAlignment="Center" Visibility="{Binding IsSwitchWindowType, Converter={StaticResource BoolToVis}}" />
+                            <ComboBox SelectedValuePath="Tag" DisplayMemberPath="DisplayText" ItemsSource="{Binding TileLayoutOptions}" SelectedValue="{Binding TileLayout, Mode=TwoWay}" Style="{StaticResource FlatComboBoxStyle}" Height="30" FontSize="11" Visibility="{Binding IsTileType, Converter={StaticResource BoolToVis}}" ToolTip="平铺布局预设" />
                           </Grid>
                           <TextBox Grid.Column="2" Height="30" FontSize="11" Margin="4,0,0,0" VerticalContentAlignment="Center" Text="{Binding Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ToolTip="名称（可选）" />
                         </Grid>
@@ -1853,6 +1855,7 @@
                                 <Grid Visibility="{Binding IsSwitchWindowType, Converter={StaticResource BoolToVis}}">
                                   <TextBox Text="{Binding NthWindowIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="30" FontSize="11" VerticalContentAlignment="Center" ToolTip="任务栏第 N 个应用（顺序同任务栏/Win+N 槽位，稳定）；图标与切换目标一致；固定未运行的槽位无法启动，托盘驻留不计入" />
                                 </Grid>
+                                <ComboBox SelectedValuePath="Tag" DisplayMemberPath="DisplayText" ItemsSource="{Binding TileLayoutOptions}" SelectedValue="{Binding TileLayout, Mode=TwoWay}" Style="{StaticResource FlatComboBoxStyle}" Height="30" FontSize="11" Visibility="{Binding IsTileType, Converter={StaticResource BoolToVis}}" ToolTip="平铺布局预设" />
                               </Grid>
 
                               <TextBox Grid.Column="4" Margin="0,0,8,0" Height="30" FontSize="11" ToolTip="启动参数 (如命令行参数或URL)" VerticalContentAlignment="Center" Text="{Binding Arguments, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding IsLaunchType}" />

--- a/WinPieGestures/SettingsWindow.xaml
+++ b/WinPieGestures/SettingsWindow.xaml
@@ -1897,6 +1897,8 @@
                   </CheckBox>
                   <TextBlock Name="TileExcludeText" Text="平铺排除名单（进程 exe 名，逗号分隔，如 notepad,spotify）：" FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,0,0,6" />
                   <TextBox Name="TileExcludeProcessesTextBox" Height="32" FontSize="12" VerticalContentAlignment="Center" Padding="8,0" TextChanged="TileExcludeProcessesTextBox_TextChanged" />
+                  <TextBlock Name="TileCycleRangeText" Text="循环切换范围（布局 key 逗号分隔，空=全部）：" FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,10,0,6" />
+                  <TextBox Name="TileCycleLayoutsTextBox" Height="32" FontSize="12" VerticalContentAlignment="Center" Padding="8,0" TextChanged="TileCycleLayoutsTextBox_TextChanged" />
                 </StackPanel>
               </Border>
             </StackPanel>

--- a/WinPieGestures/SettingsWindow.xaml
+++ b/WinPieGestures/SettingsWindow.xaml
@@ -819,7 +819,7 @@
                                   <ColumnDefinition Width="34" />
                                 </Grid.ColumnDefinitions>
                                 <ComboBox SelectedValuePath="Tag" DisplayMemberPath="DisplayText" ItemsSource="{Binding TileLayoutOptions}" SelectedValue="{Binding TileLayout, Mode=TwoWay}" Style="{StaticResource FlatComboBoxStyle}" Height="30" FontSize="11" ToolTip="平铺布局预设（含循环切换）" />
-                                <Button Grid.Column="1" Content="⇅" Height="30" Width="32" Margin="4,0,0,0" Padding="0" FontSize="12" Style="{StaticResource ModernButtonStyle}" Click="TilePresetSubs_Click" ToolTip="一键生成 7 个子布局：级联菜单即布局选择器" />
+                                <Button Grid.Column="1" Content="⇅" Height="30" Width="32" Margin="4,0,0,0" Padding="0" FontSize="12" Style="{StaticResource ModernButtonStyle}" Click="TilePresetSubs_Click" ToolTip="一键生成子布局与「恢复上次平铺」：级联菜单即布局/还原选择器" />
                               </Grid>
                           </Grid>
                           <TextBox Grid.Column="2" Height="30" FontSize="11" Margin="4,0,0,0" VerticalContentAlignment="Center" Text="{Binding Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ToolTip="名称（可选）" />

--- a/WinPieGestures/SettingsWindow.xaml.cs
+++ b/WinPieGestures/SettingsWindow.xaml.cs
@@ -420,6 +420,7 @@ public partial class SettingsWindow : Window
 			GestureSensitivityLabel.Text = $"{GestureSensitivitySlider.Value:0} px";
 		}
 		RefreshGestureMappings();
+		RefreshCancelActionEditor();
 		if (EnableOuterEscapeCheckBox != null)
 		{
 			EnableOuterEscapeCheckBox.IsChecked = ConfigManager.CurrentConfig.EnableOuterEscapeCancel;
@@ -957,6 +958,18 @@ public partial class SettingsWindow : Window
 		if (GestureMappingTitleText != null)
 		{
 			GestureMappingTitleText.Text = I18n.T("GestureMappingTitleText");
+		}
+		if (CancelActionTitleText != null)
+		{
+			CancelActionTitleText.Text = I18n.T("CancelActionTitleText");
+		}
+		if (CancelActionDescText != null)
+		{
+			CancelActionDescText.Text = I18n.T("CancelActionDescText");
+		}
+		if (CancelActionEnableText != null)
+		{
+			CancelActionEnableText.Text = I18n.T("CancelActionEnableText");
 		}
 		if (TriggerPageSubheader != null)
 		{
@@ -3210,6 +3223,7 @@ public partial class SettingsWindow : Window
 			{
 				OuterEscapeDistancePanel.Visibility = Visibility.Visible;
 			}
+			UpdateCancelActionAvailability();
 			SyncUiToConfigAndSave();
 		}
 	}
@@ -3223,7 +3237,26 @@ public partial class SettingsWindow : Window
 			{
 				OuterEscapeDistancePanel.Visibility = Visibility.Collapsed;
 			}
+			UpdateCancelActionAvailability();
 			SyncUiToConfigAndSave();
+		}
+	}
+
+	/// <summary>「外甩取消时执行的动作」依赖顺势外甩取消主开关：主开关关闭时整块禁用。</summary>
+	private void UpdateCancelActionAvailability()
+	{
+		bool master = ConfigManager.CurrentConfig?.EnableOuterEscapeCancel == true;
+		if (EnableCancelActionCheckBox != null)
+		{
+			EnableCancelActionCheckBox.IsEnabled = master;
+		}
+		if (CancelActionEditorHost != null)
+		{
+			CancelActionEditorHost.IsEnabled = master;
+		}
+		if (TestCancelActionButton != null)
+		{
+			TestCancelActionButton.IsEnabled = master;
 		}
 	}
 
@@ -7305,6 +7338,48 @@ public partial class SettingsWindow : Window
 		if (sender is FrameworkElement fe && fe.DataContext is GestureMappingViewModel vm)
 		{
 			ActionExecutor.Execute(vm.Mapping.Action);
+		}
+	}
+
+	// ==================== 取消后动作 ====================
+
+	private void RefreshCancelActionEditor()
+	{
+		if (ConfigManager.CurrentConfig == null)
+		{
+			return;
+		}
+		if (EnableCancelActionCheckBox != null)
+		{
+			EnableCancelActionCheckBox.IsChecked = ConfigManager.CurrentConfig.EnableCancelAction;
+		}
+		if (CancelActionEditorHost != null && CancelActionEditorHost.DataContext == null)
+		{
+			GestureMappingViewModel vm = new GestureMappingViewModel(new GestureMapping
+			{
+				Pattern = "",
+				Action = ConfigManager.CurrentConfig.CancelAction ?? new ActionItem { Type = "Hotkey", Name = "取消动作", Parameter = "" }
+			});
+			CancelActionEditorHost.DataContext = vm;
+		}
+		UpdateCancelActionAvailability();
+	}
+
+	private void EnableCancelActionCheckBox_Changed(object sender, RoutedEventArgs e)
+	{
+		if (_isUpdatingUi || ConfigManager.CurrentConfig == null)
+		{
+			return;
+		}
+		ConfigManager.CurrentConfig.EnableCancelAction = EnableCancelActionCheckBox.IsChecked == true;
+		SyncUiToConfigAndSave();
+	}
+
+	private void TestCancelAction_Click(object sender, RoutedEventArgs e)
+	{
+		if (ConfigManager.CurrentConfig?.CancelAction != null)
+		{
+			ActionExecutor.Execute(ConfigManager.CurrentConfig.CancelAction);
 		}
 	}
 

--- a/WinPieGestures/SettingsWindow.xaml.cs
+++ b/WinPieGestures/SettingsWindow.xaml.cs
@@ -425,10 +425,7 @@ public partial class SettingsWindow : Window
 		{
 			TileExcludeProcessesTextBox.Text = ConfigManager.CurrentConfig.TileExcludeProcesses ?? "";
 		}
-		if (TileCycleLayoutsTextBox != null)
-		{
-			TileCycleLayoutsTextBox.Text = ConfigManager.CurrentConfig.TileCycleLayouts ?? "";
-		}
+		RefreshTileCycleList();
 		if (TileIncludeMinimizedCheckBox != null)
 		{
 			TileIncludeMinimizedCheckBox.IsChecked = ConfigManager.CurrentConfig.TileIncludeMinimized;
@@ -7450,14 +7447,151 @@ public partial class SettingsWindow : Window
 		SyncUiToConfigAndSave();
 	}
 
-	private void TileCycleLayoutsTextBox_TextChanged(object sender, TextChangedEventArgs e)
+	// ==================== 循环布局选择器 ====================
+
+	private sealed class LayoutCycleItem : INotifyPropertyChanged
+	{
+		public string Key { get; }
+		public string Display { get; }
+		private bool _isChecked;
+
+		public bool IsChecked
+		{
+			get
+			{
+				return _isChecked;
+			}
+			set
+			{
+				if (_isChecked != value)
+				{
+					_isChecked = value;
+					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsChecked)));
+				}
+			}
+		}
+
+		public LayoutCycleItem(string key, string display, bool isChecked)
+		{
+			Key = key;
+			Display = display;
+			_isChecked = isChecked;
+		}
+
+		public event PropertyChangedEventHandler? PropertyChanged;
+	}
+
+	private List<LayoutCycleItem> _cycleItems = new List<LayoutCycleItem>();
+
+	private void RefreshTileCycleList()
+	{
+		List<string> cfg = new List<string>();
+		string? raw = ConfigManager.CurrentConfig?.TileCycleLayouts;
+		if (!string.IsNullOrWhiteSpace(raw))
+		{
+			foreach (string t in raw.Split(new[] { ',', ';', '，', '；', ' ' }, StringSplitOptions.RemoveEmptyEntries))
+			{
+				string k = t.Trim();
+				if (WindowTiler.IsValidLayout(k) && !cfg.Contains(k))
+				{
+					cfg.Add(k);
+				}
+			}
+		}
+		List<LayoutCycleItem> items = new List<LayoutCycleItem>();
+		foreach (string key in cfg)
+		{
+			items.Add(new LayoutCycleItem(key, WindowTiler.LayoutDisplayName(key), true));
+		}
+		foreach (string key in WindowTiler.LayoutKeys)
+		{
+			if (!cfg.Contains(key))
+			{
+				items.Add(new LayoutCycleItem(key, WindowTiler.LayoutDisplayName(key), false));
+			}
+		}
+		_cycleItems = items;
+		if (TileCycleListBox != null)
+		{
+			TileCycleListBox.ItemsSource = null;
+			TileCycleListBox.ItemsSource = _cycleItems;
+		}
+	}
+
+	private void PersistTileCycleSelection()
+	{
+		ConfigManager.CurrentConfig.TileCycleLayouts = string.Join(",", _cycleItems.Where((LayoutCycleItem i) => i.IsChecked).Select((LayoutCycleItem i) => i.Key));
+		SyncUiToConfigAndSave();
+	}
+
+	private void TileCycleUp_Click(object sender, RoutedEventArgs e)
+	{
+		if (_isUpdatingUi || ConfigManager.CurrentConfig == null || TileCycleListBox?.SelectedItem is not LayoutCycleItem sel)
+		{
+			return;
+		}
+		int idx = _cycleItems.IndexOf(sel);
+		if (idx > 0)
+		{
+			LayoutCycleItem tmp = _cycleItems[idx - 1];
+			_cycleItems[idx - 1] = sel;
+			_cycleItems[idx] = tmp;
+			RefreshTileCycleItemsOnly();
+			TileCycleListBox.SelectedItem = sel;
+			PersistTileCycleSelection();
+		}
+	}
+
+	private void TileCycleDown_Click(object sender, RoutedEventArgs e)
+	{
+		if (_isUpdatingUi || ConfigManager.CurrentConfig == null || TileCycleListBox?.SelectedItem is not LayoutCycleItem sel)
+		{
+			return;
+		}
+		int idx = _cycleItems.IndexOf(sel);
+		if (idx >= 0 && idx < _cycleItems.Count - 1)
+		{
+			LayoutCycleItem tmp = _cycleItems[idx + 1];
+			_cycleItems[idx + 1] = sel;
+			_cycleItems[idx] = tmp;
+			RefreshTileCycleItemsOnly();
+			TileCycleListBox.SelectedItem = sel;
+			PersistTileCycleSelection();
+		}
+	}
+
+	private void RefreshTileCycleItemsOnly()
+	{
+		List<LayoutCycleItem> snapshot = new List<LayoutCycleItem>(_cycleItems);
+		TileCycleListBox.ItemsSource = null;
+		TileCycleListBox.ItemsSource = snapshot;
+		_cycleItems = snapshot;
+	}
+
+	private void TileCycleAll_Click(object sender, RoutedEventArgs e)
 	{
 		if (_isUpdatingUi || ConfigManager.CurrentConfig == null)
 		{
 			return;
 		}
-		ConfigManager.CurrentConfig.TileCycleLayouts = TileCycleLayoutsTextBox.Text ?? "";
-		SyncUiToConfigAndSave();
+		foreach (LayoutCycleItem item in _cycleItems)
+		{
+			item.IsChecked = true;
+		}
+		PersistTileCycleSelection();
+	}
+
+	private void TileCycleNone_Click(object sender, RoutedEventArgs e)
+	{
+		if (_isUpdatingUi || ConfigManager.CurrentConfig == null)
+		{
+			return;
+		}
+		foreach (LayoutCycleItem item in _cycleItems)
+		{
+			item.IsChecked = false;
+		}
+		PersistTileCycleSelection();
 	}
 
 	private void GestureBrowse_Click(object sender, RoutedEventArgs e)

--- a/WinPieGestures/SettingsWindow.xaml.cs
+++ b/WinPieGestures/SettingsWindow.xaml.cs
@@ -421,6 +421,14 @@ public partial class SettingsWindow : Window
 		}
 		RefreshGestureMappings();
 		RefreshCancelActionEditor();
+		if (TileExcludeProcessesTextBox != null)
+		{
+			TileExcludeProcessesTextBox.Text = ConfigManager.CurrentConfig.TileExcludeProcesses ?? "";
+		}
+		if (TileIncludeMinimizedCheckBox != null)
+		{
+			TileIncludeMinimizedCheckBox.IsChecked = ConfigManager.CurrentConfig.TileIncludeMinimized;
+		}
 		if (EnableOuterEscapeCheckBox != null)
 		{
 			EnableOuterEscapeCheckBox.IsChecked = ConfigManager.CurrentConfig.EnableOuterEscapeCancel;
@@ -958,6 +966,22 @@ public partial class SettingsWindow : Window
 		if (GestureMappingTitleText != null)
 		{
 			GestureMappingTitleText.Text = I18n.T("GestureMappingTitleText");
+		}
+		if (TileGlobalTitleText != null)
+		{
+			TileGlobalTitleText.Text = I18n.T("TileGlobalTitleText");
+		}
+		if (TileGlobalDescText != null)
+		{
+			TileGlobalDescText.Text = I18n.T("TileGlobalDescText");
+		}
+		if (TileMinimizeText != null)
+		{
+			TileMinimizeText.Text = I18n.T("TileMinimizeText");
+		}
+		if (TileExcludeText != null)
+		{
+			TileExcludeText.Text = I18n.T("TileExcludeText");
 		}
 		if (CancelActionTitleText != null)
 		{
@@ -7381,6 +7405,41 @@ public partial class SettingsWindow : Window
 		{
 			ActionExecutor.Execute(ConfigManager.CurrentConfig.CancelAction);
 		}
+	}
+
+	// ==================== 平铺窗口 ====================
+
+	private void TilePresetSubs_Click(object sender, RoutedEventArgs e)
+	{
+		if (_isUpdatingUi || ConfigManager.CurrentConfig == null)
+		{
+			return;
+		}
+		if (sender is FrameworkElement fe && fe.DataContext is SlotViewModel vm)
+		{
+			vm.PopulateTileSubActions();
+			SyncUiToConfigAndSave();
+		}
+	}
+
+	private void TileIncludeMinimizedCheckBox_Changed(object sender, RoutedEventArgs e)
+	{
+		if (_isUpdatingUi || ConfigManager.CurrentConfig == null)
+		{
+			return;
+		}
+		ConfigManager.CurrentConfig.TileIncludeMinimized = TileIncludeMinimizedCheckBox.IsChecked == true;
+		SyncUiToConfigAndSave();
+	}
+
+	private void TileExcludeProcessesTextBox_TextChanged(object sender, TextChangedEventArgs e)
+	{
+		if (_isUpdatingUi || ConfigManager.CurrentConfig == null)
+		{
+			return;
+		}
+		ConfigManager.CurrentConfig.TileExcludeProcesses = TileExcludeProcessesTextBox.Text ?? "";
+		SyncUiToConfigAndSave();
 	}
 
 	private void GestureBrowse_Click(object sender, RoutedEventArgs e)

--- a/WinPieGestures/SettingsWindow.xaml.cs
+++ b/WinPieGestures/SettingsWindow.xaml.cs
@@ -7501,13 +7501,17 @@ public partial class SettingsWindow : Window
 		List<LayoutCycleItem> items = new List<LayoutCycleItem>();
 		foreach (string key in cfg)
 		{
-			items.Add(new LayoutCycleItem(key, WindowTiler.LayoutDisplayName(key), true));
+			LayoutCycleItem item = new LayoutCycleItem(key, WindowTiler.LayoutDisplayName(key), true);
+			item.PropertyChanged += LayoutCycleItem_PropertyChanged;
+			items.Add(item);
 		}
 		foreach (string key in WindowTiler.LayoutKeys)
 		{
 			if (!cfg.Contains(key))
 			{
-				items.Add(new LayoutCycleItem(key, WindowTiler.LayoutDisplayName(key), false));
+				LayoutCycleItem item = new LayoutCycleItem(key, WindowTiler.LayoutDisplayName(key), false);
+				item.PropertyChanged += LayoutCycleItem_PropertyChanged;
+				items.Add(item);
 			}
 		}
 		_cycleItems = items;
@@ -7515,6 +7519,19 @@ public partial class SettingsWindow : Window
 		{
 			TileCycleListBox.ItemsSource = null;
 			TileCycleListBox.ItemsSource = _cycleItems;
+		}
+	}
+
+	/// <summary>勾选/取消任意一项立即持久化（循环范围即时生效）。</summary>
+	private void LayoutCycleItem_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+	{
+		if (_isUpdatingUi || ConfigManager.CurrentConfig == null)
+		{
+			return;
+		}
+		if (e.PropertyName == nameof(LayoutCycleItem.IsChecked))
+		{
+			PersistTileCycleSelection();
 		}
 	}
 

--- a/WinPieGestures/SettingsWindow.xaml.cs
+++ b/WinPieGestures/SettingsWindow.xaml.cs
@@ -425,6 +425,10 @@ public partial class SettingsWindow : Window
 		{
 			TileExcludeProcessesTextBox.Text = ConfigManager.CurrentConfig.TileExcludeProcesses ?? "";
 		}
+		if (TileCycleLayoutsTextBox != null)
+		{
+			TileCycleLayoutsTextBox.Text = ConfigManager.CurrentConfig.TileCycleLayouts ?? "";
+		}
 		if (TileIncludeMinimizedCheckBox != null)
 		{
 			TileIncludeMinimizedCheckBox.IsChecked = ConfigManager.CurrentConfig.TileIncludeMinimized;
@@ -982,6 +986,10 @@ public partial class SettingsWindow : Window
 		if (TileExcludeText != null)
 		{
 			TileExcludeText.Text = I18n.T("TileExcludeText");
+		}
+		if (TileCycleRangeText != null)
+		{
+			TileCycleRangeText.Text = I18n.T("TileCycleRangeText");
 		}
 		if (CancelActionTitleText != null)
 		{
@@ -7439,6 +7447,16 @@ public partial class SettingsWindow : Window
 			return;
 		}
 		ConfigManager.CurrentConfig.TileExcludeProcesses = TileExcludeProcessesTextBox.Text ?? "";
+		SyncUiToConfigAndSave();
+	}
+
+	private void TileCycleLayoutsTextBox_TextChanged(object sender, TextChangedEventArgs e)
+	{
+		if (_isUpdatingUi || ConfigManager.CurrentConfig == null)
+		{
+			return;
+		}
+		ConfigManager.CurrentConfig.TileCycleLayouts = TileCycleLayoutsTextBox.Text ?? "";
 		SyncUiToConfigAndSave();
 	}
 

--- a/WinPieGestures/SlotViewModel.cs
+++ b/WinPieGestures/SlotViewModel.cs
@@ -780,7 +780,7 @@ public class SlotViewModel : INotifyPropertyChanged, IDisposable
 		}
 	}
 
-	/// <summary>一键预置 7 个子布局（主动作=级联，子项=各布局的平铺）。</summary>
+	/// <summary>一键预置子项：7 种布局 + 「恢复上次平铺」（级联子菜单 = 布局/还原选择器）。</summary>
 	public void PopulateTileSubActions()
 	{
 		List<ActionItem> list = new List<ActionItem>();
@@ -788,6 +788,7 @@ public class SlotViewModel : INotifyPropertyChanged, IDisposable
 		{
 			list.Add(new ActionItem { Type = "Tile", Parameter = key, Name = WindowTiler.LayoutDisplayName(key) });
 		}
+		list.Add(new ActionItem { Type = "Tile", Parameter = WindowTiler.RestoreParam, Name = I18n.T("TileRestoreAllLabel") });
 		Action.SubActions = list;
 		NotifySubActionsChanged();
 	}

--- a/WinPieGestures/SlotViewModel.cs
+++ b/WinPieGestures/SlotViewModel.cs
@@ -765,6 +765,7 @@ public class SlotViewModel : INotifyPropertyChanged, IDisposable
 			List<ActionTypeOption> list = new List<ActionTypeOption>
 			{
 				new ActionTypeOption { Tag = WindowTiler.CycleParam, DisplayText = "🔄 " + I18n.T("TileCycleLabel") },
+				new ActionTypeOption { Tag = WindowTiler.CycleBackParam, DisplayText = "⬅️ " + I18n.T("TileCycleBackLabel") },
 				new ActionTypeOption { Tag = WindowTiler.RestoreParam, DisplayText = "⏪ " + I18n.T("TileRestoreAllLabel") }
 			};
 			foreach (string key in WindowTiler.LayoutKeys)

--- a/WinPieGestures/SlotViewModel.cs
+++ b/WinPieGestures/SlotViewModel.cs
@@ -650,6 +650,26 @@ public class SlotViewModel : INotifyPropertyChanged, IDisposable
 		},
 		new ActionTypeOption
 		{
+			Tag = "TileRestore",
+			DisplayText = I18n.T("ActionTypeTileRestoreShort")
+		},
+		new ActionTypeOption
+		{
+			Tag = "MoveMonitor",
+			DisplayText = I18n.T("ActionTypeMoveMonitorShort")
+		},
+		new ActionTypeOption
+		{
+			Tag = "ToggleTopmost",
+			DisplayText = I18n.T("ActionTypeTopmostShort")
+		},
+		new ActionTypeOption
+		{
+			Tag = "WindowOpacity",
+			DisplayText = I18n.T("ActionTypeOpacityShort")
+		},
+		new ActionTypeOption
+		{
 			Tag = "System",
 			DisplayText = I18n.T("ActionTypeSystemShort")
 		}
@@ -686,6 +706,26 @@ public class SlotViewModel : INotifyPropertyChanged, IDisposable
 		{
 			Tag = "Tile",
 			DisplayText = I18n.T("ActionTypeTileShort")
+		},
+		new ActionTypeItem
+		{
+			Tag = "TileRestore",
+			DisplayText = I18n.T("ActionTypeTileRestoreShort")
+		},
+		new ActionTypeItem
+		{
+			Tag = "MoveMonitor",
+			DisplayText = I18n.T("ActionTypeMoveMonitorShort")
+		},
+		new ActionTypeItem
+		{
+			Tag = "ToggleTopmost",
+			DisplayText = I18n.T("ActionTypeTopmostShort")
+		},
+		new ActionTypeItem
+		{
+			Tag = "WindowOpacity",
+			DisplayText = I18n.T("ActionTypeOpacityShort")
 		},
 		new ActionTypeItem
 		{
@@ -727,13 +767,28 @@ public class SlotViewModel : INotifyPropertyChanged, IDisposable
 	{
 		get
 		{
-			List<ActionTypeOption> list = new List<ActionTypeOption>();
+			List<ActionTypeOption> list = new List<ActionTypeOption>
+			{
+				new ActionTypeOption { Tag = WindowTiler.CycleParam, DisplayText = "🔄 " + I18n.T("TileCycleLabel") }
+			};
 			foreach (string key in WindowTiler.LayoutKeys)
 			{
 				list.Add(new ActionTypeOption { Tag = key, DisplayText = WindowTiler.LayoutDisplayName(key) });
 			}
 			return list;
 		}
+	}
+
+	/// <summary>一键预置 7 个子布局（主动作=级联，子项=各布局的平铺）。</summary>
+	public void PopulateTileSubActions()
+	{
+		List<ActionItem> list = new List<ActionItem>();
+		foreach (string key in WindowTiler.LayoutKeys)
+		{
+			list.Add(new ActionItem { Type = "Tile", Parameter = key, Name = WindowTiler.LayoutDisplayName(key) });
+		}
+		Action.SubActions = list;
+		NotifySubActionsChanged();
 	}
 
 	/// <summary>平铺布局（写入 Parameter）。</summary>

--- a/WinPieGestures/SlotViewModel.cs
+++ b/WinPieGestures/SlotViewModel.cs
@@ -397,6 +397,10 @@ public class SlotViewModel : INotifyPropertyChanged, IDisposable
 			{
 				Action.Parameter = "2L";
 			}
+			if (value == "Tile" && string.IsNullOrEmpty(IconKey))
+			{
+				IconKey = "Tile"; // 默认使用平铺四宫格 logo
+			}
 			if (value == "Tile" && (Action.SubActions == null || Action.SubActions.Count == 0))
 			{
 				// 平铺动作自带子菜单：7 布局 + 「恢复上次平铺」——放置即带还原入口
@@ -782,9 +786,9 @@ public class SlotViewModel : INotifyPropertyChanged, IDisposable
 		List<ActionItem> list = new List<ActionItem>();
 		foreach (string key in WindowTiler.LayoutKeys)
 		{
-			list.Add(new ActionItem { Type = "Tile", Parameter = key, Name = WindowTiler.LayoutDisplayName(key) });
+			list.Add(new ActionItem { Type = "Tile", Parameter = key, Name = WindowTiler.LayoutDisplayName(key), IconKey = "Tile" });
 		}
-		list.Add(new ActionItem { Type = "Tile", Parameter = WindowTiler.RestoreParam, Name = I18n.T("TileRestoreAllLabel") });
+		list.Add(new ActionItem { Type = "Tile", Parameter = WindowTiler.RestoreParam, Name = I18n.T("TileRestoreAllLabel"), IconKey = "Tile" });
 		Action.SubActions = list;
 		NotifySubActionsChanged();
 	}

--- a/WinPieGestures/SlotViewModel.cs
+++ b/WinPieGestures/SlotViewModel.cs
@@ -397,6 +397,11 @@ public class SlotViewModel : INotifyPropertyChanged, IDisposable
 			{
 				Action.Parameter = "2L";
 			}
+			if (value == "Tile" && (Action.SubActions == null || Action.SubActions.Count == 0))
+			{
+				// 平铺动作自带子菜单：7 布局 + 「恢复上次平铺」——放置即带还原入口
+				PopulateTileSubActions();
+			}
 			OnPropertyChanged("Type");
 			OnPropertyChanged("IsHotkeyType");
 			OnPropertyChanged("IsLaunchType");
@@ -650,11 +655,6 @@ public class SlotViewModel : INotifyPropertyChanged, IDisposable
 		},
 		new ActionTypeOption
 		{
-			Tag = "TileRestore",
-			DisplayText = I18n.T("ActionTypeTileRestoreShort")
-		},
-		new ActionTypeOption
-		{
 			Tag = "MoveMonitor",
 			DisplayText = I18n.T("ActionTypeMoveMonitorShort")
 		},
@@ -706,11 +706,6 @@ public class SlotViewModel : INotifyPropertyChanged, IDisposable
 		{
 			Tag = "Tile",
 			DisplayText = I18n.T("ActionTypeTileShort")
-		},
-		new ActionTypeItem
-		{
-			Tag = "TileRestore",
-			DisplayText = I18n.T("ActionTypeTileRestoreShort")
 		},
 		new ActionTypeItem
 		{

--- a/WinPieGestures/SlotViewModel.cs
+++ b/WinPieGestures/SlotViewModel.cs
@@ -769,7 +769,8 @@ public class SlotViewModel : INotifyPropertyChanged, IDisposable
 		{
 			List<ActionTypeOption> list = new List<ActionTypeOption>
 			{
-				new ActionTypeOption { Tag = WindowTiler.CycleParam, DisplayText = "🔄 " + I18n.T("TileCycleLabel") }
+				new ActionTypeOption { Tag = WindowTiler.CycleParam, DisplayText = "🔄 " + I18n.T("TileCycleLabel") },
+				new ActionTypeOption { Tag = WindowTiler.RestoreParam, DisplayText = "⏪ " + I18n.T("TileRestoreAllLabel") }
 			};
 			foreach (string key in WindowTiler.LayoutKeys)
 			{

--- a/WinPieGestures/SlotViewModel.cs
+++ b/WinPieGestures/SlotViewModel.cs
@@ -389,6 +389,14 @@ public class SlotViewModel : INotifyPropertyChanged, IDisposable
 			{
 				NthWindowIndex = "1";
 			}
+			if (value == "Tile" && (string.IsNullOrEmpty(Name) || Name.StartsWith("快捷动作") || Name.StartsWith("动作")))
+			{
+				Name = I18n.T("ActionTypeTileShort");
+			}
+			if (value == "Tile" && string.IsNullOrWhiteSpace(Action.Parameter))
+			{
+				Action.Parameter = "2L";
+			}
 			OnPropertyChanged("Type");
 			OnPropertyChanged("IsHotkeyType");
 			OnPropertyChanged("IsLaunchType");
@@ -396,6 +404,7 @@ public class SlotViewModel : INotifyPropertyChanged, IDisposable
 			OnPropertyChanged("IsSystemType");
 			OnPropertyChanged("IsCommandType");
 			OnPropertyChanged("IsSwitchWindowType");
+			OnPropertyChanged("IsTileType");
 		}
 	}
 
@@ -636,6 +645,11 @@ public class SlotViewModel : INotifyPropertyChanged, IDisposable
 		},
 		new ActionTypeOption
 		{
+			Tag = "Tile",
+			DisplayText = I18n.T("ActionTypeTileShort")
+		},
+		new ActionTypeOption
+		{
 			Tag = "System",
 			DisplayText = I18n.T("ActionTypeSystemShort")
 		}
@@ -670,6 +684,11 @@ public class SlotViewModel : INotifyPropertyChanged, IDisposable
 		},
 		new ActionTypeItem
 		{
+			Tag = "Tile",
+			DisplayText = I18n.T("ActionTypeTileShort")
+		},
+		new ActionTypeItem
+		{
 			Tag = "System",
 			DisplayText = I18n.T("ActionTypeSystemShort")
 		}
@@ -700,6 +719,39 @@ public class SlotViewModel : INotifyPropertyChanged, IDisposable
 	public bool IsCommandType => Type == "Command";
 
 	public bool IsSwitchWindowType => Type == "SwitchWindow";
+
+	public bool IsTileType => Type == "Tile";
+
+	/// <summary>平铺布局下拉（key → 显示名）。</summary>
+	public List<ActionTypeOption> TileLayoutOptions
+	{
+		get
+		{
+			List<ActionTypeOption> list = new List<ActionTypeOption>();
+			foreach (string key in WindowTiler.LayoutKeys)
+			{
+				list.Add(new ActionTypeOption { Tag = key, DisplayText = WindowTiler.LayoutDisplayName(key) });
+			}
+			return list;
+		}
+	}
+
+	/// <summary>平铺布局（写入 Parameter）。</summary>
+	public string TileLayout
+	{
+		get
+		{
+			return Action.Parameter ?? "";
+		}
+		set
+		{
+			if (Action.Parameter != value)
+			{
+				Action.Parameter = value;
+				OnPropertyChanged("TileLayout");
+			}
+		}
+	}
 
 	/// <summary>任务栏第 N 个窗口的序号（1~20，仅数字）。</summary>
 	public string NthWindowIndex

--- a/WinPieGestures/SubActionEditorWindow.xaml
+++ b/WinPieGestures/SubActionEditorWindow.xaml
@@ -93,6 +93,7 @@
                     <Grid Visibility="{Binding IsSwitchWindowType, Converter={StaticResource BoolToVis}}">
                       <TextBox Text="{Binding NthWindowIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="30" FontSize="11" VerticalContentAlignment="Center" ToolTip="任务栏第 N 个应用（顺序同任务栏/Win+N 槽位，稳定）；图标与切换目标一致；固定未运行的槽位无法启动，托盘驻留不计入"/>
                     </Grid>
+                    <ComboBox SelectedValuePath="Tag" DisplayMemberPath="DisplayText" ItemsSource="{Binding TileLayoutOptions}" SelectedValue="{Binding TileLayout, Mode=TwoWay}" Style="{StaticResource FlatComboBoxStyle}" Height="30" FontSize="11" Visibility="{Binding IsTileType, Converter={StaticResource BoolToVis}}" ToolTip="平铺布局预设"/>
                   </Grid>
                   <TextBox Grid.Column="5" Margin="0,0,6,0" Height="30" FontSize="10.5" ToolTip="启动参数 (可选)" VerticalContentAlignment="Center" Text="{Binding Arguments, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding IsLaunchType}" />
                   <Button Grid.Column="6" Content="测试" Style="{StaticResource ModernButtonStyle}" Height="30" Margin="0,0,6,0" Padding="0" ToolTip="测试执行此子动作" Click="SubTest_Click" />

--- a/WinPieGestures/SubSlotViewModel.cs
+++ b/WinPieGestures/SubSlotViewModel.cs
@@ -68,6 +68,7 @@ public class SubSlotViewModel : INotifyPropertyChanged
 			OnPropertyChanged("IsSystemType");
 			OnPropertyChanged("IsCommandType");
 			OnPropertyChanged("IsSwitchWindowType");
+			OnPropertyChanged("IsTileType");
 		}
 	}
 
@@ -258,6 +259,39 @@ public class SubSlotViewModel : INotifyPropertyChanged
 	public bool IsCommandType => Type == "Command";
 
 	public bool IsSwitchWindowType => Type == "SwitchWindow";
+
+	public bool IsTileType => Type == "Tile";
+
+	/// <summary>平铺布局下拉（key → 显示名）。</summary>
+	public List<ActionTypeOption> TileLayoutOptions
+	{
+		get
+		{
+			List<ActionTypeOption> list = new List<ActionTypeOption>();
+			foreach (string key in WindowTiler.LayoutKeys)
+			{
+				list.Add(new ActionTypeOption { Tag = key, DisplayText = WindowTiler.LayoutDisplayName(key) });
+			}
+			return list;
+		}
+	}
+
+	/// <summary>平铺布局（写入 Parameter）。</summary>
+	public string TileLayout
+	{
+		get
+		{
+			return Action.Parameter ?? "";
+		}
+		set
+		{
+			if (Action.Parameter != value)
+			{
+				Action.Parameter = value;
+				OnPropertyChanged("TileLayout");
+			}
+		}
+	}
 
 	/// <summary>任务栏第 N 个窗口的序号（1~20，仅数字）。</summary>
 	public string NthWindowIndex

--- a/WinPieGestures/SubSlotViewModel.cs
+++ b/WinPieGestures/SubSlotViewModel.cs
@@ -61,6 +61,10 @@ public class SubSlotViewModel : INotifyPropertyChanged
 			{
 				NthWindowIndex = "1";
 			}
+			if (value == "Tile" && string.IsNullOrEmpty(IconKey))
+			{
+				IconKey = "Tile"; // 默认使用平铺四宫格 logo
+			}
 			OnPropertyChanged("Type");
 			OnPropertyChanged("IsHotkeyType");
 			OnPropertyChanged("IsLaunchType");

--- a/WinPieGestures/SubSlotViewModel.cs
+++ b/WinPieGestures/SubSlotViewModel.cs
@@ -269,7 +269,8 @@ public class SubSlotViewModel : INotifyPropertyChanged
 		{
 			List<ActionTypeOption> list = new List<ActionTypeOption>
 			{
-				new ActionTypeOption { Tag = WindowTiler.CycleParam, DisplayText = "🔄 " + I18n.T("TileCycleLabel") }
+				new ActionTypeOption { Tag = WindowTiler.CycleParam, DisplayText = "🔄 " + I18n.T("TileCycleLabel") },
+				new ActionTypeOption { Tag = WindowTiler.RestoreParam, DisplayText = "⏪ " + I18n.T("TileRestoreAllLabel") }
 			};
 			foreach (string key in WindowTiler.LayoutKeys)
 			{

--- a/WinPieGestures/SubSlotViewModel.cs
+++ b/WinPieGestures/SubSlotViewModel.cs
@@ -270,6 +270,7 @@ public class SubSlotViewModel : INotifyPropertyChanged
 			List<ActionTypeOption> list = new List<ActionTypeOption>
 			{
 				new ActionTypeOption { Tag = WindowTiler.CycleParam, DisplayText = "🔄 " + I18n.T("TileCycleLabel") },
+				new ActionTypeOption { Tag = WindowTiler.CycleBackParam, DisplayText = "⬅️ " + I18n.T("TileCycleBackLabel") },
 				new ActionTypeOption { Tag = WindowTiler.RestoreParam, DisplayText = "⏪ " + I18n.T("TileRestoreAllLabel") }
 			};
 			foreach (string key in WindowTiler.LayoutKeys)

--- a/WinPieGestures/SubSlotViewModel.cs
+++ b/WinPieGestures/SubSlotViewModel.cs
@@ -267,7 +267,10 @@ public class SubSlotViewModel : INotifyPropertyChanged
 	{
 		get
 		{
-			List<ActionTypeOption> list = new List<ActionTypeOption>();
+			List<ActionTypeOption> list = new List<ActionTypeOption>
+			{
+				new ActionTypeOption { Tag = WindowTiler.CycleParam, DisplayText = "🔄 " + I18n.T("TileCycleLabel") }
+			};
 			foreach (string key in WindowTiler.LayoutKeys)
 			{
 				list.Add(new ActionTypeOption { Tag = key, DisplayText = WindowTiler.LayoutDisplayName(key) });

--- a/WinPieGestures/WindowTaskbarHelper.cs
+++ b/WinPieGestures/WindowTaskbarHelper.cs
@@ -427,6 +427,28 @@ public static class WindowTaskbarHelper
 		}
 	}
 
+	/// <summary>窗口是否在当前虚拟桌面（供平铺等全量枚举时过滤）。</summary>
+	public static bool IsOnCurrentVirtualDesktop(nint hWnd)
+	{
+		try
+		{
+			if (hWnd == IntPtr.Zero)
+			{
+				return false;
+			}
+			IVirtualDesktopManager? vdm = CreateVdm();
+			if (vdm == null)
+			{
+				return false;
+			}
+			return vdm.IsWindowOnCurrentVirtualDesktop(hWnd, out _) == 0;
+		}
+		catch
+		{
+			return false;
+		}
+	}
+
 	/// <summary>抗权限获取进程 exe 路径（OpenProcess+QueryFullProcessImageName）；失败返回 null。</summary>
 	public static string? GetProcessImageNameByPid(uint pid)
 	{

--- a/WinPieGestures/WindowTaskbarHelper.cs
+++ b/WinPieGestures/WindowTaskbarHelper.cs
@@ -427,6 +427,36 @@ public static class WindowTaskbarHelper
 		}
 	}
 
+	/// <summary>抗权限获取进程 exe 路径（OpenProcess+QueryFullProcessImageName）；失败返回 null。</summary>
+	public static string? GetProcessImageNameByPid(uint pid)
+	{
+		try
+		{
+			nint hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid);
+			if (hProcess == IntPtr.Zero)
+			{
+				return null;
+			}
+			try
+			{
+				uint size = 1024;
+				StringBuilder sb = new StringBuilder((int)size);
+				if (QueryFullProcessImageName(hProcess, 0, sb, ref size))
+				{
+					return sb.ToString();
+				}
+			}
+			finally
+			{
+				CloseHandle(hProcess);
+			}
+		}
+		catch
+		{
+		}
+		return null;
+	}
+
 	/// <summary>任务栏第 n 个运行窗口的窗口标题（无则返回 null）；供轮盘中心显示"将要激活的窗口"。</summary>
 	public static string? GetNthTaskbarWindowTitle(int n)
 	{

--- a/WinPieGestures/WindowTiler.cs
+++ b/WinPieGestures/WindowTiler.cs
@@ -397,6 +397,7 @@ public static class WindowTiler
 
 		// 同 exe 分组：exe(lower) -> hwnds
 		Dictionary<string, List<nint>> groups = new Dictionary<string, List<nint>>(StringComparer.OrdinalIgnoreCase);
+		int blockedCount = 0;
 		foreach (nint h in EnumerateAllTopLevelWindows())
 		{
 			try
@@ -458,6 +459,10 @@ public static class WindowTiler
 				// 只收任务栏存在应用的窗口（Dwalia：只管理真实驻留应用的窗口），且不在系统工具/用户黑名单
 				if (exeKey == null || !slotExes.Contains(exeKey) || blockedExes.Contains(exeKey))
 				{
+					if (exeKey != null && blockedExes.Contains(exeKey))
+					{
+						blockedCount++;
+					}
 					continue;
 				}
 				StringBuilder sb = new StringBuilder(128);
@@ -504,6 +509,8 @@ public static class WindowTiler
 		{
 			result.AddRange(EnumerateTopLevelWindows());
 		}
+		// 诊断：被黑名单/杂窗挡掉的数量（用于核对目标数与真实窗口数）
+		AppLogger.LogInfo($"[Tile]   blocked={blockedCount}");
 		return result;
 	}
 

--- a/WinPieGestures/WindowTiler.cs
+++ b/WinPieGestures/WindowTiler.cs
@@ -121,6 +121,9 @@ public static class WindowTiler
 	/// <summary>轮换模式标记：参数为 Cycle 时循环切换布局。</summary>
 	public const string CycleParam = "Cycle";
 
+	/// <summary>还原标记：参数为 Restore 时还原所有窗口到平铺前。</summary>
+	public const string RestoreParam = "Restore";
+
 	public static bool IsValidLayout(string key)
 	{
 		return LayoutKeys.Contains(key);
@@ -147,6 +150,11 @@ public static class WindowTiler
 		try
 		{
 			string key = string.IsNullOrWhiteSpace(layoutKey) ? "2L" : layoutKey.Trim();
+			if (string.Equals(key, RestoreParam, StringComparison.OrdinalIgnoreCase))
+			{
+				RestoreLastLayout();
+				return;
+			}
 			if (string.Equals(key, CycleParam, StringComparison.OrdinalIgnoreCase))
 			{
 				key = LayoutKeys[s_cycleIndex % LayoutKeys.Count];

--- a/WinPieGestures/WindowTiler.cs
+++ b/WinPieGestures/WindowTiler.cs
@@ -84,6 +84,12 @@ public static class WindowTiler
 	[DllImport("user32.dll")]
 	private static extern nint GetWindow(nint hWnd, uint uCmd);
 
+	[DllImport("user32.dll", CharSet = CharSet.Unicode)]
+	private static extern int GetClassName(nint hWnd, StringBuilder lpClassName, int nMaxCount);
+
+	[DllImport("dwmapi.dll")]
+	private static extern int DwmGetWindowAttribute(nint hwnd, int dwAttribute, out int pvAttribute, int cbAttribute);
+
 	[DllImport("user32.dll", EntryPoint = "GetWindowLongPtrW")]
 	private static extern nint GetWindowLongPtr(nint hWnd, int nIndex);
 
@@ -94,6 +100,9 @@ public static class WindowTiler
 	private const long WS_CAPTION = 0x00C00000L;
 	private const long WS_THICKFRAME = 0x00040000L;
 	private const long WS_EX_TOOLWINDOW = 0x00000080L;
+	private const long WS_CHILD = 0x40000000L;
+	private const long WS_DISABLED = 0x08000000L;
+	private const int DWMWA_CLOAKED = 14;
 
 	[DllImport("user32.dll", EntryPoint = "SetWindowLongPtrW", SetLastError = true)]
 	private static extern nint SetWindowLongPtr(nint hWnd, int nIndex, nint dwNewLong);
@@ -387,6 +396,20 @@ public static class WindowTiler
 				{
 					continue;
 				}
+				// 学 Dwalia：WS_CHILD / WS_DISABLED / 工具窗 / 特殊类名 / DWM 遮蔽(CLOAKED) 一律不进布局
+				if ((style & WS_CHILD) != 0L || (style & WS_DISABLED) != 0L)
+				{
+					continue;
+				}
+				string winCls = GetClassNameSafe(h);
+				if (winCls == "Progman" || winCls == "WorkerW" || winCls == "Shell_TrayWnd" || winCls == "Shell_SecondaryTrayWnd" || winCls == "Windows.UI.Core.CoreWindow" || winCls == "ApplicationFrameWindow")
+				{
+					continue;
+				}
+				if (IsWindowCloaked(h))
+				{
+					continue;
+				}
 				long exstyle = GetWindowLongPtr(h, GWL_EXSTYLE).ToInt64();
 				if ((exstyle & WS_EX_TOOLWINDOW) != 0L)
 				{
@@ -468,6 +491,32 @@ public static class WindowTiler
 			result.AddRange(EnumerateTopLevelWindows());
 		}
 		return result;
+	}
+
+	/// <summary>窗口是否被 DWM 遮蔽（虚拟桌面隐藏/最小化过渡等隐形态）——Dwalia 的 Cloaked 判定。</summary>
+	private static bool IsWindowCloaked(nint hWnd)
+	{
+		try
+		{
+			return DwmGetWindowAttribute(hWnd, DWMWA_CLOAKED, out int cloaked, 4) == 0 && cloaked != 0;
+		}
+		catch
+		{
+			return false;
+		}
+	}
+
+	private static string GetClassNameSafe(nint hWnd)
+	{
+		try
+		{
+			StringBuilder sb = new StringBuilder(256);
+			return GetClassName(hWnd, sb, 256) > 0 ? sb.ToString() : "";
+		}
+		catch
+		{
+			return "";
+		}
 	}
 
 	/// <summary>进程 exe 名（小写、无扩展名）；失败 null。轻量缓存避免重复 OpenProcess。</summary>

--- a/WinPieGestures/WindowTiler.cs
+++ b/WinPieGestures/WindowTiler.cs
@@ -46,6 +46,12 @@ public static class WindowTiler
 	private static extern nint MonitorFromWindow(nint hWnd, uint dwFlags);
 
 	[DllImport("user32.dll")]
+	private static extern nint MonitorFromRect(RECT lprc, uint dwFlags);
+
+	[DllImport("user32.dll")]
+	private static extern nint GetShellWindow();
+
+	[DllImport("user32.dll")]
 	private static extern bool GetMonitorInfo(nint hMonitor, ref MONITORINFO lpmi);
 
 	[DllImport("user32.dll", SetLastError = true)]
@@ -69,18 +75,51 @@ public static class WindowTiler
 	[DllImport("user32.dll")]
 	private static extern uint GetWindowThreadProcessId(nint hWnd, out uint lpdwProcessId);
 
+	[DllImport("user32.dll")]
+	private static extern nint GetForegroundWindow();
+
+	[DllImport("user32.dll")]
+	private static extern bool GetWindowRect(nint hWnd, out RECT lpRect);
+
+	[DllImport("user32.dll", EntryPoint = "GetWindowLongPtrW")]
+	private static extern nint GetWindowLongPtr(nint hWnd, int nIndex);
+
+	[DllImport("user32.dll", EntryPoint = "SetWindowLongPtrW", SetLastError = true)]
+	private static extern nint SetWindowLongPtr(nint hWnd, int nIndex, nint dwNewLong);
+
+	[DllImport("user32.dll")]
+	private static extern bool SetLayeredWindowAttributes(nint hWnd, uint crKey, byte bAlpha, uint dwFlags);
+
+	[DllImport("user32.dll")]
+	private static extern bool EnumDisplayMonitors(nint hdc, nint lprcClip, EnumMonitorsProc lpfnEnum, nint dwData);
+
+	private delegate bool EnumMonitorsProc(nint hMonitor, nint hdcMonitor, ref RECT lprcMonitor, nint dwData);
+
 	private const int SW_RESTORE = 9;
 	private const uint SWP_NOZORDER = 0x0004;
+	private const uint SWP_NOMOVE = 0x0002;
+	private const uint SWP_NOSIZE = 0x0001;
 	private const uint SWP_NOACTIVATE = 0x0010;
 	private const uint SWP_SHOWWINDOW = 0x0040;
 	private const uint SWP_ASYNCWINDOWPOS = 0x4000;
 	private static readonly nint HWND_TOP = new nint(0);
+	private const uint WS_EX_LAYERED = 0x00080000;
+	private const int GWL_EXSTYLE = -20;
+	private const uint LWA_ALPHA = 0x00000002;
+	private const uint SW_RESTORE_U = 9u;
+
+	// 上次平铺快照（供「恢复」与内存记忆）
+	private static readonly Dictionary<nint, RECT> s_lastSnapshot = new Dictionary<nint, RECT>();
+	private static int s_cycleIndex;
 
 	/// <summary>可选布局 key 列表（顺序即编辑器下拉顺序）。</summary>
 	public static List<string> LayoutKeys { get; } = new List<string>
 	{
 		"2L", "2T", "3L12", "3R21", "3R", "4G", "6G"
 	};
+
+	/// <summary>轮换模式标记：参数为 Cycle 时循环切换布局。</summary>
+	public const string CycleParam = "Cycle";
 
 	public static bool IsValidLayout(string key)
 	{
@@ -108,11 +147,27 @@ public static class WindowTiler
 		try
 		{
 			string key = string.IsNullOrWhiteSpace(layoutKey) ? "2L" : layoutKey.Trim();
+			if (string.Equals(key, CycleParam, StringComparison.OrdinalIgnoreCase))
+			{
+				key = LayoutKeys[s_cycleIndex % LayoutKeys.Count];
+				s_cycleIndex = (s_cycleIndex + 1) % LayoutKeys.Count;
+			}
 			if (!IsValidLayout(key))
 			{
 				key = "2L";
 			}
-			List<nint> targets = GetTileTargets();
+			// 排除名单（进程 exe 名，逗号/分号分隔）
+			HashSet<string> exclude = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+			string? excl = ConfigManager.CurrentConfig?.TileExcludeProcesses;
+			if (!string.IsNullOrWhiteSpace(excl))
+			{
+				foreach (string token in excl.Split(new[] { ',', ';', '，', '；', ' ' }, StringSplitOptions.RemoveEmptyEntries))
+				{
+					exclude.Add(token.Trim().ToLowerInvariant());
+				}
+			}
+			bool includeMinimized = ConfigManager.CurrentConfig?.TileIncludeMinimized == true;
+			List<nint> targets = GetTileTargets(exclude, includeMinimized);
 			AppLogger.LogInfo($"[Tile] layout='{key}' targets={targets.Count}");
 			if (targets.Count == 0)
 			{
@@ -120,6 +175,7 @@ public static class WindowTiler
 			}
 			double[][] cells = LayoutCells(key);
 			int count = Math.Min(targets.Count, cells.Length);
+			Dictionary<nint, RECT> snapshot = new Dictionary<nint, RECT>();
 			for (int i = 0; i < count; i++)
 			{
 				RECT wa = WorkAreaOf(targets[i]);
@@ -130,17 +186,27 @@ public static class WindowTiler
 				int h = (int)Math.Round((wa.Bottom - wa.Top) * c[3]) - (y - wa.Top);
 				w = Math.Max(1, w);
 				h = Math.Max(1, h);
-				// 最大化/全屏状态会无视 SetWindowPos：先还原，再定位
-				if (IsIconic(targets[i]))
-				{
-					ShowWindow(targets[i], SW_RESTORE);
-				}
-				else if (IsZoomed(targets[i]))
+				RECT before;
+				GetWindowRect(targets[i], out before);
+				// 最小化/最大化会无视 SetWindowPos：先还原，再定位
+				if (IsIconic(targets[i]) || IsZoomed(targets[i]))
 				{
 					ShowWindow(targets[i], SW_RESTORE);
 				}
 				bool ok = SetWindowPos(targets[i], HWND_TOP, x, y, w, h, SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW | SWP_ASYNCWINDOWPOS);
 				AppLogger.LogInfo($"[Tile] #{i} hwnd=0x{targets[i]:X} rect=({x},{y},{w}x{h}) ok={ok}");
+				if (ok)
+				{
+					snapshot[targets[i]] = before;
+				}
+			}
+			lock (s_lastSnapshot)
+			{
+				s_lastSnapshot.Clear();
+				foreach (var kv in snapshot)
+				{
+					s_lastSnapshot[kv.Key] = kv.Value;
+				}
 			}
 		}
 		catch (Exception ex)
@@ -149,16 +215,54 @@ public static class WindowTiler
 		}
 	}
 
-	/// <summary>平铺对象：当前虚拟桌面可见的普通顶层窗口（任务栏顺序）；排除无标题/隐藏/本进程自身。</summary>
-	private static List<nint> GetTileTargets()
+	/// <summary>恢复上次平铺前的窗口位置/大小（按需优先还原显示）。</summary>
+	public static void RestoreLastLayout()
+	{
+		try
+		{
+			Dictionary<nint, RECT> snap;
+			lock (s_lastSnapshot)
+			{
+				snap = new Dictionary<nint, RECT>(s_lastSnapshot);
+			}
+			AppLogger.LogInfo($"[Tile] restore targets={snap.Count}");
+			foreach (var kv in snap)
+			{
+				try
+				{
+					RECT r = kv.Value;
+					if (IsIconic(kv.Key))
+					{
+						ShowWindow(kv.Key, SW_RESTORE);
+					}
+					SetWindowPos(kv.Key, HWND_TOP, r.Left, r.Top, Math.Max(1, r.Right - r.Left), Math.Max(1, r.Bottom - r.Top),
+						SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW | SWP_ASYNCWINDOWPOS);
+				}
+				catch
+				{
+				}
+			}
+		}
+		catch (Exception ex)
+		{
+			AppLogger.LogError("[Tile] 恢复失败", ex);
+		}
+	}
+
+	/// <summary>平铺对象：当前虚拟桌面可见窗口（任务栏顺序）；排除无标题/隐藏/本进程/排除名单；按配置决定是否含最小化。</summary>
+	private static List<nint> GetTileTargets(HashSet<string> excludedExes, bool includeMinimized)
 	{
 		List<nint> result = new List<nint>();
 		uint selfPid = (uint)Environment.ProcessId;
 		foreach (nint h in WindowTaskbarHelper.GetTaskbarOrderedWindows())
 		{
-			if (h == IntPtr.Zero || !IsWindowVisible(h) || IsIconic(h))
+			if (h == IntPtr.Zero || !IsWindowVisible(h))
 			{
-				continue; // 隐藏或最小化不参与
+				continue;
+			}
+			if (!includeMinimized && IsIconic(h))
+			{
+				continue; // 最小化不参与（默认）
 			}
 			GetWindowThreadProcessId(h, out uint pid);
 			if (pid == selfPid)
@@ -169,6 +273,14 @@ public static class WindowTiler
 			if (GetWindowText(h, sb, 128) <= 0)
 			{
 				continue; // 无标题的后台窗口不参与
+			}
+			if (excludedExes.Count > 0)
+			{
+				string? exe = WindowTaskbarHelper.GetProcessImageNameByPid(pid);
+				if (exe != null && excludedExes.Contains(System.IO.Path.GetFileNameWithoutExtension(exe).ToLowerInvariant()))
+				{
+					continue; // 命中排除名单
+				}
 			}
 			result.Add(h);
 		}
@@ -193,6 +305,165 @@ public static class WindowTiler
 	{
 		s_enumBuffer.Add(hWnd);
 		return true;
+	}
+
+	/// <summary>把当前前台窗口平移到下一台显示器（保持相对位置与尺寸）。</summary>
+	public static void MoveWindowToNextMonitor()
+	{
+		try
+		{
+			nint fg = GetForegroundWindow();
+			if (fg == IntPtr.Zero || fg == GetShellWindowHandleSafe())
+			{
+				return;
+			}
+			uint fgPid;
+			GetWindowThreadProcessId(fg, out fgPid);
+			if (fgPid == (uint)Environment.ProcessId)
+			{
+				return; // 不动自己的窗口
+			}
+			RECT cur;
+			GetWindowRect(fg, out cur);
+			RECT curWork = WorkAreaOf(fg);
+			List<RECT> monitors = new List<RECT>();
+			EnumDisplayMonitors(IntPtr.Zero, IntPtr.Zero, delegate(nint hMon, nint hdc, ref RECT rc, nint data)
+			{
+				monitors.Add(rc);
+				return true;
+			}, IntPtr.Zero);
+			if (monitors.Count < 2)
+			{
+				return; // 单显示器无可移动
+			}
+			// 找到当前所在屏，取下一个（循环）
+			int curIdx = -1;
+			for (int i = 0; i < monitors.Count; i++)
+			{
+				RECT m = monitors[i];
+				if (cur.Left >= m.Left && cur.Left < m.Right && cur.Top >= m.Top && cur.Top < m.Bottom)
+				{
+					curIdx = i;
+					break;
+				}
+			}
+			int next = (curIdx + 1) % monitors.Count;
+			RECT nm = monitors[next];
+			RECT nw = WorkAreaOfMonitor(nm);
+			// 相对当前屏工作区的比例 → 目标屏工作区
+			int curW = Math.Max(1, curWork.Right - curWork.Left);
+			int curH = Math.Max(1, curWork.Bottom - curWork.Top);
+			int fx = cur.Left - curWork.Left;
+			int fy = cur.Top - curWork.Top;
+			int targetW = Math.Max(1, nw.Right - nw.Left);
+			int targetH = Math.Max(1, nw.Bottom - nw.Top);
+			int x = nw.Left + (int)Math.Round((double)fx * targetW / curW);
+			int y = nw.Top + (int)Math.Round((double)fy * targetH / curH);
+			int w = Math.Max(1, cur.Right - cur.Left);
+			int h = Math.Max(1, cur.Bottom - cur.Top);
+			w = Math.Min(w, targetW);
+			h = Math.Min(h, targetH);
+			if (IsIconic(fg))
+			{
+				ShowWindow(fg, SW_RESTORE);
+			}
+			SetWindowPos(fg, HWND_TOP, x, y, w, h, SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW | SWP_ASYNCWINDOWPOS);
+			AppLogger.LogInfo($"[Tile] MoveToMonitor: hwnd=0x{fg:X} → monitor#{next} ({x},{y},{w}x{h})");
+		}
+		catch (Exception ex)
+		{
+			AppLogger.LogError("[Tile] 移动显示器失败", ex);
+		}
+	}
+
+	private static nint GetShellWindowHandleSafe()
+	{
+		try
+		{
+			return GetShellWindow();
+		}
+		catch
+		{
+			return IntPtr.Zero;
+		}
+	}
+
+	private static RECT WorkAreaOfMonitor(RECT monitor)
+	{
+		try
+		{
+			nint mon = MonitorFromRect(monitor, MONITOR_DEFAULTTONEAREST);
+			MONITORINFO mi = default;
+			mi.cbSize = Marshal.SizeOf<MONITORINFO>();
+			if (mon != IntPtr.Zero && GetMonitorInfo(mon, ref mi))
+			{
+				return mi.rcWork;
+			}
+		}
+		catch
+		{
+		}
+		return monitor;
+	}
+
+	/// <summary>切换当前前台窗口置顶状态；参数 "1"/"on" 强制置顶、"0"/"off" 取消、空参数切换。</summary>
+	public static void ToggleWindowTopmost(string? param)
+	{
+		try
+		{
+			nint fg = GetForegroundWindow();
+			if (fg == IntPtr.Zero || fg == GetShellWindowHandleSafe())
+			{
+				return;
+			}
+			uint fgPid;
+			GetWindowThreadProcessId(fg, out fgPid);
+			if (fgPid == (uint)Environment.ProcessId)
+			{
+				return;
+			}
+			bool top = (GetWindowLongPtr(fg, GWL_EXSTYLE).ToInt64() & 0x8L) != 0L; // WS_EX_TOPMOST
+			bool want = string.IsNullOrWhiteSpace(param) ? !top : (param.Trim() == "1" || string.Equals(param.Trim(), "on", StringComparison.OrdinalIgnoreCase));
+			SetWindowPos(fg, want ? new nint(-1) : new nint(-2), 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+			AppLogger.LogInfo($"[Tile] Topmost hwnd=0x{fg:X} → {want}");
+		}
+		catch (Exception ex)
+		{
+			AppLogger.LogError("[Tile] 置顶失败", ex);
+		}
+	}
+
+	/// <summary>设置当前前台窗口透明度（参数 1~100，空参数默认 50；100 = 不透明）。</summary>
+	public static void SetWindowOpacity(string? param)
+	{
+		try
+		{
+			nint fg = GetForegroundWindow();
+			if (fg == IntPtr.Zero || fg == GetShellWindowHandleSafe())
+			{
+				return;
+			}
+			uint fgPid;
+			GetWindowThreadProcessId(fg, out fgPid);
+			if (fgPid == (uint)Environment.ProcessId)
+			{
+				return;
+			}
+			double level = 50.0;
+			if (double.TryParse(param, out double v))
+			{
+				level = v;
+			}
+			level = Math.Max(1.0, Math.Min(100.0, level));
+			nint ex = GetWindowLongPtr(fg, GWL_EXSTYLE);
+			SetWindowLongPtr(fg, GWL_EXSTYLE, new nint(ex.ToInt64() | WS_EX_LAYERED));
+			SetLayeredWindowAttributes(fg, 0, (byte)Math.Round(level * 255.0 / 100.0), LWA_ALPHA);
+			AppLogger.LogInfo($"[Tile] Opacity hwnd=0x{fg:X} → {level}%");
+		}
+		catch (Exception ex)
+		{
+			AppLogger.LogError("[Tile] 透明度失败", ex);
+		}
 	}
 
 	/// <summary>EnumWindows 兜底枚举：可见、非本进程、有标题的顶层窗口（保留任务栏顺序路径的过滤语义）。</summary>

--- a/WinPieGestures/WindowTiler.cs
+++ b/WinPieGestures/WindowTiler.cs
@@ -102,6 +102,9 @@ public static class WindowTiler
 	private static extern bool SetLayeredWindowAttributes(nint hWnd, uint crKey, byte bAlpha, uint dwFlags);
 
 	[DllImport("user32.dll")]
+	private static extern bool GetLayeredWindowAttributes(nint hWnd, out uint crKey, out byte bAlpha, out uint dwFlags);
+
+	[DllImport("user32.dll")]
 	private static extern bool EnumDisplayMonitors(nint hdc, nint lprcClip, EnumMonitorsProc lpfnEnum, nint dwData);
 
 	private delegate bool EnumMonitorsProc(nint hMonitor, nint hdcMonitor, ref RECT lprcMonitor, nint dwData);
@@ -117,6 +120,7 @@ public static class WindowTiler
 	private const uint WS_EX_LAYERED = 0x00080000;
 	private const int GWL_EXSTYLE = -20;
 	private const uint LWA_ALPHA = 0x00000002;
+	private const uint LWA_COLORKEY = 0x00000001;
 	private const uint SW_RESTORE_U = 9u;
 
 	// 上次平铺快照（供「恢复」与内存记忆）
@@ -383,7 +387,15 @@ public static class WindowTiler
 				{
 					continue;
 				}
-				if ((GetWindowLongPtr(h, GWL_EXSTYLE).ToInt64() & WS_EX_TOOLWINDOW) != 0L)
+				long exstyle = GetWindowLongPtr(h, GWL_EXSTYLE).ToInt64();
+				if ((exstyle & WS_EX_TOOLWINDOW) != 0L)
+				{
+					continue;
+				}
+				// 排除透明/半透明窗口（分层且 alpha<255 或 COLORKEY），避免"透明窗占位"
+				if ((exstyle & WS_EX_LAYERED) != 0L &&
+					GetLayeredWindowAttributes(h, out uint crKey, out byte alpha, out uint lwaFlags) &&
+					(((lwaFlags & LWA_ALPHA) != 0u && alpha < 255) || (lwaFlags & LWA_COLORKEY) != 0u))
 				{
 					continue;
 				}

--- a/WinPieGestures/WindowTiler.cs
+++ b/WinPieGestures/WindowTiler.cs
@@ -111,18 +111,25 @@ public static class WindowTiler
 	// 上次平铺快照（供「恢复」与内存记忆）
 	private static readonly Dictionary<nint, RECT> s_lastSnapshot = new Dictionary<nint, RECT>();
 	private static int s_cycleIndex;
+	private static string s_currentLayout = "2L";
 
 	/// <summary>可选布局 key 列表（顺序即编辑器下拉顺序）。</summary>
 	public static List<string> LayoutKeys { get; } = new List<string>
 	{
-		"2L", "2T", "3L12", "3R21", "3R", "4G", "6G"
+		"2L", "2T", "3L12", "3R21", "3R", "4G", "6G", "ML", "MR", "MT", "MB"
 	};
 
 	/// <summary>轮换模式标记：参数为 Cycle 时循环切换布局。</summary>
 	public const string CycleParam = "Cycle";
 
+	/// <summary>反向轮换标记。</summary>
+	public const string CycleBackParam = "CycleBack";
+
 	/// <summary>还原标记：参数为 Restore 时还原所有窗口到平铺前。</summary>
 	public const string RestoreParam = "Restore";
+
+	/// <summary>主轴布局的 Master 占比（同 Dwalia 默认 0.6）。</summary>
+	public const double MasterFactor = 0.6;
 
 	public static bool IsValidLayout(string key)
 	{
@@ -140,8 +147,44 @@ public static class WindowTiler
 			"3R" => I18n.T("TileLayout3R"),
 			"4G" => I18n.T("TileLayout4G"),
 			"6G" => I18n.T("TileLayout6G"),
+			"ML" => I18n.T("TileLayoutML"),
+			"MR" => I18n.T("TileLayoutMR"),
+			"MT" => I18n.T("TileLayoutMT"),
+			"MB" => I18n.T("TileLayoutMB"),
 			_ => key
 		};
+	}
+
+	/// <summary>循环范围：配置的 TileCycleLayouts（逗号分隔 key）；为空则全部布局参与。</summary>
+	private static List<string> GetCycleScope()
+	{
+		List<string> list = new List<string>();
+		string? cfg = ConfigManager.CurrentConfig?.TileCycleLayouts;
+		if (!string.IsNullOrWhiteSpace(cfg))
+		{
+			foreach (string token in cfg.Split(new[] { ',', ';', '，', '；', ' ' }, StringSplitOptions.RemoveEmptyEntries))
+			{
+				string k = token.Trim();
+				if (IsValidLayout(k) && !list.Contains(k))
+				{
+					list.Add(k);
+				}
+			}
+		}
+		if (list.Count == 0)
+		{
+			list.AddRange(LayoutKeys);
+		}
+		return list;
+	}
+
+	/// <summary>当前布局（每次平铺/循环都会更新；供循环从"当前"起跳）。</summary>
+	public static string CurrentLayout
+	{
+		get
+		{
+			return s_currentLayout;
+		}
 	}
 
 	/// <summary>在后台执行平铺：取对象 → 各窗口主显示器工作区 → 按布局格子 SetWindowPos。</summary>
@@ -155,15 +198,30 @@ public static class WindowTiler
 				RestoreLastLayout();
 				return;
 			}
+			List<string> scope = GetCycleScope();
 			if (string.Equals(key, CycleParam, StringComparison.OrdinalIgnoreCase))
 			{
-				key = LayoutKeys[s_cycleIndex % LayoutKeys.Count];
-				s_cycleIndex = (s_cycleIndex + 1) % LayoutKeys.Count;
+				int cur = scope.IndexOf(s_currentLayout);
+				if (cur < 0)
+				{
+					cur = 0;
+				}
+				key = scope[(cur + 1) % scope.Count];
+			}
+			else if (string.Equals(key, CycleBackParam, StringComparison.OrdinalIgnoreCase))
+			{
+				int cur = scope.IndexOf(s_currentLayout);
+				if (cur < 0)
+				{
+					cur = 0;
+				}
+				key = scope[(cur - 1 + scope.Count) % scope.Count];
 			}
 			if (!IsValidLayout(key))
 			{
 				key = "2L";
 			}
+			s_currentLayout = key;
 			// 排除名单（进程 exe 名，逗号/分号分隔）
 			HashSet<string> exclude = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 			string? excl = ConfigManager.CurrentConfig?.TileExcludeProcesses;
@@ -181,8 +239,8 @@ public static class WindowTiler
 			{
 				return;
 			}
-			double[][] cells = LayoutCells(key);
-			int count = Math.Min(targets.Count, cells.Length);
+			List<double[]> cells = LayoutCells(key, targets.Count);
+			int count = Math.Min(targets.Count, cells.Count);
 			Dictionary<nint, RECT> snapshot = new Dictionary<nint, RECT>();
 			for (int i = 0; i < count; i++)
 			{
@@ -548,56 +606,110 @@ public static class WindowTiler
 		};
 	}
 
-	/// <summary>每种布局的格子比例 [x0,y0,x1,y1]，格子顺序 = 窗口顺序。</summary>
-	private static double[][] LayoutCells(string key)
+	/// <summary>
+/// 生成布局格子比例 [x0,y0,x1,y1]，格子顺序 = 窗口顺序。
+/// 固定预设为常量表；ML/MR/MT/MB（Master+Stack，学习 Dwalia 算法）按窗口数动态切分：
+/// Master 占 60%（Dwalia 默认 masterFactor），其余窗口在 Stack 区按 n-1 等分。
+/// </summary>
+	private static List<double[]> LayoutCells(string key, int n)
 	{
-		return key switch
+		switch (key)
 		{
-			"2L" => new[]
+		case "ML":
+			return MasterCells(n, MasterFactor, masterLeft: true, masterTop: false);
+		case "MR":
+			return MasterCells(n, MasterFactor, masterLeft: false, masterTop: false);
+		case "MT":
+			return MasterCells(n, MasterFactor, masterLeft: false, masterTop: true);
+		case "MB":
+			return MasterCells(n, MasterFactor, masterLeft: false, masterTop: true, masterBottom: true);
+		}
+		List<double[]> fixedCells = new List<double[]>();
+		switch (key)
+		{
+		case "2L":
+			fixedCells.Add(new[] { 0.0, 0.0, 0.5, 1.0 });
+			fixedCells.Add(new[] { 0.5, 0.0, 1.0, 1.0 });
+			break;
+		case "2T":
+			fixedCells.Add(new[] { 0.0, 0.0, 1.0, 0.5 });
+			fixedCells.Add(new[] { 0.0, 0.5, 1.0, 1.0 });
+			break;
+		case "3L12":
+			fixedCells.Add(new[] { 0.0, 0.0, 0.5, 1.0 });
+			fixedCells.Add(new[] { 0.5, 0.0, 1.0, 0.5 });
+			fixedCells.Add(new[] { 0.5, 0.5, 1.0, 1.0 });
+			break;
+		case "3R21":
+			fixedCells.Add(new[] { 0.0, 0.0, 0.5, 0.5 });
+			fixedCells.Add(new[] { 0.0, 0.5, 0.5, 1.0 });
+			fixedCells.Add(new[] { 0.5, 0.0, 1.0, 1.0 });
+			break;
+		case "3R":
+			fixedCells.Add(new[] { 0.0, 0.0, 1.0 / 3.0, 1.0 });
+			fixedCells.Add(new[] { 1.0 / 3.0, 0.0, 2.0 / 3.0, 1.0 });
+			fixedCells.Add(new[] { 2.0 / 3.0, 0.0, 1.0, 1.0 });
+			break;
+		case "4G":
+			fixedCells.Add(new[] { 0.0, 0.0, 0.5, 0.5 });
+			fixedCells.Add(new[] { 0.5, 0.0, 1.0, 0.5 });
+			fixedCells.Add(new[] { 0.0, 0.5, 0.5, 1.0 });
+			fixedCells.Add(new[] { 0.5, 0.5, 1.0, 1.0 });
+			break;
+		case "6G":
+			fixedCells.Add(new[] { 0.0, 0.0, 1.0 / 3.0, 0.5 });
+			fixedCells.Add(new[] { 1.0 / 3.0, 0.0, 2.0 / 3.0, 0.5 });
+			fixedCells.Add(new[] { 2.0 / 3.0, 0.0, 1.0, 0.5 });
+			fixedCells.Add(new[] { 0.0, 0.5, 1.0 / 3.0, 1.0 });
+			fixedCells.Add(new[] { 1.0 / 3.0, 0.5, 2.0 / 3.0, 1.0 });
+			fixedCells.Add(new[] { 2.0 / 3.0, 0.5, 1.0, 1.0 });
+			break;
+		default:
+			fixedCells.Add(new[] { 0.0, 0.0, 0.5, 1.0 });
+			fixedCells.Add(new[] { 0.5, 0.0, 1.0, 1.0 });
+			break;
+		}
+		return fixedCells;
+	}
+
+	/// <summary>Master+Stack 动态格子：Master 占 factor，Stack 区等分 n-1 块（Master 恒为 0 号窗口）。</summary>
+	private static List<double[]> MasterCells(int n, double factor, bool masterLeft, bool masterTop, bool masterBottom = false)
+	{
+		List<double[]> cells = new List<double[]>();
+		if (n <= 0)
+		{
+			return cells;
+		}
+		if (n == 1)
+		{
+			cells.Add(new[] { 0.0, 0.0, 1.0, 1.0 });
+			return cells;
+		}
+		int stack = n - 1;
+		if (masterLeft || !masterTop)
+		{
+			// 左右主轴：Master 占 factor（左或右），Stack 侧列按行等分
+			double mX0 = masterLeft ? 0.0 : 1.0 - factor;
+			double mX1 = masterLeft ? factor : 1.0;
+			double sX0 = masterLeft ? factor : 0.0;
+			double sX1 = masterLeft ? 1.0 : 1.0 - factor;
+			cells.Add(new[] { mX0, 0.0, mX1, 1.0 });
+			for (int i = 0; i < stack; i++)
 			{
-				new[] { 0.0, 0.0, 0.5, 1.0 },
-				new[] { 0.5, 0.0, 1.0, 1.0 }
-			},
-			"2T" => new[]
-			{
-				new[] { 0.0, 0.0, 1.0, 0.5 },
-				new[] { 0.0, 0.5, 1.0, 1.0 }
-			},
-			"3L12" => new[]
-			{
-				new[] { 0.0, 0.0, 0.5, 1.0 },
-				new[] { 0.5, 0.0, 1.0, 0.5 },
-				new[] { 0.5, 0.5, 1.0, 1.0 }
-			},
-			"3R21" => new[]
-			{
-				new[] { 0.0, 0.0, 0.5, 0.5 },
-				new[] { 0.0, 0.5, 0.5, 1.0 },
-				new[] { 0.5, 0.0, 1.0, 1.0 }
-			},
-			"3R" => new[]
-			{
-				new[] { 0.0, 0.0, 1.0 / 3.0, 1.0 },
-				new[] { 1.0 / 3.0, 0.0, 2.0 / 3.0, 1.0 },
-				new[] { 2.0 / 3.0, 0.0, 1.0, 1.0 }
-			},
-			"4G" => new[]
-			{
-				new[] { 0.0, 0.0, 0.5, 0.5 },
-				new[] { 0.5, 0.0, 1.0, 0.5 },
-				new[] { 0.0, 0.5, 0.5, 1.0 },
-				new[] { 0.5, 0.5, 1.0, 1.0 }
-			},
-			"6G" => new[]
-			{
-				new[] { 0.0, 0.0, 1.0 / 3.0, 0.5 },
-				new[] { 1.0 / 3.0, 0.0, 2.0 / 3.0, 0.5 },
-				new[] { 2.0 / 3.0, 0.0, 1.0, 0.5 },
-				new[] { 0.0, 0.5, 1.0 / 3.0, 1.0 },
-				new[] { 1.0 / 3.0, 0.5, 2.0 / 3.0, 1.0 },
-				new[] { 2.0 / 3.0, 0.5, 1.0, 1.0 }
-			},
-			_ => new[] { new[] { 0.0, 0.0, 0.5, 1.0 }, new[] { 0.5, 0.0, 1.0, 1.0 } }
-		};
+				cells.Add(new[] { sX0, (double)i / stack, sX1, (double)(i + 1) / stack });
+			}
+			return cells;
+		}
+		// 上下主轴：Master 占 factor（顶部或底部），Stack 横排按列等分
+		double mY0 = masterBottom ? 1.0 - factor : 0.0;
+		double mY1 = masterBottom ? 1.0 : factor;
+		double sY0 = masterBottom ? 0.0 : factor;
+		double sY1 = masterBottom ? 1.0 - factor : 1.0;
+		cells.Add(new[] { 0.0, mY0, 1.0, mY1 });
+		for (int i = 0; i < stack; i++)
+		{
+			cells.Add(new[] { (double)i / stack, sY0, (double)(i + 1) / stack, sY1 });
+		}
+		return cells;
 	}
 }

--- a/WinPieGestures/WindowTiler.cs
+++ b/WinPieGestures/WindowTiler.cs
@@ -785,6 +785,23 @@ public static class WindowTiler
 			return AutoGridCells(n); // AutoGrid：按数量自适应行列
 		}
 		List<double[]> fixedCells = new List<double[]>();
+		// 固定网格布局：窗口数等于名义格数时用其标准形状；否则回退"恰好覆盖 N 的无空格网格"，
+		// 避免窗口少时出现空位（先算窗口数，再定布局）。
+		int nominal = key switch
+		{
+			"2L" => 2,
+			"2T" => 2,
+			"3L12" => 3,
+			"3R21" => 3,
+			"3R" => 3,
+			"4G" => 4,
+			"6G" => 6,
+			_ => 0
+		};
+		if (nominal > 0 && n != nominal)
+		{
+			return ExactGridCells(n);
+		}
 		switch (key)
 		{
 		case "2L":
@@ -839,6 +856,38 @@ public static class WindowTiler
 		for (int i = 0; i < n; i++)
 		{
 			cells.Add(new[] { 0.0, 0.0, 1.0, 1.0 });
+		}
+		return cells;
+	}
+
+	/// <summary>恰好覆盖 n 个窗口的无空格网格（行列数取 n 最接近平方的因子分解）。</summary>
+	private static List<double[]> ExactGridCells(int n)
+	{
+		List<double[]> cells = new List<double[]>();
+		if (n <= 0)
+		{
+			return cells;
+		}
+		if (n == 1)
+		{
+			cells.Add(new[] { 0.0, 0.0, 1.0, 1.0 });
+			return cells;
+		}
+		int cols = (int)Math.Ceiling(Math.Sqrt(n));
+		while (cols > 1 && n % cols != 0)
+		{
+			cols--;
+		}
+		if (n % cols != 0)
+		{
+			cols = 1;
+		}
+		int rows = n / cols;
+		for (int i = 0; i < n; i++)
+		{
+			int r = i / cols;
+			int c = i % cols;
+			cells.Add(new[] { (double)c / cols, (double)r / rows, (double)(c + 1) / cols, (double)(r + 1) / rows });
 		}
 		return cells;
 	}

--- a/WinPieGestures/WindowTiler.cs
+++ b/WinPieGestures/WindowTiler.cs
@@ -354,16 +354,33 @@ public static class WindowTiler
 		}
 	}
 
+	/// <summary>内置"系统/厂商后台工具"黑名单（恒生效，避免干扰平铺）：输入法、UWP 宿主、设置、华硕等。</summary>
+	private static readonly string[] s_systemUtilityExes =
+	{
+		"textinputhost", "ctfmon", "sihost", "startmenuexperiencehost", "searchhost", "searchapp",
+		"shellexperiencehost", "runtimebroker", "backgroundtaskhost", "dllhost", "applicationframehost",
+		"systemsettings", "ashotplugctrl", "asmonitorcontrol", "armourycrateservice", "asusappservice",
+		"hhddevicediscovery", "igfxext", "igfxpers", "hkcmd"
+	};
+
 	/// <summary>
-/// 平铺对象：当前虚拟桌面上的可见窗口。只管理"exe 出现在任务栏槽位"的应用窗口（Dwalia 语义：
-/// 只处理真实驻留应用），同 exe 多窗口全收（两个终端都参与）；组间顺序 = 任务栏槽位顺序，
-/// 组内按句柄升序（≈先启动在前，先启动者为 Master）。
-/// 排除：无标题栏/工具窗/透明/遮蔽/无拥有者/无标题/本进程/排除名单/非任务栏应用的杂窗。
-/// </summary>
-	private static List<nint> GetTileTargets(HashSet<string> excludedExes, bool includeMinimized)
+	/// 平铺对象：当前虚拟桌面上的可见窗口。只管理"exe 出现在任务栏槽位"的应用窗口（Dwalia 语义：
+	/// 只处理真实驻留应用），同 exe 多窗口全收（两个终端都参与）；组间顺序 = 任务栏槽位顺序，
+	/// 组内按句柄升序（≈先启动在前，先启动者为 Master）。
+	/// 排除：无标题栏/工具窗/透明/遮蔽/无拥有者/无标题/本进程/系统工具黑名单/用户排除名单/非任务栏应用的杂窗。
+	/// </summary>
+	private static List<nint> GetTileTargets(HashSet<string> userExcludedExes, bool includeMinimized)
 	{
 		List<nint> result = new List<nint>();
 		uint selfPid = (uint)Environment.ProcessId;
+
+		// 黑名单 = 内置系统工具 + 用户配置的排除名单
+		HashSet<string> blockedExes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		blockedExes.UnionWith(s_systemUtilityExes);
+		if (userExcludedExes.Count > 0)
+		{
+			blockedExes.UnionWith(userExcludedExes);
+		}
 
 		// 槽位顺序 → exe 名顺序（分组排序基准 + 白名单：只收这些 exe 的窗口）
 		List<string> slotExeOrder = new List<string>();
@@ -437,22 +454,14 @@ public static class WindowTiler
 				{
 					continue;
 				}
-				if (excludedExes.Count > 0)
-				{
-					string? exe = ExeNameOfPid(pid);
-					if (exe != null && excludedExes.Contains(exe))
-					{
-						continue;
-					}
-				}
-				StringBuilder sb = new StringBuilder(128);
-				if (GetWindowText(h, sb, 128) <= 0)
+				string? exeKey = ExeNameOfPid(pid);
+				// 只收任务栏存在应用的窗口（Dwalia：只管理真实驻留应用的窗口），且不在系统工具/用户黑名单
+				if (exeKey == null || !slotExes.Contains(exeKey) || blockedExes.Contains(exeKey))
 				{
 					continue;
 				}
-				string? exeKey = ExeNameOfPid(pid);
-				// 只收任务栏存在应用的窗口（Dwalia：只管理真实驻留应用的窗口）——杂窗/后台窗一律不入布局
-				if (exeKey == null || !slotExes.Contains(exeKey))
+				StringBuilder sb = new StringBuilder(128);
+				if (GetWindowText(h, sb, 128) <= 0)
 				{
 					continue;
 				}

--- a/WinPieGestures/WindowTiler.cs
+++ b/WinPieGestures/WindowTiler.cs
@@ -210,10 +210,14 @@ public static class WindowTiler
 			}
 			lock (s_lastSnapshot)
 			{
-				s_lastSnapshot.Clear();
-				foreach (var kv in snapshot)
+				// 只记录"第一次"平铺前的状态：后续换布局/循环不覆盖，
+				// 保证「还原所有窗口」始终回到首次平铺之前的样式。
+				if (s_lastSnapshot.Count == 0)
 				{
-					s_lastSnapshot[kv.Key] = kv.Value;
+					foreach (var kv in snapshot)
+					{
+						s_lastSnapshot[kv.Key] = kv.Value;
+					}
 				}
 			}
 		}

--- a/WinPieGestures/WindowTiler.cs
+++ b/WinPieGestures/WindowTiler.cs
@@ -116,7 +116,7 @@ public static class WindowTiler
 	/// <summary>可选布局 key 列表（顺序即编辑器下拉顺序）。</summary>
 	public static List<string> LayoutKeys { get; } = new List<string>
 	{
-		"2L", "2T", "3L12", "3R21", "3R", "4G", "6G", "ML", "MR", "MT", "MB"
+		"2L", "2T", "3L12", "3R21", "3R", "4G", "6G", "ML", "MR", "MT", "MB", "MO", "HS", "VS", "COL", "BSP", "AG"
 	};
 
 	/// <summary>轮换模式标记：参数为 Cycle 时循环切换布局。</summary>
@@ -151,6 +151,12 @@ public static class WindowTiler
 			"MR" => I18n.T("TileLayoutMR"),
 			"MT" => I18n.T("TileLayoutMT"),
 			"MB" => I18n.T("TileLayoutMB"),
+			"MO" => I18n.T("TileLayoutMO"),
+			"HS" => I18n.T("TileLayoutHS"),
+			"VS" => I18n.T("TileLayoutVS"),
+			"COL" => I18n.T("TileLayoutCOL"),
+			"BSP" => I18n.T("TileLayoutBSP"),
+			"AG" => I18n.T("TileLayoutAG"),
 			_ => key
 		};
 	}
@@ -623,6 +629,18 @@ public static class WindowTiler
 			return MasterCells(n, MasterFactor, masterLeft: false, masterTop: true);
 		case "MB":
 			return MasterCells(n, MasterFactor, masterLeft: false, masterTop: true, masterBottom: true);
+		case "HS":
+			return MasterCells(n, 0.5, masterLeft: false, masterTop: true); // HorizontalStack：上主 50% + 下栈单行
+		case "VS":
+			return MasterCells(n, 0.5, masterLeft: true, masterTop: false); // VerticalStack：左主 50% + 右栈单列
+		case "MO":
+			return MonocleCells(n); // Monocle：每窗占满工作区
+		case "COL":
+			return ColumnsCells(n); // Columns：等宽竖列
+		case "BSP":
+			return BspCells(n);     // BSP：交替二分递归
+		case "AG":
+			return AutoGridCells(n); // AutoGrid：按数量自适应行列
 		}
 		List<double[]> fixedCells = new List<double[]>();
 		switch (key)
@@ -670,6 +688,80 @@ public static class WindowTiler
 			break;
 		}
 		return fixedCells;
+	}
+
+	/// <summary>Monocle：所有窗口占满同一工作区（层叠，最后者在上）。</summary>
+	private static List<double[]> MonocleCells(int n)
+	{
+		List<double[]> cells = new List<double[]>();
+		for (int i = 0; i < n; i++)
+		{
+			cells.Add(new[] { 0.0, 0.0, 1.0, 1.0 });
+		}
+		return cells;
+	}
+
+	/// <summary>Columns：等宽竖列，每窗一列。</summary>
+	private static List<double[]> ColumnsCells(int n)
+	{
+		List<double[]> cells = new List<double[]>();
+		for (int i = 0; i < n; i++)
+		{
+			cells.Add(new[] { (double)i / n, 0.0, (double)(i + 1) / n, 1.0 });
+		}
+		return cells;
+	}
+
+	/// <summary>BSP：交替二分递归——第 i 层取当前区块一半，其余窗口递归剩余区块。</summary>
+	private static List<double[]> BspCells(int n)
+	{
+		List<double[]> cells = new List<double[]>();
+		BspSplit(cells, 0.0, 0.0, 1.0, 1.0, 0, n);
+		return cells;
+	}
+
+	private static void BspSplit(List<double[]> cells, double x0, double y0, double x1, double y1, int i, int n)
+	{
+		if (i >= n)
+		{
+			return;
+		}
+		if (i == n - 1)
+		{
+			cells.Add(new[] { x0, y0, x1, y1 });
+			return;
+		}
+		if (i % 2 == 0)
+		{
+			double mx = (x0 + x1) / 2.0;
+			cells.Add(new[] { x0, y0, mx, y1 });
+			BspSplit(cells, mx, y0, x1, y1, i + 1, n);
+		}
+		else
+		{
+			double my = (y0 + y1) / 2.0;
+			cells.Add(new[] { x0, y0, x1, my });
+			BspSplit(cells, x0, my, x1, y1, i + 1, n);
+		}
+	}
+
+	/// <summary>AutoGrid：按窗口数自适应行列（cols=⌈√n⌉）。</summary>
+	private static List<double[]> AutoGridCells(int n)
+	{
+		List<double[]> cells = new List<double[]>();
+		if (n <= 0)
+		{
+			return cells;
+		}
+		int cols = (int)Math.Ceiling(Math.Sqrt(n));
+		int rows = (n + cols - 1) / cols;
+		for (int i = 0; i < n; i++)
+		{
+			int r = i / cols;
+			int c = i % cols;
+			cells.Add(new[] { (double)c / cols, (double)r / rows, (double)(c + 1) / cols, (double)(r + 1) / rows });
+		}
+		return cells;
 	}
 
 	/// <summary>Master+Stack 动态格子：Master 占 factor，Stack 区等分 n-1 块（Master 恒为 0 号窗口）。</summary>

--- a/WinPieGestures/WindowTiler.cs
+++ b/WinPieGestures/WindowTiler.cs
@@ -1,0 +1,320 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Windows;
+
+namespace WinPieGestures;
+
+/// <summary>
+/// 平铺窗口执行器：把当前虚拟桌面上的可见窗口按预置布局平铺到各自主显示器工作区。
+/// 纯物理像素 SetWindowPos；不激活、不抢焦点；由 ActionExecutor 的后台队列调用。
+/// </summary>
+public static class WindowTiler
+{
+	[StructLayout(LayoutKind.Sequential)]
+	private struct RECT
+	{
+		public int Left;
+		public int Top;
+		public int Right;
+		public int Bottom;
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	private struct MONITORINFO
+	{
+		public int cbSize;
+		public RECT rcMonitor;
+		public RECT rcWork;
+		public uint dwFlags;
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	private struct POINT
+	{
+		public int x;
+		public int y;
+	}
+
+	private const uint MONITOR_DEFAULTTONEAREST = 2;
+
+	[DllImport("user32.dll")]
+	private static extern nint MonitorFromPoint(POINT pt, uint dwFlags);
+
+	[DllImport("user32.dll")]
+	private static extern nint MonitorFromWindow(nint hWnd, uint dwFlags);
+
+	[DllImport("user32.dll")]
+	private static extern bool GetMonitorInfo(nint hMonitor, ref MONITORINFO lpmi);
+
+	[DllImport("user32.dll", SetLastError = true)]
+	private static extern bool SetWindowPos(nint hWnd, nint hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+
+	[DllImport("user32.dll")]
+	private static extern bool ShowWindow(nint hWnd, int nCmdShow);
+
+	[DllImport("user32.dll")]
+	private static extern bool IsWindowVisible(nint hWnd);
+
+	[DllImport("user32.dll")]
+	private static extern bool IsIconic(nint hWnd);
+
+	[DllImport("user32.dll")]
+	private static extern bool IsZoomed(nint hWnd);
+
+	[DllImport("user32.dll")]
+	private static extern int GetWindowText(nint hWnd, StringBuilder lpString, int nMaxCount);
+
+	[DllImport("user32.dll")]
+	private static extern uint GetWindowThreadProcessId(nint hWnd, out uint lpdwProcessId);
+
+	private const int SW_RESTORE = 9;
+	private const uint SWP_NOZORDER = 0x0004;
+	private const uint SWP_NOACTIVATE = 0x0010;
+	private const uint SWP_SHOWWINDOW = 0x0040;
+	private const uint SWP_ASYNCWINDOWPOS = 0x4000;
+	private static readonly nint HWND_TOP = new nint(0);
+
+	/// <summary>可选布局 key 列表（顺序即编辑器下拉顺序）。</summary>
+	public static List<string> LayoutKeys { get; } = new List<string>
+	{
+		"2L", "2T", "3L12", "3R21", "3R", "4G", "6G"
+	};
+
+	public static bool IsValidLayout(string key)
+	{
+		return LayoutKeys.Contains(key);
+	}
+
+	public static string LayoutDisplayName(string key)
+	{
+		return key switch
+		{
+			"2L" => I18n.T("TileLayout2L"),
+			"2T" => I18n.T("TileLayout2T"),
+			"3L12" => I18n.T("TileLayout3L12"),
+			"3R21" => I18n.T("TileLayout3R21"),
+			"3R" => I18n.T("TileLayout3R"),
+			"4G" => I18n.T("TileLayout4G"),
+			"6G" => I18n.T("TileLayout6G"),
+			_ => key
+		};
+	}
+
+	/// <summary>在后台执行平铺：取对象 → 各窗口主显示器工作区 → 按布局格子 SetWindowPos。</summary>
+	public static void ExecuteTile(string? layoutKey)
+	{
+		try
+		{
+			string key = string.IsNullOrWhiteSpace(layoutKey) ? "2L" : layoutKey.Trim();
+			if (!IsValidLayout(key))
+			{
+				key = "2L";
+			}
+			List<nint> targets = GetTileTargets();
+			AppLogger.LogInfo($"[Tile] layout='{key}' targets={targets.Count}");
+			if (targets.Count == 0)
+			{
+				return;
+			}
+			double[][] cells = LayoutCells(key);
+			int count = Math.Min(targets.Count, cells.Length);
+			for (int i = 0; i < count; i++)
+			{
+				RECT wa = WorkAreaOf(targets[i]);
+				double[] c = cells[i];
+				int x = wa.Left + (int)Math.Round((wa.Right - wa.Left) * c[0]);
+				int y = wa.Top + (int)Math.Round((wa.Bottom - wa.Top) * c[1]);
+				int w = (int)Math.Round((wa.Right - wa.Left) * c[2]) - (x - wa.Left);
+				int h = (int)Math.Round((wa.Bottom - wa.Top) * c[3]) - (y - wa.Top);
+				w = Math.Max(1, w);
+				h = Math.Max(1, h);
+				// 最大化/全屏状态会无视 SetWindowPos：先还原，再定位
+				if (IsIconic(targets[i]))
+				{
+					ShowWindow(targets[i], SW_RESTORE);
+				}
+				else if (IsZoomed(targets[i]))
+				{
+					ShowWindow(targets[i], SW_RESTORE);
+				}
+				bool ok = SetWindowPos(targets[i], HWND_TOP, x, y, w, h, SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW | SWP_ASYNCWINDOWPOS);
+				AppLogger.LogInfo($"[Tile] #{i} hwnd=0x{targets[i]:X} rect=({x},{y},{w}x{h}) ok={ok}");
+			}
+		}
+		catch (Exception ex)
+		{
+			AppLogger.LogError("[Tile] 平铺失败", ex);
+		}
+	}
+
+	/// <summary>平铺对象：当前虚拟桌面可见的普通顶层窗口（任务栏顺序）；排除无标题/隐藏/本进程自身。</summary>
+	private static List<nint> GetTileTargets()
+	{
+		List<nint> result = new List<nint>();
+		uint selfPid = (uint)Environment.ProcessId;
+		foreach (nint h in WindowTaskbarHelper.GetTaskbarOrderedWindows())
+		{
+			if (h == IntPtr.Zero || !IsWindowVisible(h) || IsIconic(h))
+			{
+				continue; // 隐藏或最小化不参与
+			}
+			GetWindowThreadProcessId(h, out uint pid);
+			if (pid == selfPid)
+			{
+				continue; // 排除设置窗等自身窗口
+			}
+			StringBuilder sb = new StringBuilder(128);
+			if (GetWindowText(h, sb, 128) <= 0)
+			{
+				continue; // 无标题的后台窗口不参与
+			}
+			result.Add(h);
+		}
+		if (result.Count == 0)
+		{
+			// 兜底：任务栏快照拿不到时，直接枚举顶层窗口（当前桌面的可见普通窗口）
+			result.AddRange(EnumerateTopLevelWindows());
+		}
+		return result;
+	}
+
+	private delegate bool EnumWindowsProc(nint hWnd, nint lParam);
+
+	[DllImport("user32.dll")]
+	private static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, nint lParam);
+
+	private static readonly EnumWindowsProc s_enumProc = EnumCallback;
+
+	private static List<nint> s_enumBuffer = new List<nint>();
+
+	private static bool EnumCallback(nint hWnd, nint lParam)
+	{
+		s_enumBuffer.Add(hWnd);
+		return true;
+	}
+
+	/// <summary>EnumWindows 兜底枚举：可见、非本进程、有标题的顶层窗口（保留任务栏顺序路径的过滤语义）。</summary>
+	private static List<nint> EnumerateTopLevelWindows()
+	{
+		uint selfPid = (uint)Environment.ProcessId;
+		List<nint> buffer = new List<nint>();
+		List<nint> previous = s_enumBuffer;
+		s_enumBuffer = buffer;
+		try
+		{
+			EnumWindows(s_enumProc, IntPtr.Zero);
+		}
+		catch
+		{
+		}
+		finally
+		{
+			s_enumBuffer = previous;
+		}
+		List<nint> found = new List<nint>();
+		foreach (nint h in buffer)
+		{
+			try
+			{
+				if (h == IntPtr.Zero || !IsWindowVisible(h) || IsIconic(h))
+				{
+					continue;
+				}
+				GetWindowThreadProcessId(h, out uint pid);
+				if (pid == selfPid)
+				{
+					continue;
+				}
+				StringBuilder sb = new StringBuilder(128);
+				if (GetWindowText(h, sb, 128) <= 0)
+				{
+					continue;
+				}
+				found.Add(h);
+			}
+			catch
+			{
+			}
+		}
+		return found;
+	}
+
+	private static RECT WorkAreaOf(nint hWnd)
+	{
+		try
+		{
+			nint mon = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
+			MONITORINFO mi = default;
+			mi.cbSize = Marshal.SizeOf<MONITORINFO>();
+			if (mon != IntPtr.Zero && GetMonitorInfo(mon, ref mi))
+			{
+				return mi.rcWork;
+			}
+		}
+		catch
+		{
+		}
+		return new RECT
+		{
+			Left = (int)SystemParameters.VirtualScreenLeft,
+			Top = (int)SystemParameters.VirtualScreenTop,
+			Right = (int)(SystemParameters.VirtualScreenLeft + SystemParameters.VirtualScreenWidth),
+			Bottom = (int)(SystemParameters.VirtualScreenTop + SystemParameters.VirtualScreenHeight)
+		};
+	}
+
+	/// <summary>每种布局的格子比例 [x0,y0,x1,y1]，格子顺序 = 窗口顺序。</summary>
+	private static double[][] LayoutCells(string key)
+	{
+		return key switch
+		{
+			"2L" => new[]
+			{
+				new[] { 0.0, 0.0, 0.5, 1.0 },
+				new[] { 0.5, 0.0, 1.0, 1.0 }
+			},
+			"2T" => new[]
+			{
+				new[] { 0.0, 0.0, 1.0, 0.5 },
+				new[] { 0.0, 0.5, 1.0, 1.0 }
+			},
+			"3L12" => new[]
+			{
+				new[] { 0.0, 0.0, 0.5, 1.0 },
+				new[] { 0.5, 0.0, 1.0, 0.5 },
+				new[] { 0.5, 0.5, 1.0, 1.0 }
+			},
+			"3R21" => new[]
+			{
+				new[] { 0.0, 0.0, 0.5, 0.5 },
+				new[] { 0.0, 0.5, 0.5, 1.0 },
+				new[] { 0.5, 0.0, 1.0, 1.0 }
+			},
+			"3R" => new[]
+			{
+				new[] { 0.0, 0.0, 1.0 / 3.0, 1.0 },
+				new[] { 1.0 / 3.0, 0.0, 2.0 / 3.0, 1.0 },
+				new[] { 2.0 / 3.0, 0.0, 1.0, 1.0 }
+			},
+			"4G" => new[]
+			{
+				new[] { 0.0, 0.0, 0.5, 0.5 },
+				new[] { 0.5, 0.0, 1.0, 0.5 },
+				new[] { 0.0, 0.5, 0.5, 1.0 },
+				new[] { 0.5, 0.5, 1.0, 1.0 }
+			},
+			"6G" => new[]
+			{
+				new[] { 0.0, 0.0, 1.0 / 3.0, 0.5 },
+				new[] { 1.0 / 3.0, 0.0, 2.0 / 3.0, 0.5 },
+				new[] { 2.0 / 3.0, 0.0, 1.0, 0.5 },
+				new[] { 0.0, 0.5, 1.0 / 3.0, 1.0 },
+				new[] { 1.0 / 3.0, 0.5, 2.0 / 3.0, 1.0 },
+				new[] { 2.0 / 3.0, 0.5, 1.0, 1.0 }
+			},
+			_ => new[] { new[] { 0.0, 0.0, 0.5, 1.0 }, new[] { 0.5, 0.0, 1.0, 1.0 } }
+		};
+	}
+}

--- a/WinPieGestures/WindowTiler.cs
+++ b/WinPieGestures/WindowTiler.cs
@@ -325,47 +325,150 @@ public static class WindowTiler
 		}
 	}
 
-	/// <summary>平铺对象：当前虚拟桌面可见窗口（任务栏顺序）；排除无标题/隐藏/本进程/排除名单；按配置决定是否含最小化。</summary>
+	/// <summary>
+/// 平铺对象：当前虚拟桌面上的可见窗口。按进程 exe 分组全量枚举（同名/同 exe 的多窗口——如两个终端——全部参与，
+/// 不依赖任务栏槽位折叠）；组间顺序 = 任务栏槽位顺序，组内按句柄升序（≈先启动在前，先启动者为 Master）。
+/// 排除：无标题/隐藏/本进程/排除名单；是否含最小化按配置。
+/// </summary>
 	private static List<nint> GetTileTargets(HashSet<string> excludedExes, bool includeMinimized)
 	{
 		List<nint> result = new List<nint>();
 		uint selfPid = (uint)Environment.ProcessId;
-		foreach (nint h in WindowTaskbarHelper.GetTaskbarOrderedWindows())
+
+		// 槽位顺序 → exe 名顺序（分组排序基准）
+		List<string> slotExeOrder = new List<string>();
+		foreach (nint slot in WindowTaskbarHelper.GetTaskbarOrderedWindows())
 		{
-			if (h == IntPtr.Zero || !IsWindowVisible(h))
+			GetWindowThreadProcessId(slot, out uint pid);
+			string? exe = ExeNameOfPid(pid);
+			if (exe != null && !slotExeOrder.Contains(exe))
 			{
-				continue;
+				slotExeOrder.Add(exe);
 			}
-			if (!includeMinimized && IsIconic(h))
+		}
+
+		// 同 exe 分组：exe(lower) -> hwnds
+		Dictionary<string, List<nint>> groups = new Dictionary<string, List<nint>>(StringComparer.OrdinalIgnoreCase);
+		List<nint> noExe = new List<nint>();
+		foreach (nint h in EnumerateAllTopLevelWindows())
+		{
+			try
 			{
-				continue; // 最小化不参与（默认）
-			}
-			GetWindowThreadProcessId(h, out uint pid);
-			if (pid == selfPid)
-			{
-				continue; // 排除设置窗等自身窗口
-			}
-			StringBuilder sb = new StringBuilder(128);
-			if (GetWindowText(h, sb, 128) <= 0)
-			{
-				continue; // 无标题的后台窗口不参与
-			}
-			if (excludedExes.Count > 0)
-			{
-				string? exe = WindowTaskbarHelper.GetProcessImageNameByPid(pid);
-				if (exe != null && excludedExes.Contains(System.IO.Path.GetFileNameWithoutExtension(exe).ToLowerInvariant()))
+				if (!IsWindowVisible(h))
 				{
-					continue; // 命中排除名单
+					continue;
+				}
+				if (!includeMinimized && IsIconic(h))
+				{
+					continue;
+				}
+				if (!WindowTaskbarHelper.IsOnCurrentVirtualDesktop(h))
+				{
+					continue;
+				}
+				GetWindowThreadProcessId(h, out uint pid);
+				if (pid == selfPid)
+				{
+					continue;
+				}
+				if (excludedExes.Count > 0)
+				{
+					string? exe = ExeNameOfPid(pid);
+					if (exe != null && excludedExes.Contains(exe))
+					{
+						continue;
+					}
+				}
+				StringBuilder sb = new StringBuilder(128);
+				if (GetWindowText(h, sb, 128) <= 0)
+				{
+					continue;
+				}
+				string? exeKey = ExeNameOfPid(pid);
+				if (exeKey == null)
+				{
+					noExe.Add(h);
+				}
+				else if (!groups.TryGetValue(exeKey, out List<nint>? g))
+				{
+					g = new List<nint>();
+					groups[exeKey] = g;
+					g.Add(h);
+				}
+				else
+				{
+					g.Add(h);
 				}
 			}
-			result.Add(h);
+			catch
+			{
+			}
 		}
+		foreach (List<nint> g in groups.Values)
+		{
+			g.Sort(); // 组内句柄升序（先启动在前）
+		}
+		// 按槽位顺序输出组，再输出未出现在槽位的组（按其最小句柄排序），最后无 exe 的
+		HashSet<string> emitted = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		foreach (string exe in slotExeOrder)
+		{
+			if (groups.TryGetValue(exe, out List<nint>? g))
+			{
+				result.AddRange(g);
+				emitted.Add(exe);
+			}
+		}
+		List<string> rest = groups.Keys.Where((string k) => !emitted.Contains(k)).OrderBy((string k) => groups[k][0]).ToList();
+		foreach (string exe in rest)
+		{
+			result.AddRange(groups[exe]);
+		}
+		noExe.Sort();
+		result.AddRange(noExe);
+
 		if (result.Count == 0)
 		{
-			// 兜底：任务栏快照拿不到时，直接枚举顶层窗口（当前桌面的可见普通窗口）
 			result.AddRange(EnumerateTopLevelWindows());
 		}
 		return result;
+	}
+
+	/// <summary>进程 exe 名（小写、无扩展名）；失败 null。轻量缓存避免重复 OpenProcess。</summary>
+	private static string? ExeNameOfPid(uint pid)
+	{
+		string key = pid.ToString();
+		if (s_exeNameCache.TryGetValue(key, out string? cached))
+		{
+			return cached;
+		}
+		string? exe = WindowTaskbarHelper.GetProcessImageNameByPid(pid);
+		string? lower = exe == null ? null : System.IO.Path.GetFileNameWithoutExtension(exe).ToLowerInvariant();
+		if (s_exeNameCache.Count > 256)
+		{
+			s_exeNameCache.Clear();
+		}
+		s_exeNameCache[key] = lower;
+		return lower;
+	}
+
+	/// <summary>EnumWindows 全量枚举顶层窗口（不过滤，便于分组；注意通过枚举回调收集）。</summary>
+	private static List<nint> EnumerateAllTopLevelWindows()
+	{
+		List<nint> buffer = new List<nint>();
+		List<nint> previous = s_enumBuffer;
+		s_enumBuffer = buffer;
+		try
+		{
+			EnumWindows(s_enumProc, IntPtr.Zero);
+		}
+		catch
+		{
+		}
+		finally
+		{
+			s_enumBuffer = previous;
+		}
+		return buffer;
 	}
 
 	private delegate bool EnumWindowsProc(nint hWnd, nint lParam);
@@ -376,6 +479,8 @@ public static class WindowTiler
 	private static readonly EnumWindowsProc s_enumProc = EnumCallback;
 
 	private static List<nint> s_enumBuffer = new List<nint>();
+
+	private static readonly Dictionary<string, string?> s_exeNameCache = new Dictionary<string, string?>();
 
 	private static bool EnumCallback(nint hWnd, nint lParam)
 	{

--- a/WinPieGestures/WindowTiler.cs
+++ b/WinPieGestures/WindowTiler.cs
@@ -81,8 +81,19 @@ public static class WindowTiler
 	[DllImport("user32.dll")]
 	private static extern bool GetWindowRect(nint hWnd, out RECT lpRect);
 
+	[DllImport("user32.dll")]
+	private static extern nint GetWindow(nint hWnd, uint uCmd);
+
 	[DllImport("user32.dll", EntryPoint = "GetWindowLongPtrW")]
 	private static extern nint GetWindowLongPtr(nint hWnd, int nIndex);
+
+	private const int GWL_STYLE = -16;
+	private const uint GW_OWNER = 4;
+
+	// WS_CAPTION = WS_BORDER|WS_DLGFRAME；WS_THICKFRAME 可调整；WS_EX_TOOLWINDOW 工具窗（不进任务栏）
+	private const long WS_CAPTION = 0x00C00000L;
+	private const long WS_THICKFRAME = 0x00040000L;
+	private const long WS_EX_TOOLWINDOW = 0x00000080L;
 
 	[DllImport("user32.dll", EntryPoint = "SetWindowLongPtrW", SetLastError = true)]
 	private static extern nint SetWindowLongPtr(nint hWnd, int nIndex, nint dwNewLong);
@@ -363,6 +374,20 @@ public static class WindowTiler
 					continue;
 				}
 				if (!WindowTaskbarHelper.IsOnCurrentVirtualDesktop(h))
+				{
+					continue;
+				}
+				// 只收"标准应用窗口"：有标题栏、可调整、非工具窗、无拥有者（丢弃不进任务栏的后台/工具/对话框）
+				long style = GetWindowLongPtr(h, GWL_STYLE).ToInt64();
+				if ((style & WS_CAPTION) == 0L || (style & WS_THICKFRAME) == 0L)
+				{
+					continue;
+				}
+				if ((GetWindowLongPtr(h, GWL_EXSTYLE).ToInt64() & WS_EX_TOOLWINDOW) != 0L)
+				{
+					continue;
+				}
+				if (GetWindow(h, GW_OWNER) != IntPtr.Zero)
 				{
 					continue;
 				}

--- a/WinPieGestures/WindowTiler.cs
+++ b/WinPieGestures/WindowTiler.cs
@@ -269,6 +269,11 @@ public static class WindowTiler
 			{
 				return;
 			}
+			foreach (nint t in targets)
+			{
+				GetWindowThreadProcessId(t, out uint tp);
+				AppLogger.LogInfo($"[Tile]   target hwnd=0x{t:X} exe={ExeNameOfPid(tp) ?? "?"}");
+			}
 			List<double[]> cells = LayoutCells(key, targets.Count);
 			int count = Math.Min(targets.Count, cells.Count);
 			Dictionary<nint, RECT> snapshot = new Dictionary<nint, RECT>();
@@ -350,22 +355,24 @@ public static class WindowTiler
 	}
 
 	/// <summary>
-/// 平铺对象：当前虚拟桌面上的可见窗口。按进程 exe 分组全量枚举（同名/同 exe 的多窗口——如两个终端——全部参与，
-/// 不依赖任务栏槽位折叠）；组间顺序 = 任务栏槽位顺序，组内按句柄升序（≈先启动在前，先启动者为 Master）。
-/// 排除：无标题/隐藏/本进程/排除名单；是否含最小化按配置。
+/// 平铺对象：当前虚拟桌面上的可见窗口。只管理"exe 出现在任务栏槽位"的应用窗口（Dwalia 语义：
+/// 只处理真实驻留应用），同 exe 多窗口全收（两个终端都参与）；组间顺序 = 任务栏槽位顺序，
+/// 组内按句柄升序（≈先启动在前，先启动者为 Master）。
+/// 排除：无标题栏/工具窗/透明/遮蔽/无拥有者/无标题/本进程/排除名单/非任务栏应用的杂窗。
 /// </summary>
 	private static List<nint> GetTileTargets(HashSet<string> excludedExes, bool includeMinimized)
 	{
 		List<nint> result = new List<nint>();
 		uint selfPid = (uint)Environment.ProcessId;
 
-		// 槽位顺序 → exe 名顺序（分组排序基准）
+		// 槽位顺序 → exe 名顺序（分组排序基准 + 白名单：只收这些 exe 的窗口）
 		List<string> slotExeOrder = new List<string>();
+		HashSet<string> slotExes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 		foreach (nint slot in WindowTaskbarHelper.GetTaskbarOrderedWindows())
 		{
 			GetWindowThreadProcessId(slot, out uint pid);
 			string? exe = ExeNameOfPid(pid);
-			if (exe != null && !slotExeOrder.Contains(exe))
+			if (exe != null && slotExes.Add(exe))
 			{
 				slotExeOrder.Add(exe);
 			}
@@ -373,7 +380,6 @@ public static class WindowTiler
 
 		// 同 exe 分组：exe(lower) -> hwnds
 		Dictionary<string, List<nint>> groups = new Dictionary<string, List<nint>>(StringComparer.OrdinalIgnoreCase);
-		List<nint> noExe = new List<nint>();
 		foreach (nint h in EnumerateAllTopLevelWindows())
 		{
 			try
@@ -445,11 +451,12 @@ public static class WindowTiler
 					continue;
 				}
 				string? exeKey = ExeNameOfPid(pid);
-				if (exeKey == null)
+				// 只收任务栏存在应用的窗口（Dwalia：只管理真实驻留应用的窗口）——杂窗/后台窗一律不入布局
+				if (exeKey == null || !slotExes.Contains(exeKey))
 				{
-					noExe.Add(h);
+					continue;
 				}
-				else if (!groups.TryGetValue(exeKey, out List<nint>? g))
+				if (!groups.TryGetValue(exeKey, out List<nint>? g))
 				{
 					g = new List<nint>();
 					groups[exeKey] = g;
@@ -483,8 +490,6 @@ public static class WindowTiler
 		{
 			result.AddRange(groups[exe]);
 		}
-		noExe.Sort();
-		result.AddRange(noExe);
 
 		if (result.Count == 0)
 		{


### PR DESCRIPTION
## 概述
面板新增「**平铺窗口 (Tile)**」动作：触发后把当前虚拟桌面上的可见应用窗口，
按所选布局排布到各自主显示器工作区。

### 1. 布局引擎
- **固定网格**：2L / 2T / 3L12 / 3R21 / 3R / 4G / 6G；
- **Master+Stack 主轴族**（主窗 60%，按窗口数动态切分）：ML / MR / MT / MB；
  - H-Stack (HS)、V-Stack (VS)（50/50 主副）；
- **Monocle (MO)**：全屏层叠；**Columns (COL)**：等宽竖列；
- **Binary Split (BSP)**：交替横竖对半递归切分；**Auto Grid (AG)**：按 `⌈√n⌉` 自适应行列；
- **先数窗口、再定形状**：窗口数与名义格数不一致时自动采用**精确覆盖网格（ExactGrid）**，
  第 N 窗必然有格——**平铺后绝不出现空位**。

### 2. 布局循环（状态化）
- `循环切换` / `循环返回`：**从当前布局起跳**双向包裹（手动选过的布局也参与序列）；
- **循环范围选择器**：设置页勾选参与项 + ▲▼ 排序（空=全部 17 种）；
- 全量布局进 槽位/手势/取消/子动作 编辑器下拉。

### 3. 还原与记忆
- 记录**首次平铺前**的快照（换布局/循环不覆盖），「还原所有窗口」一键回到首次平铺前；
- **StarPie 退出时自动还原**所有窗口；
- 「平铺窗口」**⇅ 一键预置子菜单**：7 布局 + 还原 = 8 个子项（级联即布局/还原选择器）。

### 4. 窗口筛选
- 只管理**任务栏存在的应用 exe**（同名多窗口如双终端全部参与，组内按创建序、先启动为 Master）；
- 排除：无标题栏 `WS_CAPTION`/不可调 `WS_THICKFRAME`/工具窗/透明分层(`LWA_ALPHA<255`/COLORKEY)/
  被拥有(`owner`)/`WS_CHILD`/`WS_DISABLED`/DWM 遮蔽(`DWMWA_CLOAKED`)/shell-UWP 类名/
  **内置系统工具黑名单**（textinputhost、ApplicationFrameHost、华硕 ashotplugctrl 等）+ 用户排除名单；
- 配置：排除名单、是否含最小化、全局在「触发与场景」页。

## 改动文件
`WindowTiler.cs`、`ActionExecutor.cs`、`AppConfig.cs`、`SlotViewModel.cs`、
`SubSlotViewModel.cs`、`GestureMappingViewModel.cs`、`IconHelper.cs`、`WindowTaskbarHelper.cs`、
`SettingsWindow.xaml(.cs)`、`I18n.cs`

## 测试
- [x] `dotnet build -c Release` 0 错误
- [x] 各布局按窗口数精确铺满、无空位
- [x] 循环范围/顺序、双向循环、从当前布局起跳
- [x] 还原到首次平铺前；退出自动还原；最小化/排除名单/黑名单生效
- [x] 与手势/二级菜单/取消动作联动正常

## 备注
- 仍然透明窗口占位现象