### PR TITLE
fix(ui): 优化紧凑动作列表的参数区域显示

### DIFF
--- a/WinPieGestures/SettingsWindow.xaml
+++ b/WinPieGestures/SettingsWindow.xaml
@@ -2329,8 +2329,8 @@
                                   <ColumnDefinition Width="86" />
                                   <ColumnDefinition Width="132" MinWidth="132" />
                                   <ColumnDefinition Width="136" MinWidth="136" />
-                                  <ColumnDefinition Width="*" />
-                                  <ColumnDefinition Width="68" />
+                                  <ColumnDefinition Width="*" MinWidth="200" />
+                                  <ColumnDefinition Width="Auto" />
                                   <ColumnDefinition Width="Auto" />
                                   <ColumnDefinition Width="Auto" />
                                   <ColumnDefinition Width="58" />
@@ -2405,7 +2405,7 @@
                                   <ComboBox SelectedValuePath="Tag" DisplayMemberPath="DisplayText" ItemsSource="{Binding TileLayoutOptions}" SelectedValue="{Binding TileLayout, Mode=TwoWay}" Style="{StaticResource FlatComboBoxStyle}" Height="30" FontSize="11" Visibility="{Binding IsTileType, Converter={StaticResource BoolToVis}}" ToolTip="平铺布局预设" />
                                 </Grid>
 
-                                <TextBox Grid.Column="4" Margin="0,0,8,0" Height="30" FontSize="11" ToolTip="启动参数 (如命令行参数或URL)" VerticalContentAlignment="Center" Text="{Binding Arguments, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding IsLaunchType}" />
+                                <TextBox Grid.Column="4" Width="68" Margin="0,0,8,0" Height="30" FontSize="11" ToolTip="启动参数 (如命令行参数或URL)" VerticalContentAlignment="Center" Text="{Binding Arguments, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding IsLaunchType}" Visibility="{Binding IsLaunchType, Converter={StaticResource BoolToVis}}" />
                                 <Button Grid.Column="5" Style="{StaticResource ModernButtonStyle}" Height="30" Padding="8,0" Margin="0,0,6,0" ToolTip="配置该扇区的二级级联子动作菜单" Content="{Binding SubActionButtonText}" Click="ManageSubActions_Click" />
 
                                 <StackPanel Grid.Column="6" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,6,0">


### PR DESCRIPTION
### 背景

在“手势方向与动作映射”页面的“紧凑全览列表”模式中，动作行原本存在两个布局问题：

1. 窗口宽度减小时，操作类型后方的核心参数编辑区是唯一的弹性列，因此会被优先压缩，严重时可能完全不可见；
2. “启动参数”输入框只对 `Launch` 类型有效，但在快捷热键、文件夹、系统控制、运行命令、切换窗口等类型下仍然占用固定的 `68px` 空间，并显示为一个没有实际用途的禁用输入框。

### 修改内容

#### 1. 为核心参数编辑区设置最小宽度

将紧凑动作行中的核心参数列由：

    <ColumnDefinition Width="*" />

调整为：

    <ColumnDefinition Width="*" MinWidth="200" />

该区域承载以下类型的专用参数编辑器：

- 快捷热键录制器；
- 启动程序路径；
- 文件夹路径；
- 系统控制预设；
- 运行命令和终端选择；
- 任务栏窗口序号；
- 窗口平铺布局。

设置最小宽度后，缩小设置窗口时，这些核心控件不会再被压缩到完全不可见。

<img width="1256" height="718" alt="PixPin_2026-09-03_18-21-34" src="https://github.com/user-attachments/assets/c5e1bd8b-c022-405a-9542-01d2d989b81b" />


#### 2. 将启动参数列改为自适应宽度

将启动参数列由固定宽度：

    <ColumnDefinition Width="68" />

调整为：

    <ColumnDefinition Width="Auto" />

列宽现在由启动参数输入框的实际可见状态决定。

#### 3. 启动参数框仅在 Launch 类型下显示

为启动参数输入框增加：

    Width="68"
    Visibility="{Binding IsLaunchType, Converter={StaticResource BoolToVis}}"

非 `Launch` 类型下，启动参数框及其所在的 `Auto` 列会自动收缩，不再保留无意义的空白区域，释放出的宽度会优先提供给核心参数编辑器。

### 影响范围

本次修改仅涉及：

    WinPieGestures/SettingsWindow.xaml

修改位置位于：

    MappingsListModeGrid
    └─ SlotsItemsControl
       └─ SlotActionRow

因此只影响“紧凑全览列表”模式，不影响：

- 默认的“画布联动精调”模式；
- 动作参数的数据绑定；
- 动作执行逻辑；
- 配置文件结构；
- 动作类型判断；
- 二级级联动作；
- 轮盘显示与触发逻辑。

### 行为兼容性

本次修改属于纯 UI 布局优化，不修改任何动作数据。

已有配置中的以下字段保持不变：

- `Action.Type`
- `Action.Parameter`
- `Action.Arguments`
- `Action.CommandTerminal`

切换到非 `Launch` 类型时，原有 `Arguments` 数据不会被删除，只是输入框被折叠；重新切换回 `Launch` 类型后仍可继续显示和编辑。
