### PR TITLE
fix(tests): 恢复 GUI 测试套件与 v1.6.8dev2 更新检查器改动的兼容性

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -562,17 +562,19 @@ def test_v135_program_picker_clean_icons_and_core_customization(app):
     time.sleep(0.4)
     
     # 2. Check Core Icon controls exist
+    # v1.6.8dev2: CoreIconTypeComboBox lives inside CoreIconConfigPanel, which is
+    # collapsed until ShowCoreIcon is enabled — check the box before asserting it
     core_chk = win.child_window(auto_id="ShowCoreIconCheckBox", control_type="CheckBox")
     assert core_chk.exists(timeout=3), "ShowCoreIconCheckBox should exist"
-    
+
+    if core_chk.get_toggle_state() == 0:
+        core_chk.toggle()
+        time.sleep(0.4)
+
     core_combo = win.child_window(auto_id="CoreIconTypeComboBox", control_type="ComboBox")
     assert core_combo.exists(timeout=3), "CoreIconTypeComboBox should exist"
-    
-    # 3. Toggle ShowCoreIcon and select Core Pattern
-    try:
-        core_chk.toggle()
-    except Exception:
-        pass
+
+    # 3. Select Core Pattern
     core_combo.select(1)
     time.sleep(0.6)
     
@@ -632,6 +634,15 @@ def test_v136_glow_color_customization_config_memory_and_core_image(app):
     time.sleep(0.3)
     
     # 3. Check Core Image Controls
+    # v1.6.8dev2: CoreIconTypeComboBox is hidden inside CoreIconConfigPanel until
+    # ShowCoreIcon is enabled — check the box first
+    core_chk = win.child_window(auto_id="ShowCoreIconCheckBox", control_type="CheckBox")
+    assert core_chk.exists(timeout=3), "ShowCoreIconCheckBox should exist"
+
+    if core_chk.get_toggle_state() == 0:
+        core_chk.toggle()
+        time.sleep(0.4)
+
     core_combo = win.child_window(auto_id="CoreIconTypeComboBox", control_type="ComboBox")
     assert core_combo.exists(timeout=3), "CoreIconTypeComboBox should exist"
     
@@ -775,11 +786,11 @@ def test_v139_folder_action_type_and_i18n_consistency(app):
     focus_title = win.child_window(auto_id="FocusSlotTitleText", control_type="Text")
     assert focus_title.exists(timeout=3), "FocusSlotTitleText should exist"
     
-    # 3. Locate the first slot's Action Type ComboBox (8 aggregated action types,
-    #    index 3 = Folder) and select "Folder"
+    # 3. Locate the first slot's Action Type ComboBox (9 aggregated action types
+    #    since v1.6.8dev2 added ShellTool, index 3 = Folder) and select "Folder"
     type_combo = win.child_window(auto_id="FocusActionTypeComboBox", control_type="ComboBox")
     assert type_combo.exists(timeout=3), "FocusActionTypeComboBox should exist"
-    assert type_combo.item_count() == 8, f"FocusActionTypeComboBox should have 8 action types, got {type_combo.item_count()}"
+    assert type_combo.item_count() == 9, f"FocusActionTypeComboBox should have 9 action types, got {type_combo.item_count()}"
     type_combo.select(3)
     time.sleep(0.3)
     


### PR DESCRIPTION
## 背景

v1.6.8dev2 及更新检查器重构（4920f08）落地后，GUI 测试套件中有 3 个用例失败。
经逐一定位，均为**测试断言过时**，并非应用功能 bug。本 PR 恢复套件绿态。

由于 GUI 套件需要真实桌面环境、无法在 CI 中运行（CI 仅做构建验证），
UI 重构容易悄悄打破测试而不被察觉——本 PR 正是补上这一环。

## 修复内容（共 1 个文件、3 处）

### 1. test_v135 / test_v136：断言时机早于控件解锁
- v1.6.8dev2 将 `CoreIconTypeComboBox` 移入了新增的 `CoreIconConfigPanel`
  （SettingsWindow.xaml L1883），该面板仅在勾选 `ShowCoreIcon` 后展开
  （SettingsWindow.xaml.cs L889-891、L8215-8217）。
- 两个用例在未勾选的情况下就断言下拉框存在，必然失败（v135 的勾选动作
  甚至晚在断言之后才发生）。
- 修复：断言前先检查 `ShowCoreIconCheckBox` 勾选状态（带 toggle 守卫 + 0.4s 等待）。

### 2. test_v139：动作类型数量写死为 8
- `SlotViewModel.AggregatedActionTypes`（SlotViewModel.cs L761-771）因新增
  `ShellTool`（⚡，配套新的 Shell 动作选择器）变为 **9 项**，断言仍写死 8。
- 修复：8 → 9。下方 `select(3)` 选 Folder 不受影响（Folder 仍是索引 3），未改动。

## 验证

- 基线：upstream main `4920f08`（含新增的 theme / update 两个测试）
- 完整套件：**21/21 通过**（修复前 18/21）
- 运行环境：Windows 11，Python 3.12，pywinauto UIA

## 附带发现（供作者参考，与本 PR 无关可另行处理）

排查中发现 `ShowCoreIcon` 配置声明默认值为 `true`（AppConfig.cs L152），
但全新环境（空 AppData 沙盒）首次运行落盘的 config.json 即为 `false`，
导致中心图案面板默认折叠。怀疑 SettingsWindow.xaml.cs 中存在早于
勾选框初始化（L888）的保存路径，建议作者有空排查。

以下为修改前后的测试
<img width="877" height="679" alt="Screenshot 2026-09-05 175944" src="https://github.com/user-attachments/assets/133d3c2e-ed1a-46dd-805e-dd4339b708b9" />
<img width="865" height="445" alt="Screenshot 2026-09-05 180455" src="https://github.com/user-attachments/assets/70b04a75-c23e-4111-b20b-6ac4dfa32194" />
AI自查
<img width="879" height="451" alt="Screenshot 2026-09-05 183024" src="https://github.com/user-attachments/assets/5ea2a2aa-b00f-4e1c-98ae-8b45c51090ac" />



