### PR TITLE
fix(ui): 修复设置窗口输入框文字垂直不居中与裁切

### DIFF
--- a/WinPieGestures/SettingsWindow.xaml
+++ b/WinPieGestures/SettingsWindow.xaml
@@ -64,14 +64,15 @@
         <Setter Property="BorderBrush" Value="{DynamicResource InputBorderBrush}" />
         <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
         <Setter Property="TextBoxBase.CaretBrush" Value="{DynamicResource TextPrimaryBrush}" />
+        <Setter Property="FontSize" Value="12" />
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="Padding" Value="8,4" />
+        <Setter Property="Padding" Value="8,0" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="Template">
           <Setter.Value>
             <ControlTemplate TargetType="{x:Type TextBox}">
               <Border Background="{TemplateBinding Control.Background}" BorderBrush="{TemplateBinding Control.BorderBrush}" BorderThickness="{TemplateBinding Control.BorderThickness}" CornerRadius="6" SnapsToDevicePixels="True">
-                <ScrollViewer Name="PART_ContentHost" Margin="{TemplateBinding Control.Padding}" VerticalAlignment="Center" />
+                <ScrollViewer Name="PART_ContentHost" Margin="{TemplateBinding Control.Padding}" HorizontalAlignment="Stretch" VerticalAlignment="{TemplateBinding Control.VerticalContentAlignment}" VerticalScrollBarVisibility="Disabled" />
               </Border>
             </ControlTemplate>
           </Setter.Value>


### PR DESCRIPTION
## 背景

1：设置窗口中所有支持键盘输入的输入框（TextBox，共 45 处，包括光晕色值、轮盘文字颜色、
   轮盘显示文本 (Action Name)、启动程序目标路径、启动参数等），文字均垂直偏上、顶格显示
   且边缘被裁切，聚焦输入时还会整体上跳；所有下拉框（ComboBox）显示正常；
2：根因在隐式 TextBox 样式的控件模板（SettingsWindow.xaml 62–79 行）：模板中内容宿主
   PART_ContentHost 的垂直居中，仅在「文字行高 ≤ 可视区高度」时才生效。中文字体
   （微软雅黑系）行高约为字号的 1.6 倍，固定 Height 28/30 的输入框扣除 2px 边框与上下
   共 8px Padding 后，可视区仅剩 18–20px，行高放不下，文字只能顶格渲染并被裁切；
3：聚焦/输入时，TextBoxBase 的光标滚动计算假设内容宿主占满控件空间，而居中收窄的视口
   使垂直滚动偏移被算成非 0 值，进一步造成文字上跳、顶部被裁。

## 修改内容

仅调整 **SettingsWindow.xaml** 中窗口级隐式 TextBox 样式（+3/-2），一处修改覆盖全部
45 处输入框，不改动任何实例的 Height 与布局：

- **Padding `8,4` → `8,0`**：释放垂直空间使行高完全容纳，垂直居中真正生效；水平 8px
  内边距保留，长路径横向滚动不受影响；
- **新增默认 `FontSize=12`**：16 个未显式设置字号的色值/路径输入框原继承 WPF 默认
  16px 字号、行高溢出最严重，现与全窗口 11/11.5/12 的字号约定统一；
- **PART_ContentHost 增加 `VerticalScrollBarVisibility="Disabled"`**：单行输入无需
  垂直滚动，强制垂直偏移恒为 0，根治聚焦时文字上跳裁切；
- **模板 `VerticalAlignment` 改为 `{TemplateBinding VerticalContentAlignment}`**：
  原样式中的 `VerticalContentAlignment=Center` Setter 对 TextBoxBase 实际无效
  （死代码），经模板绑定后真正生效，样式语义一致（默认仍为 Center）。

## 验证

- `dotnet build WinPieGestures -c Release`：**0 错误**；
- 启动应用逐项目测：光晕色值、轮盘文字颜色、轮盘显示文本、启动程序目标路径、启动参数
  及各设置页其余输入框，文字均垂直居中、无裁切；聚焦输入、光标移动、选区、长路径横向
  滚动正常；测试套件不涉及本 PR 改动文件；
- 修复前后对比：

<img width="564" height="87" alt="Screenshot 2026-09-05 185558" src="https://github.com/user-attachments/assets/510abe88-b238-48e8-9083-88717a39bd31" />


<img width="620" height="107" alt="Screenshot 2026-09-05 194110" src="https://github.com/user-attachments/assets/68b0225a-41f1-4466-8973-d0e68dd3151f" />


## AI 自查声明

使用glm-5.3-flash进行自查。
<img width="889" height="521" alt="Screenshot 2026-09-05 194025" src="https://github.com/user-attachments/assets/fd41736c-5e6a-4165-a1d4-808539b2599c" />


