### PR TITLE
README_EN.md 更新至 v1.6.8，与中文版内容对齐并修复图片路径笔误

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ StarPie `v1.6.8` 在原有快捷轮盘基础上，进一步整合了**轨迹手�
   <br/><br/>
   <img src="./attachments/样式展示.gif" width="680" alt="多几何形态与视觉布局展示" />
   <br/><br/>
-  <img src="./attachments轮盘样式.gif" width="680" alt="预设主题风格与画布实时渲染演示" />
+  <img src="./attachments/轮盘样式.gif" width="680" alt="预设主题风格与画布实时渲染演示" />
 </div>
 
 ---

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,12 +1,12 @@
 <div align="center">
 
-<img src="./assets/logo.png" width="110" height="110" alt="StarPie Logo" />
+<img src="./assets/logo_dark.png" width="110" height="110" alt="StarPie Logo" />
 
 # StarPie
 
 ### Lightweight, Fast & Configurable Radial Pie Menu for Windows 10 / 11
 
-[![Release Version](https://img.shields.io/badge/Release-v1.4.3-2563EB.svg?style=flat-square&logo=github)](https://github.com/SoftBlack42/StarPie/releases)
+[![Release Version](https://img.shields.io/badge/Release-v1.6.8-2563EB.svg?style=flat-square&logo=github)](https://github.com/SoftBlack42/StarPie/releases)
 [![Platform](https://img.shields.io/badge/Platform-Windows%2010%20%7C%2011%20(x64)-0078D4.svg?style=flat-square&logo=windows)](https://microsoft.com/windows)
 [![.NET](https://img.shields.io/badge/.NET-8.0%20WPF-512BD4.svg?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-10B981.svg?style=flat-square)](LICENSE)
@@ -20,7 +20,7 @@
 
 <br/>
 
-[🚀 Quick Start](#download) • [✨ Key Features](#features) • [🎨 Visual Customization](#visuals) • [🌐 i18n](#i18n) • [🛠️ Build & Dev](#build) • [💡 Story & Maintenance](#acknowledgements) • [📋 Changelog](CHANGELOG.md)
+[🌟 Highlights](#highlights) • [🚀 Quick Start](#download) • [✨ Features](#features) • [🎨 Visual Customization](#visuals) • [🌐 i18n](#i18n) • [🛠️ Build & Development](#build) • [💡 Story & Maintenance](#acknowledgements) • [📋 Changelog](CHANGELOG.md)
 
 </div>
 
@@ -28,166 +28,366 @@
 
 ## <a id="intro"></a>📖 Introduction
 
-**StarPie** is a lightweight, responsive radial mouse gesture tool (Pie Menu) built for Windows 10 and 11.
+**StarPie** is a lightweight radial mouse gesture (Radial / Pie Menu) productivity tool built exclusively for Windows 10 / 11.
 
-Hold and drag the right mouse button in any application to summon a fast radial menu right under your cursor. It supports 4 / 8 / 12 sector layouts, per-application profiles, hotkey recordings, quick app launching, and comprehensive visual styling.
+In daily use or professional 3D modeling software, you can summon the radial wheel with the **right / middle / side mouse buttons or a keyboard trigger key**, or execute actions directly with independent trail gestures. The current version supports 4 / 8 / 12 sector wheels, multi-level sub-actions, per-application profiles (Per-App Profiles), window management & tiling, on-screen OCR, hotkey recording, URL & command dispatching, and comprehensive visual customization — turning high-frequency operations into natural muscle memory.
 
 > 💡 **Design Highlights**:
-> - **Low Memory Footprint**: Native C# WPF application with ~3 to 5 MB background RAM usage;
-> - **Low Latency Response**: Built on Win32 `WH_MOUSE_LL` hooks, ensuring fast response without affecting native right-click actions;
-> - **Portable & Standalone**: Self-contained single executable available (no external runtime installation required);
-> - **Single-Instance Protection**: Global mutex prevents duplicate running instances.
+> - **Low Resource Usage**: Built on native C# WPF with no bundled browser engine; the background-resident process targets a lightweight footprint of roughly **3 – 8 MB** in typical idle scenarios;
+> - **Low Latency Response**: Built on the Win32 `WH_MOUSE_LL` low-level event stream for instant response, without affecting normal right-click behavior;
+> - **Portable & Green**: Ships as a standalone single-file build (with the .NET runtime embedded — just unzip and run); configuration is stored locally in `config.json`;
+
+<details open>
+<summary><b>🎬 Demo Video / Video Demo</b></summary>
+<br/>
+
+<div align="center">
+  <a href="https://www.bilibili.com/video/BV1XjtA6KEGL" target="_blank">
+    <img src="./attachments/video_cover.png" width="700" alt="StarPie Demo Video" />
+  </a>
+  <p>
+    <a href="https://www.bilibili.com/video/BV1XjtA6KEGL"><b>📺 Click to watch the narrated walkthrough &amp; live demo on Bilibili</b></a>
+  </p>
+</div>
+
+</details>
 
 ---
 
-## <a id="features"></a>✨ Key Features
+## <a id="highlights"></a>🌟 v1.6.8 Highlights
 
-### 1. ⚡ Quick Mouse Gesture Summon & Execution
-- Hold and drag the right mouse button to summon the radial menu. Release over any sector to trigger its configured action (hotkey, application launch, folder opening, or system action);
-- Normal single right-clicks pass through to display default Windows context menus cleanly.
+Building on the original radial menu, StarPie `v1.6.8` further integrates **trail gestures, window management, on-screen OCR, multi-profile configuration, and in-depth visual customization**, while keeping lightweight, low latency, and muscle memory as its core design directions.
+
+| Area | Current Capabilities |
+| :--- | :--- |
+| **Wheel Interaction** | 4 / 8 / 12 sectors, center-core actions, multi-level sub-wheels, honeycomb fans & outer-escape cancel |
+| **Trail Gestures** | Up to 3 segments, 8-direction combinations, trail overlay, per-segment sensitivity & release hints |
+| **Actions & Windows** | Hotkeys, apps, URLs, folders, commands, system controls, plus window switching, tiling, cross-monitor moves, always-on-top & transparency |
+| **Screen OCR** | Local offline Windows recognition, AI vision APIs & custom HTTP OCR |
+| **Configuration UX** | Two-pane focused editing, live wheel canvas, sector drag-to-swap, running-window capture & compact overview list |
+| **Visual Customization** | Multiple wheel shapes, independent level-1 / level-2 themes, per-sector font / icon / text-position overrides & screen-edge overflow protection |
+
+> 📋 For the complete version history, see [CHANGELOG.md](CHANGELOG.md).
+
+---
+
+## <a id="features"></a>✨ Features
+
+### 1. ⚡ Quick Gesture Summon & Action Trigger
+
+- Hold and drag the right mouse button past the configured threshold to summon the wheel; slide onto a target sector and release to trigger its action (hotkey, app launch, folder, or system function);
+- A normal right-click still opens the native context menu — the two never conflict;
+- Supports right / middle / side buttons, single keyboard keys, and modifier combos as trigger keys, with either drag-past-threshold or long-press-delay summoning;
+- While recording hotkeys, the app can temporarily take exclusive control and pause global hotkeys, preventing system combos like `Win + D` or `Alt + Tab` from firing accidentally.
 
 <div align="center">
-  <img src="./attachments/01_radial_summon.gif" width="680" alt="Quick Radial Gesture Summon Demo" />
+  <img src="./attachments/第一张.gif" width="680" alt="Quick gesture summon & action trigger demo" />
   <br/><br/>
-  <img src="./attachments/01_1.gif" width="680" alt="Real-world Radial Gesture Interaction Demo" />
+  <img src="./attachments/按键组合触发录制.gif" width="680" alt="Key combo trigger recording demo" />
 </div>
 
 ---
 
-### 2. 🚀 Outer Escape Cancel
-- To abort an action, you don't need to drag back to the center core;
-- Simply flick or overshoot outwards past the wheel boundary. The menu enters a translucent cancel state and releasing the button triggers nothing;
-- Configurable toggle switch and adjustable distance threshold slider (140px ~ 320px) provided in settings.
+### 2. 🌟 Multi-Level Cascading Sub-Wheels
+
+- **Multi-level cascade interaction**: freely expand 1–4 secondary sub-actions in any sector. When the cursor dwells inside a sector, the outer ring smoothly unfolds secondary sub-sectors with a spring animation; slide outward to trigger at full speed.
+- **Fully independent level-1 / level-2 themes & colors**: size, font size, and icon layout can be tuned per level; the secondary wheel can either **sync with the primary wheel in one click** or be **styled with a completely independent look & palette**;
+- Two secondary forms are available — the outer sub-ring and the honeycomb fan — with hysteresis hold and debounce logic to reduce flicker and accidental collapse during boundary movements;
+- Both level-1 and level-2 actions support drag-to-swap, with an option to swap a primary action's secondary sub-actions along with it.
 
 <div align="center">
-  <img src="./attachments/02_outer_escape_cancel.gif" width="680" alt="Outer Escape Cancel Demo" />
-</div>
-
----
-
-### <a id="visuals"></a>3. 🎨 Multiple Shapes & Theme Presets
-- **4 Geometric Shapes**: Original Compact, Floating Circle, Rounded Capsule, and Hexagon Hive;
-- **Built-in Presets**: System Auto, Light, Dark, Glassmorphism, Matcha Forest, Glacial Ice, and Morandi Muted;
-- Includes an interactive **Live Preview Canvas** on the right side of the preferences window.
-
-<div align="center">
-  <img src="./attachments/03_themes_and_shapes.gif" width="680" alt="Themes and Shapes Customization Demo" />
+  <img src="./attachments/第三张.gif" width="680" alt="Secondary wheel demo" />
   <br/><br/>
-  <img src="./attachments/03_1.gif" width="680" alt="Multiple Shapes and Layout Showcase" />
+  <img src="./attachments/蜂窝扇.gif" width="680" alt="Honeycomb fan secondary wheel demo" />
+</div>
+
+---
+
+### 3. 🚀 Outer Escape Cancel
+
+- If you change your mind after drawing a gesture, there is no need to drag back to the center core;
+- Simply flick outward past the wheel boundary — the wheel enters a translucent safe-cancel state, and releasing the button triggers nothing;
+- It can be toggled in settings and fine-tuned with a distance slider (140px ~ 320px); since `v1.6.5`, the outer-escape cancel can also be bound to its own action with common presets, while the center-core cancel can stay silent.
+
+<div align="center">
+  <img src="./attachments/外甩取消.gif" width="680" alt="Outer escape cancel demo" />
+</div>
+
+---
+
+### <a id="visuals"></a>4. 🎨 Multiple Wheel Shapes & Style Presets
+
+- **4 geometric shapes**: Classic Compact Sectors (Original), Floating Circle (Circle), Rounded Capsule (Capsule), and Hexagon Hive;
+- **Preset themes**: System Auto, Light, Dark, Liquid Glass, Matcha Forest, Glacial Blue, and Morandi Muted;
+- The **live interactive preview canvas** on the right supports zoom, pan, reset, click-to-select, and drag-to-swap with instant feedback; `v1.6.8` adds a screen-edge overflow-protection strategy with X / Y safety margins.
+
+<div align="center">
+  <img src="./attachments/主题样式展示.gif" width="680" alt="Wheel shape & theme switching demo" />
   <br/><br/>
-  <img src="./attachments/03_2.gif" width="680" alt="Theme Presets and Live Canvas Preview Demo" />
-</div>
-
----
-
-### 4. 🎨 Advanced Color Tuning & Preset Management
-- Collapsible fine-tuning panel for sector background, glow, borders, and text colors;
-- Supports hex input, color dialog, and screen eyedropper;
-- Save, rename, or delete custom color presets anytime.
-
-<div align="center">
-  <img src="./attachments/04_custom_colors.gif" width="680" alt="Custom Color Tuning Demo" />
-</div>
-
----
-
-### 5. 🖼️ Custom Vector & Image Icon Imports
-- Import custom **SVG vector files** or **PNG / ICO / JPG** images into your icon library;
-- Custom icons are stored locally and can be renamed or deleted easily.
-
-<div align="center">
-  <img src="./attachments/05_custom_icons.gif" width="680" alt="Custom Icon Import Demo" />
-</div>
-
----
-
-### 6. 🎯 Dynamic 4 / 8 / 12 Sector Layouts
-- **4-Sector Layout**: Large cardinal angles, ideal for high-speed blind navigation;
-- **8-Sector Layout**: Balanced 8-directional layout (default);
-- **12-Sector Layout**: High-density action mapping for complex workflows.
-
-<div align="center">
-  <img src="./attachments/06_sector_counts.gif" width="680" alt="4/8/12 Sector Adaptation Demo" />
-</div>
-
----
-
-### 7. 💼 Per-App Profiles & Program Picker
-- Create dedicated gesture profiles for apps like Chrome, VS Code, Photoshop, or CAD;
-- Integrated application scanner scans installed software and filters stale shortcuts;
-- Supports creating, copying, deleting, and renaming profiles.
-
-<div align="center">
-  <img src="./attachments/07_per_app_profiles.gif" width="680" alt="Per-App Profiles Demo" />
+  <img src="./attachments/样式展示.gif" width="680" alt="Multiple shapes & visual layout showcase" />
   <br/><br/>
-  <img src="./attachments/07_1.gif" width="680" alt="Application Scanner and Profile Switching Demo" />
+  <img src="./attachments/轮盘样式.gif" width="680" alt="Preset themes & live canvas rendering demo" />
 </div>
 
 ---
 
-### 8. 🛡️ Gaming Isolation, Safety & Multilingual Support
-- **Fullscreen & Game Detection**: Automatically bypasses gestures during fullscreen games;
-- **Modifier Key Passthrough**: Bypass gestures when holding Ctrl, Shift, or Alt;
-- **Blacklist**: Add specific processes to bypass list;
-- **Multilingual Support**: Supports Simplified Chinese, Traditional Chinese, English, and Japanese with instant hot switching.
+### 5. 🎨 Advanced Color Tuning & Preset Renaming
+
+- An independent collapsible panel for fine-tuning sector background, highlight glow, borders, and text colors;
+- Supports hexadecimal color input, palette selection, and on-screen eyedropper;
+- Save the current colors as custom presets, with one-click renaming and deletion.
 
 <div align="center">
-  <img src="./attachments/08_settings_and_i18n.gif" width="680" alt="Safety and Multilingual Demo" />
+  <img src="./attachments/04_custom_colors.gif" width="680" alt="Advanced color tuning & preset management demo" />
+  <br/><br/>
+  <img src="./attachments/中心图案调节.gif" width="680" alt="Center emblem tuning demo" />
+  <br/><br/>
+  <img src="./attachments/扇区样式定制.gif" width="680" alt="Sector style customization demo" />
 </div>
 
 ---
 
-## <a id="download"></a>🚀 Download & Quick Start
+### 6. 🖼️ Custom Vector / Image Icon Import
 
-### Latest Release: `v1.4.2`
+- The icon library accepts local **SVG vector files** as well as **PNG / ICO / JPG** images;
+- Imported icons are stored in the local configuration directory, can be freely used in any sector, and support custom renaming and deletion.
+
+<div align="center">
+  <img src="./attachments/05_custom_icons.gif" width="680" alt="Custom icon import & management demo" />
+</div>
+
+---
+
+### 7. 🎯 Adaptive 4 / 8 / 12 Sector Layouts
+
+- **4 sectors**: wide cardinal angles, ideal for blind operation;
+- **8 sectors**: the classic balanced 8-direction layout (default);
+- **12 sectors**: high-density action mapping for multi-action workflows; the center core can also hold its own independent action, with a configurable activation dead-zone sensitivity.
+
+<div align="center">
+  <img src="./attachments/06_sector_counts.gif" width="680" alt="4/8/12 sector adaptation demo" />
+</div>
+
+---
+
+### 8. 💼 Per-App Profiles
+
+- Assign dedicated wheel profiles to different foreground apps such as Chrome, VS Code, Photoshop, or SolidWorks;
+- StarPie automatically matches the profile of the currently active app and falls back to the global profile when no dedicated one exists;
+- Profiles can be created, duplicated, deleted, and renamed in one click, making it easy to reuse and maintain different workflows.
+
+<div align="center">
+  <img src="./attachments/07_per_app_profiles.gif" width="680" alt="Per-app profiles demo" />
+</div>
+
+---
+
+### 9. 🎛️ Action Configuration Workspace, Quick App Capture & Drag-to-Edit
+
+- The Actions page adopts a two-pane workspace — "profile + focused editing card + live wheel canvas" — while keeping a compact overview list for scanning multiple actions at a glance;
+- A smart app selector aggregates installed programs and supports name search and quick filtering;
+- A running-window capture tool lets you pick a window or process directly from the current desktop, reducing manual hunting for executable paths;
+- Click the canvas to select a target sector, and drag to swap primary sectors, secondary actions, and the center core;
+- The center core can enable its own action, with dead-zone release triggering, common presets, and independent text & icon layout;
+- Every sector can independently override layout mode, font, font size, text color, icon size, text position, and X / Y offsets.
+
+<div align="center">
+   <img src="./attachments/程序拖拽配置界面.gif" width="680" alt="Drag-and-drop action configuration UI demo" />
+   <br/><br/>
+  <img src="./attachments/07_1.gif" width="680" alt="Smart app search & action configuration" />
+</div>
+
+---
+
+### 10. 🛡️ Scene Isolation, Fullscreen Safety & Multilingual
+
+- **Fullscreen & game detection**: the native right-click is automatically released while fullscreen-exclusive apps or games are running;
+- **Modifier passthrough**: bypass the wheel while holding Ctrl / Shift / Alt;
+- **Blacklist support**: add specific processes to the exclusion list;
+- **Hot language switching**: built-in Simplified Chinese, Traditional Chinese, English, and Japanese, effective instantly; `ScreenHelper` unifies multi-monitor, mixed-DPI, and screen-edge coordinate handling to reduce summoning drift and wheel overflow on secondary displays.
+
+<div align="center">
+  <img src="./attachments/08_settings_and_i18n.gif" width="680" alt="Safety & multilingual settings demo" />
+  <br/><br/>
+  <img src="./attachments/边缘呼出防溢出.gif" width="680" alt="Edge overflow protection configuration" />
+</div>
+
+---
+
+### 11. ➡️ Independent Trail Gestures & Visual Hints
+
+- A dedicated right, middle, or side button can be assigned to trail gestures, running in parallel with the wheel trigger key;
+- Supports up to 3 segments and 8 directions, with short-segment filtering and adjacent same-direction merging to reduce micro-jitter misjudgment during fast drawing;
+- A transparent trail overlay with start-point and release hints is displayed while drawing; segment sensitivity and hint text placement are adjustable;
+- Light clicks below the drag threshold are replayed as native mouse clicks, leaving everyday operation untouched.
+
+<div align="center">
+<img src="./attachments/按键组合触发录制.gif" width="680" alt="Key combo trigger recording demo" />
+</div>
+
+---
+
+### 12. 🧰 A More Complete Action Type System
+
+| Action Category | Main Use |
+| :--- | :--- |
+| **Hotkeys** | Record or assemble key combos, with primary-key search, Pause / Break support, and exclusive capture |
+| **Launch App** | Start EXEs, shortcuts, or files, with arguments and a normal-privilege launch option |
+| **Open URL** | Open with the system default, Chrome, Edge, Firefox, or a custom browser |
+| **Open Folder** | Open local paths plus virtual directories like Desktop and Downloads |
+| **Run Command** | CMD, PowerShell, WSL, and hidden terminal modes |
+| **Screen OCR** | Snip a screen region and call local, AI, or custom HTTP recognition |
+| **Window Management** | Switch windows, tile, move across monitors, always-on-top, and transparency control |
+| **System Control** | Lock screen, volume, media, Task View, virtual desktops, and other system functions |
+
+Action execution and display icons are fully decoupled — the same action can independently choose a built-in vector icon, the program's icon, or a custom image, no longer constrained by the action type.
+
+---
+
+### 13. 🪟 Window Switching, Management & Tiling Layouts
+
+- **Switch taskbar windows**: bind the Nth running window by the current taskbar order, with icon, title, and activation target all using the same snapshot;
+- **Window tiling**: built-in layouts including Left/Right, Top/Bottom, Master-Stack, Grid, Single Window, Horizontal Stack, Vertical Stack, Columns, BSP, and Auto Grid;
+- Supports cycling layouts forward / backward, restoring pre-tiling positions, including minimized windows, and a custom process exclusion list;
+- Move the currently active window to the next monitor, toggle always-on-top, or adjust window transparency.
+
+<div align="center">
+  <img src="./attachments/进程窗口切换.png" width="680" alt="Taskbar window switching demo" />
+</div>
+
+---
+
+### 14. 📝 Native Windows OCR & Extensible Recognition Interfaces
+
+- Snip any screen region and run text recognition, powered by the native offline `Windows.Media.Ocr` engine on Windows 10 / 11;
+- Optional AI vision APIs or custom HTTP OCR services, with language-pack environment diagnostics and a configuration panel;
+- Recognition results support auto-copy, a result window, merged lines, CJK spacing handling, and browser search.
+
+<div align="center">
+  <img src="./attachments/OCR.gif" width="680" alt="OCR demo" />
+  <br/><br/>
+  <img src="./attachments/OCR接口配置.png" width="680" alt="OCR interface configuration" />
+</div>
+
+---
+
+### 15. 🔄 Online Updates, Diagnostic Logs & Contributor Info
+
+- Built-in GitHub Releases update checking with selectable update channels, proxy mirrors, custom proxies, and ignored versions;
+- System logs are written asynchronously via a background queue; the log directory and today's log can be opened quickly from settings;
+- The contributor card uses an offline roster by default and never connects on startup, only requesting fresh data on manual refresh or update checks.
+
+<div align="center">
+  <img src="./attachments/系统内置更新与贡献展示.gif" width="680" alt="Built-in updater & contributor showcase demo" />
+</div>
+
+---
+
+## <a id="download"></a>🚀 Quick Start & Download
+
+### Current Mainline Release: `v1.6.8`
 
 | Package | Recommended For | Description | Download |
 | :--- | :--- | :--- | :--- |
-| **Standalone Single File (Recommended)** | All Users | Built-in .NET runtime, zero external dependencies | [⬇️ Download StarPie.exe](https://github.com/SoftBlack42/StarPie/releases) |
-| **Lightweight Portable Package** | Users with .NET 8 installed | Small archive size, portable | [⬇️ Download Lightweight Zip](https://github.com/SoftBlack42/StarPie/releases) |
-| **Historical Releases** | Archival & comparison | Previous release builds and notes | [📂 Releases Archive](https://github.com/SoftBlack42/StarPie/releases) |
+| **Standalone Single-File (Recommended)** | All users | .NET runtime embedded; unzip and run | [⬇️ Download StarPie.exe (Standalone)](https://github.com/SoftBlack42/StarPie/releases) |
+| **Lightweight Portable** | Users with .NET 8 runtime installed | Small footprint, portable | [⬇️ Download StarPie Portable](https://github.com/SoftBlack42/StarPie/releases) |
+| **Historical Releases** | Version rollbacks & comparison | Binaries and notes of previous versions | [📂 Browse Releases Archive](https://github.com/SoftBlack42/StarPie/releases) |
 
 ### Basic Workflow:
-1. Run `StarPie.exe` (it stays active in the system tray);
-2. Hold and drag the **right mouse button** anywhere to summon the wheel;
-3. Release over a sector to trigger the mapped action;
-4. Double-click the tray icon to open the configuration window.
+1. Download and run `StarPie.exe` — the app runs quietly in the system tray;
+2. Double-click the tray icon or right-click and choose "Preferences", then record the wheel trigger key under "Triggers & Scenes";
+3. Hold the trigger key and drag past the threshold, or long-press per your configuration, to summon the wheel near the cursor;
+4. Slide onto the target sector and release the trigger key to execute the action; flick outward to cancel or run a custom cancel action;
+5. For trail gestures, enable a dedicated gesture trigger key and map 1–3 segment direction combos on the Actions page.
 
 ---
 
-## <a id="i18n"></a>🌐 Internationalization (i18n)
+## <a id="i18n"></a>🌐 Multilingual Support (Internationalization)
 
-Switch interface languages anytime in `Advanced & System`:
+Switch the interface language anytime under "⚙️ Advanced & System" in the settings page:
 
-| Code | Language | Status |
+| Code | Display Name | Status |
 | :--- | :--- | :---: |
-| `zh-CN` | 🇨🇳 Simplified Chinese | 🟢 Supported |
-| `zh-TW` | 🇭🇰/🇹🇼 Traditional Chinese | 🟢 Supported |
-| `en` | 🇺🇸 English | 🟢 Supported |
-| `ja` | 🇯🇵 Japanese | 🟢 Supported |
-| `Auto` | 🖥️ System Default | 🟢 Supported |
+| `zh-CN` | 🇨🇳 简体中文 (Simplified Chinese) | 🟢 Fully Supported |
+| `zh-TW` | 🇭🇰/🇹🇼 繁體中文 (Traditional Chinese) | 🟢 Fully Supported |
+| `en` | 🇺🇸 English | 🟢 Fully Supported |
+| `ja` | 🇯🇵 日本語 (Japanese) | 🟢 Fully Supported |
+| `Auto` | 🖥️ Follow OS Language | 🟢 Fully Supported |
 
 ---
 
-## <a id="build"></a>🛠️ Development & Build
+## <a id="build"></a>🛠️ Local Build & Development
 
 ### Requirements
 - Windows 10 / 11 (x64)
 - [.NET 8.0 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
-- Python 3.10+ (for automated GUI tests only)
+- Python 3.10+ (only needed to run the automated test suite)
 
 ### Build & Run
 ```bash
+# 1. Clone the repository
 git clone https://github.com/SoftBlack42/StarPie.git
 cd StarPie
+
+# 2. Build the project (Release)
 dotnet build WinPieGestures/WinPieGestures.csproj -c Release
+
+# 3. Run the project
 dotnet run --project WinPieGestures/WinPieGestures.csproj
+
+# 4. Publish the lightweight build (requires .NET 8 Desktop Runtime on the target machine)
+dotnet publish WinPieGestures/WinPieGestures.csproj -c Release -r win-x64 --no-self-contained -o releases/local/Lightweight
+
+# 5. Publish the standalone build (self-contained with .NET runtime)
+dotnet publish WinPieGestures/WinPieGestures.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o releases/local/Standalone
 ```
 
-### Automated Tests (18/18 Passed 🟢)
+### Running the Automated Tests (19 GUI cases currently)
 ```bash
+# Install test dependencies
 pip install pytest pywinauto
+
+# Run the tests
 python -m pytest tests/test_settings.py -v
+```
+
+---
+
+## <a id="structure"></a>📂 Project Structure
+
+```text
+StarPie/
+├── .github/                         # CI workflows & community configs
+├── WinPieGestures/                  # Core project (C# / .NET 8 / WPF)
+│   ├── ActionExecutor.cs            # Hotkey, app, URL, command & system action dispatching
+│   ├── ActionItem.cs                # Action model & per-sector layout overrides
+│   ├── MouseHook.cs                 # Win32 low-level mouse hook thread
+│   ├── KeyboardHook.cs              # Win32 low-level keyboard hook & exclusive recording
+│   ├── GestureController.cs         # Wheel & trail gesture state machine
+│   ├── GestureMapping*.cs           # Trail combo mapping & configuration models
+│   ├── GestureTrailOverlay.cs       # Trail rendering & release hint overlay
+│   ├── RadialWindow.xaml(.cs)       # Transparent wheel window & runtime rendering
+│   ├── SettingsWindow.xaml(.cs)     # Two-pane canvas, focused editing & system settings
+│   ├── WindowTaskbarHelper.cs       # Taskbar order, window icons & switching snapshots
+│   ├── WindowTiler.cs               # Window tiling, restore, cycling & cross-screen control
+│   ├── WindowPickerWindow.xaml(.cs) # Active window & process capture tool
+│   ├── ScreenHelper.cs              # Multi-monitor, DPI & screen-edge coordinates
+│   ├── ScreenSnipWindow.xaml(.cs)   # OCR snipping region selection
+│   ├── OcrManager.cs                # Local, AI & HTTP OCR dispatching
+│   ├── OcrSettingsDialog.xaml(.cs)  # OCR engine & interface settings
+│   ├── OcrResultWindow.xaml(.cs)    # OCR result display
+│   ├── UpdateManager.cs             # GitHub Releases update checking
+│   ├── AppLogger.cs                 # Asynchronous runtime logging
+│   ├── ConfigManager.cs             # Config persistence, import/export & autostart
+│   ├── IconHelper.cs                # Built-in / program / custom icon resolution
+│   └── WinPieGestures.csproj        # .NET 8 WPF project configuration
+├── releases/                        # Historical versions & release archive
+├── attachments/                     # README screenshots, GIFs & pending demo assets
+├── tests/                           # pywinauto GUI automation tests
+├── CHANGELOG.md                     # Full version changelog
+├── CONTRIBUTING.md                  # Contribution guide
+├── LICENSE                          # MIT License
+└── README.md                        # Main documentation (Chinese)
 ```
 
 ---
@@ -195,18 +395,26 @@ python -m pytest tests/test_settings.py -v
 ## <a id="acknowledgements"></a>💡 Story & Maintenance
 
 ### 🌟 Inspiration
-As a Mechanical Engineering student frequently using CAD tools like SolidWorks, I appreciated the convenience of mouse gesture radial menus. With the help of AI Agent tools, I wanted to bring this interaction model to the wider Windows desktop environment.
 
-Feedback, bug reports, and pull requests are always welcome!
+I am a student majoring in Mechanical Design, Manufacturing & Automation. In daily 3D modeling with SolidWorks, I always found its built-in mouse gesture radial menu extremely handy.
 
-### 🤖 AI Collaboration
-Designed and architected by the developer, with implementation and test automation co-authored with **AI Agent - Antigravity**.
+After getting to know AI-agent-assisted development tools, the idea came to me of bringing this radial interaction to the entire Windows desktop, hoping to make everyday office work and operation more convenient. For those who have never used a gesture wheel before, this may well be a novel and efficient interaction experience.
 
-### 📌 Maintenance Note
-StarPie v1.4.2 is feature-complete and ready for daily use. Due to academic commitments, updates will follow a phased maintenance schedule.
+Although similar radial-menu projects already exist in the open-source community, each differs in feature focus and interaction details. From the initial idea to the release — interrupted from time to time by coursework and competitions — the current version took about a week of on-and-off collaboration with an AI Agent.
+
+If anything in this project is imperfect or overlooked, thank you for your understanding. Bug reports, usage feedback, and improvement suggestions are always welcome via GitHub Issues!
+
+### 🤖 Human-AI Collaborative Development
+
+This project is led by the developer for architecture design, interaction logic planning, and system tuning, with code construction, multilingual support, interaction optimization, and GUI automation testing co-authored by an AI agent (**AI Agent - Antigravity**) and open-source contributors.
+
+### 📌 Maintenance Notes
+
+- **Current status**: As of 2026-09-04, `main` has been updated to StarPie `v1.6.8`; the wheel, trail gestures, window management, OCR, and configuration workflows are still being continuously refined;
+- **Ongoing cadence**: The project continues to be maintained through joint iteration by the developer, community contributors, and AI agents — feature suggestions, compatibility feedback, and demo assets are welcome via Issues / Pull Requests.
 
 ---
 
 ## <a id="license"></a>📄 License
 
-Licensed under the [MIT License](LICENSE).
+This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## 背景
1：`README_EN.md` 长期停留在 v1.4.x：徽章为 v1.4.3、下载区标注 v1.4.2、测试标题写 18/18，与主线 v1.6.8 相差四个大版本，英文用户看到的功能描述与实际严重不符；
2：中文版 v1.5.x 起新增的功能在英文版中完全缺失（英文版仅 8 个功能章节，中文版 15 个），缺少：多级级联子轮盘/蜂窝扇、独立轨迹手势、窗口管理与平铺、屏幕 OCR、动作配置工作区、动作类型体系总表、在线更新与贡献者卡片等章节；
3：顺带发现 `README.md` 第 4 节图片路径笔误：`./attachments轮盘样式.gif` 缺少 `/`，该图在 GitHub 上无法显示。

## 修改内容
- **README_EN.md**：全文重写（212 行 → 425 行），逐节对齐中文版 v1.6.8：
  - 徽章统一为 Release v1.6.8、Tests 19/19，Logo 换用 `logo_dark.png`；
  - 补齐功能章节至 15 节，新增「v1.6.8 功能概览」表、Bilibili 演示视频区块、项目结构目录树、5 步使用流程、publish 发布命令；
  - 维护说明更新为 2026-09-04 / v1.6.8 状态；
  - 演示素材与中文版完全一致（含中文文件名 GIF，GitHub 渲染正常）。
- **README.md**：修复第 4 节图片路径 `./attachments轮盘样式.gif` → `./attachments/轮盘样式.gif`。

## 验证
纯文档改动，不涉及任何代码文件。自动化校验：
- 两份 README 各 **25/25** 图片引用均指向真实存在的文件（无死链）；
- 各 **9/9** 内部锚点跳转有效；
- 徽章与正文版本号一致（均为 v1.6.8）。

※ 此处贴：你 fork 页面上 README_EN.md 的渲染效果截图（如头部徽章 + 某个新章节）

## AI 自查声明
使用 glm-5.3-flash 进行自查，结论见截图：

※ 此处贴：下面那份自查报告的截图
<img width="461" height="488" alt="Screenshot 2026-09-05 222957" src="https://github.com/user-attachments/assets/70873bef-0692-4618-a8d3-1e7ab848170a" />
