### PR TITLE
feat: 平铺引擎修复+ 超编缺编布局规则 + 屏幕边距与窗口间距设置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ $RECYCLE.BIN/
 .DS_Store
 
 
+
+# AI Assistant Workspace Data
+.workbuddy/

--- a/WinPieGestures/App.xaml.cs
+++ b/WinPieGestures/App.xaml.cs
@@ -252,7 +252,16 @@ public partial class App : Application
 		}
 		try
 		{
-			ConfigManager.SaveConfig();
+			// 本次启动若因配置损坏而回落默认，绝不能在退出时把默认值写回磁盘，
+			// 否则用户尚可从 .corrupt 备份恢复的配置会被永久覆盖。
+			if (ConfigManager.IsFallbackConfig)
+			{
+				AppLogger.LogInfo("Skipped exit-time config save: loaded config was a fallback default");
+			}
+			else
+			{
+				ConfigManager.SaveConfig();
+			}
 		}
 		catch
 		{

--- a/WinPieGestures/AppConfig.cs
+++ b/WinPieGestures/AppConfig.cs
@@ -49,6 +49,15 @@ public class AppConfig
 	/// <summary>平铺"循环切换"参与范围：布局 key 逗号分隔（空=全部布局参与循环）。</summary>
 	public string TileCycleLayouts { get; set; } = "";
 
+	/// <summary>平铺屏幕边距：工作区四周留白（物理像素，0=贴边）。</summary>
+	public int TileMarginTop { get; set; }
+	public int TileMarginBottom { get; set; }
+	public int TileMarginLeft { get; set; }
+	public int TileMarginRight { get; set; }
+
+	/// <summary>平铺窗口之间的间距（物理像素，0=紧贴）。</summary>
+	public int TileGap { get; set; }
+
 	public string AnimationSpeed { get; set; } = "Balanced";
 
 	public double CustomAnimationDurationMs { get; set; } = 80.0;

--- a/WinPieGestures/ConfigManager.cs
+++ b/WinPieGestures/ConfigManager.cs
@@ -17,6 +17,10 @@ public static class ConfigManager
 
 	public static AppConfig CurrentConfig { get; private set; }
 
+	// 本次启动是否因配置文件损坏而回落到了默认配置。
+	// 为 true 时必须禁止任何自动写盘，否则会把默认配置覆盖掉用户尚可恢复的损坏文件。
+	public static bool IsFallbackConfig { get; private set; }
+
 	private static string GetAppDataFolder()
 	{
 		string path = (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("LOCALAPPDATA")) ? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) : Environment.GetEnvironmentVariable("LOCALAPPDATA"));
@@ -39,6 +43,25 @@ public static class ConfigManager
 			}
 		}
 		return text;
+	}
+
+	// 保留无法解析的配置文件现场，使用户有机会手工恢复，而不是被默认配置静默覆盖。
+	private static void BackupCorruptConfig()
+	{
+		try
+		{
+			if (!File.Exists(ConfigPath))
+			{
+				return;
+			}
+			string destFileName = ConfigPath + ".corrupt." + DateTime.Now.ToString("yyyyMMddHHmmss");
+			File.Copy(ConfigPath, destFileName, overwrite: true);
+			AppLogger.LogInfo("Backed up unreadable config to '" + destFileName + "'");
+		}
+		catch (Exception ex)
+		{
+			AppLogger.LogError("Failed to back up unreadable config", ex);
+		}
 	}
 
 	static ConfigManager()
@@ -171,7 +194,11 @@ public static class ConfigManager
 							}
 						};
 					}
-					SaveConfig();
+					// 回落默认配置时禁止自动落盘：否则会立刻用默认值覆盖掉用户尚可恢复的配置文件
+					if (!IsFallbackConfig)
+					{
+						SaveConfig();
+					}
 				}
 			}
 			I18n.SetLanguage(CurrentConfig.Language);
@@ -188,14 +215,18 @@ public static class ConfigManager
 				}
 			});
 		}
-		catch (Exception)
+		catch (Exception ex)
 		{
+			AppLogger.LogError("Failed to load config from '" + ConfigPath + "', falling back to default configuration", ex);
+			BackupCorruptConfig();
+			IsFallbackConfig = true;
 			CurrentConfig = CreateDefaultConfig();
 			I18n.SetLanguage(CurrentConfig.Language);
 		}
 	}
 
-	public static void SaveConfig()
+	// 返回是否保存成功，调用方据此决定提示文案，避免无条件宣称“已保存”。
+	public static bool SaveConfig()
 	{
 		try
 		{
@@ -208,11 +239,25 @@ public static class ConfigManager
 				WriteIndented = true
 			};
 			string contents = JsonSerializer.Serialize(CurrentConfig, options);
-			File.WriteAllText(ConfigPath, contents);
+			// 原子写：先落临时文件再替换。直接 WriteAllText 一旦中途被中断（退出/崩溃/断电）
+			// 会留下截断的 config.json，下次启动即被判为损坏并回落默认配置。
+			string tempPath = ConfigPath + ".tmp";
+			File.WriteAllText(tempPath, contents);
+			if (File.Exists(ConfigPath))
+			{
+				// 保留上一份完好配置，替换失败时仍可人工回退
+				File.Replace(tempPath, ConfigPath, ConfigPath + ".bak");
+			}
+			else
+			{
+				File.Move(tempPath, ConfigPath, overwrite: true);
+			}
+			return true;
 		}
 		catch (Exception ex)
 		{
 			AppLogger.LogError("Failed to save config to file", ex);
+			return false;
 		}
 	}
 

--- a/WinPieGestures/I18n.cs
+++ b/WinPieGestures/I18n.cs
@@ -1209,10 +1209,24 @@ public static class I18n
 		};
 		dictionary["TileGlobalDescText"] = new Dictionary<LanguageCode, string>
 		{
-			[LanguageCode.ZhCn] = "「平铺窗口」动作的全局行为。",
-			[LanguageCode.ZhTw] = "「平鋪視窗」動作的全域行為。",
-			[LanguageCode.En] = "Global behaviour of the Tile Windows action.",
-			[LanguageCode.Ja] = "「ウィンドウを並べる」アクションの全体挙動です。"
+			[LanguageCode.ZhCn] = "「平铺窗口」动作的全局行为（屏幕边距、窗口间距、包含最小化窗口、排除名单与多布局循环切换）。",
+			[LanguageCode.ZhTw] = "「平鋪視窗」動作的全域行為（螢幕邊距、視窗間距、包含最小化視窗、排除名單與多佈局循環切換）。",
+			[LanguageCode.En] = "Global behaviour of the Tile Windows action (screen margins, window gaps, minimized windows, exclusion list and layout cycling).",
+			[LanguageCode.Ja] = "「ウィンドウを並べる」アクションの全体挙動（画面マージン、ウィンドウ間隔、最小化ウィンドウの包含、除外リスト、レイアウト切替）。"
+		};
+		dictionary["TileMarginText"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "屏幕边距（上 / 下 / 左 / 右，物理像素，0 = 贴边）：",
+			[LanguageCode.ZhTw] = "螢幕邊距（上 / 下 / 左 / 右，物理像素，0 = 貼邊）：",
+			[LanguageCode.En] = "Screen margins (Top / Bottom / Left / Right, physical pixels, 0 = flush):",
+			[LanguageCode.Ja] = "画面マージン（上 / 下 / 左 / 右、物理ピクセル、0 = 端に寄せる）："
+		};
+		dictionary["TileGapText"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "窗口间距（物理像素，0 = 紧贴）：",
+			[LanguageCode.ZhTw] = "視窗間距（物理像素，0 = 緊貼）：",
+			[LanguageCode.En] = "Gap between windows (physical pixels, 0 = flush):",
+			[LanguageCode.Ja] = "ウィンドウ間隔（物理ピクセル、0 = 隙間なし）："
 		};
 		dictionary["TileMinimizeText"] = new Dictionary<LanguageCode, string>
 		{

--- a/WinPieGestures/SettingsWindow.xaml
+++ b/WinPieGestures/SettingsWindow.xaml
@@ -909,7 +909,7 @@
                                   <ComboBox Grid.Column="1" Width="108" Margin="4,0,0,0" ItemsSource="{Binding Terminals}" SelectedValuePath="Tag" DisplayMemberPath="DisplayText" SelectedValue="{Binding CommandTerminal, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FlatComboBoxStyle}" Height="30" FontSize="10" />
                                 </Grid>
                                 <TextBox Text="{Binding NthWindowIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="30" FontSize="11" VerticalContentAlignment="Center" Visibility="{Binding IsSwitchWindowType, Converter={StaticResource BoolToVis}}" ToolTip="任务栏第 N 个应用（同 Win+N 槽位语义）" />
-                                <ComboBox SelectedValuePath="Tag" DisplayMemberPath="DisplayText" ItemsSource="{Binding TileLayoutOptions}" SelectedValue="{Binding TileLayout, Mode=TwoWay}" Style="{StaticResource FlatComboBoxStyle}" Height="30" FontSize="11" Visibility="{Binding IsTileType, Converter={StaticResource BoolToVis}}" ToolTip="平铺布局预设" />
+                                <ComboBox SelectedValuePath="Tag" DisplayMemberPath="DisplayText" ItemsSource="{Binding TileLayoutOptions}" SelectedValue="{Binding TileLayout, Mode=TwoWay}" SelectionChanged="TileLayoutComboBox_SelectionChanged" Style="{StaticResource FlatComboBoxStyle}" Height="30" FontSize="11" Visibility="{Binding IsTileType, Converter={StaticResource BoolToVis}}" ToolTip="平铺布局预设" />
                               </Grid>
                               <TextBox Grid.Column="3" Height="30" FontSize="11" Margin="4,0,0,0" VerticalContentAlignment="Center" Text="{Binding Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ToolTip="名称（显示自定义，可留空）" />
                               <Button Grid.Column="4" Content="测试" Height="30" Margin="4,0,0,0" Padding="4,0" FontSize="11" Style="{StaticResource ModernButtonStyle}" Click="TestGesture_Click" />
@@ -1101,7 +1101,7 @@
                                     <ComboBox ItemsSource="{Binding WindowManagerSubModes}" SelectedValuePath="Tag" DisplayMemberPath="DisplayText" SelectedValue="{Binding WindowManagerSubMode, Mode=TwoWay}" Style="{StaticResource FlatComboBoxStyle}" Height="32" FontSize="11" />
                                     
                                     <!-- 平铺预设选择 -->
-                                    <ComboBox Grid.Column="1" Margin="6,0,0,0" SelectedValuePath="Tag" DisplayMemberPath="DisplayText" ItemsSource="{Binding TileLayoutOptions}" SelectedValue="{Binding TileLayout, Mode=TwoWay}" Style="{StaticResource FlatComboBoxStyle}" Height="32" FontSize="11" Visibility="{Binding IsTileSubMode, Converter={StaticResource BoolToVis}}" ToolTip="平铺布局预设" />
+                                    <ComboBox Grid.Column="1" Margin="6,0,0,0" SelectedValuePath="Tag" DisplayMemberPath="DisplayText" ItemsSource="{Binding TileLayoutOptions}" SelectedValue="{Binding TileLayout, Mode=TwoWay}" SelectionChanged="TileLayoutComboBox_SelectionChanged" Style="{StaticResource FlatComboBoxStyle}" Height="32" FontSize="11" Visibility="{Binding IsTileSubMode, Converter={StaticResource BoolToVis}}" ToolTip="平铺布局预设" />
                                     
                                     <!-- 切换任务栏序号 -->
                                     <TextBox Grid.Column="1" Margin="6,0,0,0" Text="{Binding NthWindowIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="32" FontSize="11.5" VerticalContentAlignment="Center" Visibility="{Binding IsSwitchWindowSubMode, Converter={StaticResource BoolToVis}}" ToolTip="输入任务栏序号 1~20 (等同 Win + 序号)" />
@@ -2847,7 +2847,7 @@
                                   <Grid Visibility="{Binding IsSwitchWindowType, Converter={StaticResource BoolToVis}}">
                                     <TextBox Text="{Binding NthWindowIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="30" FontSize="11" VerticalContentAlignment="Center" ToolTip="任务栏第 N 个应用（顺序同任务栏/Win+N 槽位，稳定）；图标与切换目标一致；固定未运行的槽位无法启动，托盘驻留不计入" />
                                   </Grid>
-                                  <ComboBox SelectedValuePath="Tag" DisplayMemberPath="DisplayText" ItemsSource="{Binding TileLayoutOptions}" SelectedValue="{Binding TileLayout, Mode=TwoWay}" Style="{StaticResource FlatComboBoxStyle}" Height="30" FontSize="11" Visibility="{Binding IsTileType, Converter={StaticResource BoolToVis}}" ToolTip="平铺布局预设" />
+                                  <ComboBox SelectedValuePath="Tag" DisplayMemberPath="DisplayText" ItemsSource="{Binding TileLayoutOptions}" SelectedValue="{Binding TileLayout, Mode=TwoWay}" SelectionChanged="TileLayoutComboBox_SelectionChanged" Style="{StaticResource FlatComboBoxStyle}" Height="30" FontSize="11" Visibility="{Binding IsTileType, Converter={StaticResource BoolToVis}}" ToolTip="平铺布局预设" />
                                 </Grid>
 
                                 <TextBox Grid.Column="4" Width="68" Margin="0,0,8,0" Height="30" FontSize="11" ToolTip="启动参数 (如命令行参数或URL)" VerticalContentAlignment="Center" Text="{Binding Arguments, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding IsLaunchType}" Visibility="{Binding IsLaunchType, Converter={StaticResource BoolToVis}}" />

--- a/WinPieGestures/SettingsWindow.xaml
+++ b/WinPieGestures/SettingsWindow.xaml
@@ -2887,7 +2887,7 @@
                             <TextBlock Name="TileSettingsStatusText" Text="已收纳 (点击展开)" FontSize="10" FontWeight="SemiBold" Foreground="{DynamicResource AccentPrimaryBrush}" />
                           </Border>
                         </StackPanel>
-                        <TextBlock Name="TileGlobalDescText" Text="「平铺窗口」动作的全局行为（包含最小化窗口、排除名单与多布局循环切换）。" FontSize="11.5" Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,3,0,0" TextWrapping="Wrap" />
+                        <TextBlock Name="TileGlobalDescText" Text="「平铺窗口」动作的全局行为（屏幕边距、窗口间距、包含最小化窗口、排除名单与多布局循环切换）。" FontSize="11.5" Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,3,0,0" TextWrapping="Wrap" />
                       </StackPanel>
                       <Border Grid.Column="1" Background="{DynamicResource SubtleCardBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="6" Padding="8,4" VerticalAlignment="Center">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
@@ -2914,6 +2914,24 @@
                         <TextBox Name="TileExcludeProcessesTextBox" Height="32" FontSize="12" VerticalContentAlignment="Center" Padding="8,0" TextChanged="TileExcludeProcessesTextBox_TextChanged" />
                         <Button Grid.Column="1" Content="🎯 捕捉排除进程..." Style="{StaticResource ModernButtonStyle}" Height="32" Padding="10,0" Margin="6,0,0,0" ToolTip="打开智能窗口捕捉器，选取桌面运行中的程序加入平铺排除名单（自动安全排除 StarPie 自身）" Click="TileCaptureCurrentProcess_Click" />
                       </Grid>
+                      <TextBlock Name="TileMarginText" Text="屏幕边距（上 / 下 / 左 / 右，物理像素，0 = 贴边）：" FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,0,0,6" />
+                      <Grid Margin="0,0,0,10">
+                        <Grid.ColumnDefinitions>
+                          <ColumnDefinition Width="*" />
+                          <ColumnDefinition Width="6" />
+                          <ColumnDefinition Width="*" />
+                          <ColumnDefinition Width="6" />
+                          <ColumnDefinition Width="*" />
+                          <ColumnDefinition Width="6" />
+                          <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBox Name="TileMarginTopTextBox" Grid.Column="0" Height="32" FontSize="12" VerticalContentAlignment="Center" Padding="8,0" Tag="Top" TextChanged="TileMarginTextBox_TextChanged" ToolTip="上边距（0~1000 物理像素）" />
+                        <TextBox Name="TileMarginBottomTextBox" Grid.Column="2" Height="32" FontSize="12" VerticalContentAlignment="Center" Padding="8,0" Tag="Bottom" TextChanged="TileMarginTextBox_TextChanged" ToolTip="下边距（0~1000 物理像素）" />
+                        <TextBox Name="TileMarginLeftTextBox" Grid.Column="4" Height="32" FontSize="12" VerticalContentAlignment="Center" Padding="8,0" Tag="Left" TextChanged="TileMarginTextBox_TextChanged" ToolTip="左边距（0~1000 物理像素）" />
+                        <TextBox Name="TileMarginRightTextBox" Grid.Column="6" Height="32" FontSize="12" VerticalContentAlignment="Center" Padding="8,0" Tag="Right" TextChanged="TileMarginTextBox_TextChanged" ToolTip="右边距（0~1000 物理像素）" />
+                      </Grid>
+                      <TextBlock Name="TileGapText" Text="窗口间距（物理像素，0 = 紧贴）：" FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,0,0,6" />
+                      <TextBox Name="TileGapTextBox" Width="80" HorizontalAlignment="Left" Height="32" FontSize="12" VerticalContentAlignment="Center" Padding="8,0" Margin="0,0,0,10" TextChanged="TileGapTextBox_TextChanged" ToolTip="相邻窗口之间的空隙（0~500 物理像素）" />
                       <Grid Margin="0,4,0,6">
                         <Grid.ColumnDefinitions>
                           <ColumnDefinition Width="*" />

--- a/WinPieGestures/SettingsWindow.xaml.cs
+++ b/WinPieGestures/SettingsWindow.xaml.cs
@@ -618,6 +618,26 @@ public partial class SettingsWindow : Window
 		{
 			TileExcludeProcessesTextBox.Text = ConfigManager.CurrentConfig.TileExcludeProcesses ?? "";
 		}
+		if (TileMarginTopTextBox != null)
+		{
+			TileMarginTopTextBox.Text = ConfigManager.CurrentConfig.TileMarginTop.ToString();
+		}
+		if (TileMarginBottomTextBox != null)
+		{
+			TileMarginBottomTextBox.Text = ConfigManager.CurrentConfig.TileMarginBottom.ToString();
+		}
+		if (TileMarginLeftTextBox != null)
+		{
+			TileMarginLeftTextBox.Text = ConfigManager.CurrentConfig.TileMarginLeft.ToString();
+		}
+		if (TileMarginRightTextBox != null)
+		{
+			TileMarginRightTextBox.Text = ConfigManager.CurrentConfig.TileMarginRight.ToString();
+		}
+		if (TileGapTextBox != null)
+		{
+			TileGapTextBox.Text = ConfigManager.CurrentConfig.TileGap.ToString();
+		}
 		RefreshTileCycleList();
 		if (TileIncludeMinimizedCheckBox != null)
 		{
@@ -1381,6 +1401,14 @@ public partial class SettingsWindow : Window
 		if (TileExcludeText != null)
 		{
 			TileExcludeText.Text = I18n.T("TileExcludeText");
+		}
+		if (TileMarginText != null)
+		{
+			TileMarginText.Text = I18n.T("TileMarginText");
+		}
+		if (TileGapText != null)
+		{
+			TileGapText.Text = I18n.T("TileGapText");
 		}
 		if (TileCycleRangeText != null)
 		{
@@ -11928,6 +11956,46 @@ public partial class SettingsWindow : Window
 			return;
 		}
 		ConfigManager.CurrentConfig.TileExcludeProcesses = TileExcludeProcessesTextBox.Text ?? "";
+		SyncUiToConfigAndSave();
+	}
+
+	/// <summary>解析文本框为夹紧到 [min,max] 的整数（非法/空输入回落默认值）。</summary>
+	private static int ParseClampedInt(string? text, int min, int max, int fallback)
+	{
+		if (!int.TryParse((text ?? "").Trim(), out int v))
+		{
+			v = fallback;
+		}
+		return Math.Clamp(v, min, max);
+	}
+
+	private void TileMarginTextBox_TextChanged(object sender, TextChangedEventArgs e)
+	{
+		if (_isUpdatingUi || ConfigManager.CurrentConfig == null)
+		{
+			return;
+		}
+		if (sender is System.Windows.Controls.TextBox tb && tb.Tag is string field)
+		{
+			int v = ParseClampedInt(tb.Text, 0, 1000, 0);
+			switch (field)
+			{
+				case "Top": ConfigManager.CurrentConfig.TileMarginTop = v; break;
+				case "Bottom": ConfigManager.CurrentConfig.TileMarginBottom = v; break;
+				case "Left": ConfigManager.CurrentConfig.TileMarginLeft = v; break;
+				case "Right": ConfigManager.CurrentConfig.TileMarginRight = v; break;
+			}
+			SyncUiToConfigAndSave();
+		}
+	}
+
+	private void TileGapTextBox_TextChanged(object sender, TextChangedEventArgs e)
+	{
+		if (_isUpdatingUi || ConfigManager.CurrentConfig == null)
+		{
+			return;
+		}
+		ConfigManager.CurrentConfig.TileGap = ParseClampedInt(TileGapTextBox?.Text, 0, 500, 0);
 		SyncUiToConfigAndSave();
 	}
 

--- a/WinPieGestures/SettingsWindow.xaml.cs
+++ b/WinPieGestures/SettingsWindow.xaml.cs
@@ -2056,11 +2056,13 @@ public partial class SettingsWindow : Window
 		_autoSaveDebounceTimer.Start();
 	}
 
-	private void SyncUiToConfigAndSave(bool saveToDisk = true)
+	// 返回是否确实写入成功。UI 初始化期间（_isUpdatingUi）或配置为空时直接返回 false，
+	// 调用方不应在 false 时宣称“已保存”。
+	private bool SyncUiToConfigAndSave(bool saveToDisk = true)
 	{
 		if (_isUpdatingUi || ConfigManager.CurrentConfig == null)
 		{
-			return;
+			return false;
 		}
 		try
 		{
@@ -2247,11 +2249,13 @@ public partial class SettingsWindow : Window
 			}
 			if (saveToDisk)
 			{
-				ConfigManager.SaveConfig();
+				return ConfigManager.SaveConfig();
 			}
+			return true;
 		}
 		catch (Exception)
 		{
+			return false;
 		}
 	}
 
@@ -3652,7 +3656,7 @@ public partial class SettingsWindow : Window
 				{
 					item.Type = "Tile";
 					item.Parameter = "2L";
-					if (string.IsNullOrEmpty(item.Name) || item.Name.StartsWith("扇区"))
+					if (string.IsNullOrEmpty(item.Name) || item.Name.StartsWith("扇区") || item.Name.StartsWith("新动作") || item.Name.StartsWith("截屏识字"))
 					{
 						item.Name = "平铺: " + WindowTiler.LayoutDisplayName("2L");
 					}
@@ -3678,7 +3682,7 @@ public partial class SettingsWindow : Window
 			else if (newType == "Ocr" || newType == "ScreenOcr")
 			{
 				item.Type = "Ocr";
-				if (string.IsNullOrEmpty(item.Name) || item.Name.StartsWith("扇区") || item.Name.StartsWith("新动作"))
+				if (string.IsNullOrEmpty(item.Name) || item.Name.StartsWith("扇区") || item.Name.StartsWith("新动作") || item.Name.StartsWith("平铺"))
 				{
 					item.Name = "截屏识字";
 				}
@@ -3828,6 +3832,13 @@ public partial class SettingsWindow : Window
 			RenderMappingsWheelPreview();
 			ScheduleAutoSave();
 		}
+	}
+
+	// 手势映射区与轮盘槽位区的平铺布局下拉为纯 TwoWay 绑定，只写内存；
+	// 必须在此补一次自动保存调度，否则布局修改要等下一次其他事件才被顺带落盘。
+	private void TileLayoutComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+	{
+		ScheduleAutoSave();
 	}
 
 	private void ApplyFocusTileLayout(string layout)
@@ -9911,8 +9922,14 @@ public partial class SettingsWindow : Window
 
 	private void SaveButton_Click(object sender, RoutedEventArgs e)
 	{
-		SyncUiToConfigAndSave();
-		System.Windows.MessageBox.Show("配置已成功保存至硬盘！", "成功", MessageBoxButton.OK, MessageBoxImage.Asterisk);
+		if (SyncUiToConfigAndSave())
+		{
+			System.Windows.MessageBox.Show("配置已成功保存至硬盘！", "成功", MessageBoxButton.OK, MessageBoxImage.Asterisk);
+		}
+		else
+		{
+			System.Windows.MessageBox.Show("配置保存失败。请查看日志了解原因，并确认程序对配置目录有写入权限。", "保存失败", MessageBoxButton.OK, MessageBoxImage.Error);
+		}
 	}
 
 	private void CloseButton_Click(object sender, RoutedEventArgs e)

--- a/WinPieGestures/WindowTaskbarHelper.cs
+++ b/WinPieGestures/WindowTaskbarHelper.cs
@@ -439,14 +439,38 @@ public static class WindowTaskbarHelper
 			IVirtualDesktopManager? vdm = CreateVdm();
 			if (vdm == null)
 			{
-				return false;
+				// VDM 整体不可用（如系统组件缺失）：fail-open，交由上层过滤兜底，
+				// 否则所有窗口会被静默丢弃导致平铺"看不见"任何窗口。
+				LogVdmUnavailableOnce();
+				return true;
 			}
-			return vdm.IsWindowOnCurrentVirtualDesktop(hWnd, out _) == 0;
+			// COM 调用返回错误码（提权窗口、部分系统窗口常见）≠ 不在当前桌面：
+			// 仅当 HRESULT 成功时信任判定结果（BOOL 非 0 = 在当前桌面），失败则 fail-open，避免误丢真实可见窗口。
+			int onCurrent = 0;
+			if (vdm.IsWindowOnCurrentVirtualDesktop(hWnd, out onCurrent) == 0)
+			{
+				return onCurrent != 0;
+			}
+			LogVdmUnavailableOnce();
+			return true;
 		}
 		catch
 		{
-			return false;
+			LogVdmUnavailableOnce();
+			return true;
 		}
+	}
+
+	private static bool s_vdmWarned;
+
+	private static void LogVdmUnavailableOnce()
+	{
+		if (s_vdmWarned)
+		{
+			return;
+		}
+		s_vdmWarned = true;
+		AppLogger.LogWarn("[VDM] IVirtualDesktopManager 不可用/调用失败，虚拟桌面过滤已放宽（fail-open）");
 	}
 
 	/// <summary>抗权限获取进程 exe 路径（OpenProcess+QueryFullProcessImageName）；失败返回 null。</summary>

--- a/WinPieGestures/WindowTiler.cs
+++ b/WinPieGestures/WindowTiler.cs
@@ -281,6 +281,17 @@ public static class WindowTiler
 				}
 			}
 			bool includeMinimized = ConfigManager.CurrentConfig?.TileIncludeMinimized == true;
+			// 屏幕边距与窗口间距（物理像素，读取时夹紧防呆）
+			int mt = Math.Clamp(ConfigManager.CurrentConfig?.TileMarginTop ?? 0, 0, 1000);
+			int mb = Math.Clamp(ConfigManager.CurrentConfig?.TileMarginBottom ?? 0, 0, 1000);
+			int ml = Math.Clamp(ConfigManager.CurrentConfig?.TileMarginLeft ?? 0, 0, 1000);
+			int mr = Math.Clamp(ConfigManager.CurrentConfig?.TileMarginRight ?? 0, 0, 1000);
+			int gap = Math.Clamp(ConfigManager.CurrentConfig?.TileGap ?? 0, 0, 500);
+			int gapHalf = gap / 2;
+			if (ml + mr + mt + mb + gap > 0)
+			{
+				AppLogger.LogInfo($"[Tile] margin L{ml}/T{mt}/R{mr}/B{mb}, gap={gap}");
+			}
 			List<nint> targets = GetTileTargets(exclude, includeMinimized);
 			AppLogger.LogInfo($"[Tile] layout='{key}' targets={targets.Count}");
 			if (targets.Count == 0)
@@ -326,11 +337,25 @@ public static class WindowTiler
 				{
 					nint hwnd = groupWindows[i];
 					RECT wa = WorkAreaOf(hwnd);
+					// 应用屏幕边距（收缩工作区，并夹紧防负尺寸）
+					wa.Left += ml;
+					wa.Top += mt;
+					wa.Right = Math.Max(wa.Left + 1, wa.Right - mr);
+					wa.Bottom = Math.Max(wa.Top + 1, wa.Bottom - mb);
 					double[] c = cells[i];
 					int x = wa.Left + (int)Math.Round((wa.Right - wa.Left) * c[0]);
 					int y = wa.Top + (int)Math.Round((wa.Bottom - wa.Top) * c[1]);
 					int w = (int)Math.Round((wa.Right - wa.Left) * c[2]) - (x - wa.Left);
 					int h = (int)Math.Round((wa.Bottom - wa.Top) * c[3]) - (y - wa.Top);
+					// 应用窗口间距：内边缘各收缩 gap/2，外边缘不缩（外圈留白已由边距控制）
+					int gl = c[0] > 1e-9 ? gapHalf : 0;
+					int gt = c[1] > 1e-9 ? gapHalf : 0;
+					int gr = c[2] < 1 - 1e-9 ? gapHalf : 0;
+					int gb = c[3] < 1 - 1e-9 ? gapHalf : 0;
+					x += gl;
+					y += gt;
+					w -= gl + gr;
+					h -= gt + gb;
 					w = Math.Max(1, w);
 					h = Math.Max(1, h);
 					// 最小化/最大化会无视 SetWindowPos：先无激活还原，再捕获快照坐标

--- a/WinPieGestures/WindowTiler.cs
+++ b/WinPieGestures/WindowTiler.cs
@@ -301,7 +301,7 @@ public static class WindowTiler
 			foreach (nint t in targets)
 			{
 				GetWindowThreadProcessId(t, out uint tp);
-				AppLogger.LogInfo($"[Tile]   target hwnd=0x{t:X} exe={ExeNameOfPid(tp) ?? "?"}");
+				AppLogger.LogInfo($"[Tile]   target hwnd=0x{t:X} exe={ExeNameOfPid(tp) ?? "?"} title=\"{TitleOf(t)}\"");
 			}
 			// 按显示器分区平铺：同一显示器上的窗口独立套用布局，
 			// 避免"两窗分布两屏各占半屏"的不可预测行为。分区顺序 = 显示器在目标序列中的首次出现顺序。
@@ -367,7 +367,7 @@ public static class WindowTiler
 					GetWindowRect(hwnd, out RECT before);
 					GetWindowThreadProcessId(hwnd, out uint pid);
 					bool ok = SetWindowPos(hwnd, HWND_TOP, x, y, w, h, SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW | SWP_ASYNCWINDOWPOS);
-					AppLogger.LogInfo($"[Tile] #{globalIndex} hwnd=0x{hwnd:X} rect=({x},{y},{w}x{h}) ok={ok}");
+					AppLogger.LogInfo($"[Tile] #{globalIndex} hwnd=0x{hwnd:X} exe={ExeNameOfPid(pid) ?? "?"} title=\"{TitleOf(hwnd)}\" rect=({x},{y},{w}x{h}) ok={ok}");
 					globalIndex++;
 					if (ok)
 					{
@@ -660,6 +660,24 @@ public static class WindowTiler
 		}
 		s_exeNameCache[key] = lower;
 		return lower;
+	}
+
+	/// <summary>读取窗口标题（日志用，截断 128 字符，失败返回空串）。</summary>
+	private static string TitleOf(nint hWnd)
+	{
+		try
+		{
+			if (hWnd == IntPtr.Zero || !IsWindow(hWnd))
+			{
+				return "";
+			}
+			StringBuilder sb = new StringBuilder(128);
+			return GetWindowText(hWnd, sb, 128) > 0 ? sb.ToString() : "";
+		}
+		catch
+		{
+			return "";
+		}
 	}
 
 	/// <summary>EnumWindows 全量枚举顶层窗口（不过滤，便于分组；注意通过枚举回调收集）。</summary>

--- a/WinPieGestures/WindowTiler.cs
+++ b/WinPieGestures/WindowTiler.cs
@@ -64,6 +64,9 @@ public static class WindowTiler
 	private static extern bool IsWindowVisible(nint hWnd);
 
 	[DllImport("user32.dll")]
+	private static extern bool IsWindow(nint hWnd);
+
+	[DllImport("user32.dll")]
 	private static extern bool IsIconic(nint hWnd);
 
 	[DllImport("user32.dll")]
@@ -119,6 +122,9 @@ public static class WindowTiler
 	private delegate bool EnumMonitorsProc(nint hMonitor, nint hdcMonitor, ref RECT lprcMonitor, nint dwData);
 
 	private const int SW_RESTORE = 9;
+
+	/// <summary>还原窗口但不激活（不抢前台焦点）；Win32 SW_SHOWNOACTIVATE。</summary>
+	private const int SW_SHOWNOACTIVATE = 4;
 	private const uint SWP_NOZORDER = 0x0004;
 	private const uint SWP_NOMOVE = 0x0002;
 	private const uint SWP_NOSIZE = 0x0001;
@@ -132,9 +138,21 @@ public static class WindowTiler
 	private const uint LWA_COLORKEY = 0x00000001;
 	private const uint SW_RESTORE_U = 9u;
 
-	// 上次平铺快照（供「恢复」与内存记忆）
-	private static readonly Dictionary<nint, RECT> s_lastSnapshot = new Dictionary<nint, RECT>();
-	private static int s_cycleIndex;
+	// 上次平铺快照（供「恢复」与内存记忆）。条目同时记录进程 PID：
+	// HWND 会被系统复用，恢复时校验 PID 避免把旧坐标应用到无关窗口。
+	private readonly struct TileSnapshotEntry
+	{
+		public readonly RECT Rect;
+		public readonly uint Pid;
+
+		public TileSnapshotEntry(RECT rect, uint pid)
+		{
+			Rect = rect;
+			Pid = pid;
+		}
+	}
+
+	private static readonly Dictionary<nint, TileSnapshotEntry> s_lastSnapshot = new Dictionary<nint, TileSnapshotEntry>();
 	private static string s_currentLayout = "2L";
 
 	/// <summary>可选布局 key 列表（顺序即编辑器下拉顺序）。</summary>
@@ -274,35 +292,74 @@ public static class WindowTiler
 				GetWindowThreadProcessId(t, out uint tp);
 				AppLogger.LogInfo($"[Tile]   target hwnd=0x{t:X} exe={ExeNameOfPid(tp) ?? "?"}");
 			}
-			List<double[]> cells = LayoutCells(key, targets.Count);
-			int count = Math.Min(targets.Count, cells.Count);
-			Dictionary<nint, RECT> snapshot = new Dictionary<nint, RECT>();
-			for (int i = 0; i < count; i++)
+			// 按显示器分区平铺：同一显示器上的窗口独立套用布局，
+			// 避免"两窗分布两屏各占半屏"的不可预测行为。分区顺序 = 显示器在目标序列中的首次出现顺序。
+			List<List<nint>> monitorGroups = new List<List<nint>>();
+			Dictionary<nint, int> groupIndexByMonitor = new Dictionary<nint, int>();
+			foreach (nint hwnd in targets)
 			{
-				RECT wa = WorkAreaOf(targets[i]);
-				double[] c = cells[i];
-				int x = wa.Left + (int)Math.Round((wa.Right - wa.Left) * c[0]);
-				int y = wa.Top + (int)Math.Round((wa.Bottom - wa.Top) * c[1]);
-				int w = (int)Math.Round((wa.Right - wa.Left) * c[2]) - (x - wa.Left);
-				int h = (int)Math.Round((wa.Bottom - wa.Top) * c[3]) - (y - wa.Top);
-				w = Math.Max(1, w);
-				h = Math.Max(1, h);
-				RECT before;
-				GetWindowRect(targets[i], out before);
-				// 最小化/最大化会无视 SetWindowPos：先还原，再定位
-				if (IsIconic(targets[i]) || IsZoomed(targets[i]))
+				nint mon = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+				if (!groupIndexByMonitor.TryGetValue(mon, out int gi))
 				{
-					ShowWindow(targets[i], SW_RESTORE);
+					gi = monitorGroups.Count;
+					groupIndexByMonitor[mon] = gi;
+					monitorGroups.Add(new List<nint>());
 				}
-				bool ok = SetWindowPos(targets[i], HWND_TOP, x, y, w, h, SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW | SWP_ASYNCWINDOWPOS);
-				AppLogger.LogInfo($"[Tile] #{i} hwnd=0x{targets[i]:X} rect=({x},{y},{w}x{h}) ok={ok}");
-				if (ok)
+				monitorGroups[gi].Add(hwnd);
+			}
+
+			Dictionary<nint, TileSnapshotEntry> snapshot = new Dictionary<nint, TileSnapshotEntry>();
+			int globalIndex = 0;
+			foreach (List<nint> group in monitorGroups)
+			{
+				List<double[]> cells = LayoutCells(key, group.Count);
+				int count = Math.Min(group.Count, cells.Count);
+				for (int i = 0; i < count; i++)
 				{
-					snapshot[targets[i]] = before;
+					nint hwnd = group[i];
+					RECT wa = WorkAreaOf(hwnd);
+					double[] c = cells[i];
+					int x = wa.Left + (int)Math.Round((wa.Right - wa.Left) * c[0]);
+					int y = wa.Top + (int)Math.Round((wa.Bottom - wa.Top) * c[1]);
+					int w = (int)Math.Round((wa.Right - wa.Left) * c[2]) - (x - wa.Left);
+					int h = (int)Math.Round((wa.Bottom - wa.Top) * c[3]) - (y - wa.Top);
+					w = Math.Max(1, w);
+					h = Math.Max(1, h);
+					// 最小化/最大化会无视 SetWindowPos：先无激活还原，再捕获快照坐标
+					// （顺序很重要：最小化窗口的 GetWindowRect 是 -32000 系，必须还原后读取）
+					if (IsIconic(hwnd) || IsZoomed(hwnd))
+					{
+						ShowWindow(hwnd, SW_SHOWNOACTIVATE);
+					}
+					GetWindowRect(hwnd, out RECT before);
+					GetWindowThreadProcessId(hwnd, out uint pid);
+					bool ok = SetWindowPos(hwnd, HWND_TOP, x, y, w, h, SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW | SWP_ASYNCWINDOWPOS);
+					AppLogger.LogInfo($"[Tile] #{globalIndex} hwnd=0x{hwnd:X} rect=({x},{y},{w}x{h}) ok={ok}");
+					globalIndex++;
+					if (ok)
+					{
+						snapshot[hwnd] = new TileSnapshotEntry(before, pid);
+					}
 				}
 			}
 			lock (s_lastSnapshot)
 			{
+				// 清理已销毁窗口的陈旧条目（HWND 可能被系统复用，恢复时还需校验 PID）
+				List<nint> dead = null;
+				foreach (var kv in s_lastSnapshot)
+				{
+					if (!IsWindow(kv.Key))
+					{
+						(dead ??= new List<nint>()).Add(kv.Key);
+					}
+				}
+				if (dead != null)
+				{
+					foreach (nint d in dead)
+					{
+						s_lastSnapshot.Remove(d);
+					}
+				}
 				// 只记录"第一次"平铺前的状态：后续换布局/循环不覆盖，
 				// 保证「还原所有窗口」始终回到首次平铺之前的样式。
 				if (s_lastSnapshot.Count == 0)
@@ -325,20 +382,31 @@ public static class WindowTiler
 	{
 		try
 		{
-			Dictionary<nint, RECT> snap;
+			Dictionary<nint, TileSnapshotEntry> snap;
 			lock (s_lastSnapshot)
 			{
-				snap = new Dictionary<nint, RECT>(s_lastSnapshot);
+				snap = new Dictionary<nint, TileSnapshotEntry>(s_lastSnapshot);
 			}
 			AppLogger.LogInfo($"[Tile] restore targets={snap.Count}");
 			foreach (var kv in snap)
 			{
 				try
 				{
-					RECT r = kv.Value;
+					// HWND 会被系统复用：窗口已销毁或 PID 不匹配（复用给了其他进程）时跳过，
+					// 避免把旧坐标应用到无关窗口。
+					if (!IsWindow(kv.Key))
+					{
+						continue;
+					}
+					GetWindowThreadProcessId(kv.Key, out uint pid);
+					if (pid != kv.Value.Pid)
+					{
+						continue;
+					}
+					RECT r = kv.Value.Rect;
 					if (IsIconic(kv.Key))
 					{
-						ShowWindow(kv.Key, SW_RESTORE);
+						ShowWindow(kv.Key, SW_SHOWNOACTIVATE);
 					}
 					SetWindowPos(kv.Key, HWND_TOP, r.Left, r.Top, Math.Max(1, r.Right - r.Left), Math.Max(1, r.Bottom - r.Top),
 						SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW | SWP_ASYNCWINDOWPOS);
@@ -507,7 +575,10 @@ public static class WindowTiler
 
 		if (result.Count == 0)
 		{
-			result.AddRange(EnumerateTopLevelWindows());
+			// 主路径（任务栏白名单 + 严格过滤）全军覆没：回退弱过滤兜底。
+			// 该路径过滤语义远弱于主路径，必须显式留痕便于排查。
+			AppLogger.LogWarn("[Tile] 主过滤路径无目标，回退弱过滤兜底枚举（VDM 不可用或所有窗口被过滤）");
+			result.AddRange(EnumerateTopLevelWindows(includeMinimized));
 		}
 		// 诊断：被黑名单/杂窗挡掉的数量（用于核对目标数与真实窗口数）
 		AppLogger.LogInfo($"[Tile]   blocked={blockedCount}");
@@ -755,7 +826,7 @@ public static class WindowTiler
 	}
 
 	/// <summary>EnumWindows 兜底枚举：可见、非本进程、有标题的顶层窗口（保留任务栏顺序路径的过滤语义）。</summary>
-	private static List<nint> EnumerateTopLevelWindows()
+	private static List<nint> EnumerateTopLevelWindows(bool includeMinimized)
 	{
 		uint selfPid = (uint)Environment.ProcessId;
 		List<nint> buffer = new List<nint>();
@@ -777,7 +848,12 @@ public static class WindowTiler
 		{
 			try
 			{
-				if (h == IntPtr.Zero || !IsWindowVisible(h) || IsIconic(h))
+				if (h == IntPtr.Zero || !IsWindowVisible(h))
+				{
+					continue;
+				}
+				// 与主路径语义对齐：仅当未开启「包含最小化窗口」时才跳过最小化窗口
+				if (!includeMinimized && IsIconic(h))
 				{
 					continue;
 				}

--- a/WinPieGestures/WindowTiler.cs
+++ b/WinPieGestures/WindowTiler.cs
@@ -312,11 +312,19 @@ public static class WindowTiler
 			int globalIndex = 0;
 			foreach (List<nint> group in monitorGroups)
 			{
-				List<double[]> cells = LayoutCells(key, group.Count);
-				int count = Math.Min(group.Count, cells.Count);
+				// 固定布局超编：只平铺任务栏顺序前 nominal 个窗口，其余保持原样（不移动、不进快照）
+				List<nint> groupWindows = group;
+				int nominal = NominalCellCount(key);
+				if (nominal > 0 && group.Count > nominal)
+				{
+					AppLogger.LogInfo($"[Tile] 布局 {key} 名义 {nominal} 格，本屏 {group.Count} 窗，按任务栏顺序取前 {nominal} 个，其余 {group.Count - nominal} 窗不参与");
+					groupWindows = group.Take(nominal).ToList();
+				}
+				List<double[]> cells = LayoutCells(key, groupWindows.Count);
+				int count = Math.Min(groupWindows.Count, cells.Count);
 				for (int i = 0; i < count; i++)
 				{
-					nint hwnd = group[i];
+					nint hwnd = groupWindows[i];
 					RECT wa = WorkAreaOf(hwnd);
 					double[] c = cells[i];
 					int x = wa.Left + (int)Math.Round((wa.Right - wa.Left) * c[0]);
@@ -931,22 +939,13 @@ public static class WindowTiler
 			return AutoGridCells(n); // AutoGrid：按数量自适应行列
 		}
 		List<double[]> fixedCells = new List<double[]>();
-		// 固定网格布局：窗口数等于名义格数时用其标准形状；否则回退"恰好覆盖 N 的无空格网格"，
-		// 避免窗口少时出现空位（先算窗口数，再定布局）。
-		int nominal = key switch
+		// 固定网格布局：窗口数等于名义格数时用其标准形状；
+		// 缺编（n < 名义）时回退占满网格（行优先 + 末行摊平），窗口铺满整个工作区不留空位；
+		// 超编（n > 名义）由 ExecuteTile 在分组层截断到名义格数，此处恒有 n <= nominal。
+		int nominal = NominalCellCount(key);
+		if (nominal > 0 && n < nominal)
 		{
-			"2L" => 2,
-			"2T" => 2,
-			"3L12" => 3,
-			"3R21" => 3,
-			"3R" => 3,
-			"4G" => 4,
-			"6G" => 6,
-			_ => 0
-		};
-		if (nominal > 0 && n != nominal)
-		{
-			return ExactGridCells(n);
+			return FillGridCells(n);
 		}
 		switch (key)
 		{
@@ -1006,34 +1005,45 @@ public static class WindowTiler
 		return cells;
 	}
 
-	/// <summary>恰好覆盖 n 个窗口的无空格网格（行列数取 n 最接近平方的因子分解）。</summary>
-	private static List<double[]> ExactGridCells(int n)
+	/// <summary>固定布局的名义格数（2L/2T=2，3L12/3R21/3R=3，4G=4，6G=6；动态布局返回 0 表示不限）。</summary>
+	private static int NominalCellCount(string key)
+	{
+		return key switch
+		{
+			"2L" => 2,
+			"2T" => 2,
+			"3L12" => 3,
+			"3R21" => 3,
+			"3R" => 3,
+			"4G" => 4,
+			"6G" => 6,
+			_ => 0
+		};
+	}
+
+	/// <summary>
+	/// 占满网格：任意 n 个窗口铺满整个工作区、无空位。
+	/// 行优先填充（cols=⌈√n⌉），最后一行不足 cols 个窗口时摊平整行宽度。
+	/// 例：n=2 → 左右对半；n=3 → 上排 2 窗各半宽 + 下排 1 窗全宽；
+	/// n=5 → 上排 3 窗 + 下排 2 窗（各 1.5 倍宽）；n=6 → 标准 2×3 六宫格。
+	/// </summary>
+	private static List<double[]> FillGridCells(int n)
 	{
 		List<double[]> cells = new List<double[]>();
 		if (n <= 0)
 		{
 			return cells;
 		}
-		if (n == 1)
-		{
-			cells.Add(new[] { 0.0, 0.0, 1.0, 1.0 });
-			return cells;
-		}
 		int cols = (int)Math.Ceiling(Math.Sqrt(n));
-		while (cols > 1 && n % cols != 0)
-		{
-			cols--;
-		}
-		if (n % cols != 0)
-		{
-			cols = 1;
-		}
-		int rows = n / cols;
+		int rows = (n + cols - 1) / cols;
 		for (int i = 0; i < n; i++)
 		{
 			int r = i / cols;
 			int c = i % cols;
-			cells.Add(new[] { (double)c / cols, (double)r / rows, (double)(c + 1) / cols, (double)(r + 1) / rows });
+			// 最后一行不足 cols 个时，按实际窗口数摊平行宽，保证铺满且无空位
+			bool isLastRow = r == rows - 1;
+			int rowCols = isLastRow ? n - (rows - 1) * cols : cols;
+			cells.Add(new[] { (double)c / rowCols, (double)r / rows, (double)(c + 1) / rowCols, (double)(r + 1) / rows });
 		}
 		return cells;
 	}


### PR DESCRIPTION
## 概述

本轮围绕「平铺窗口」功能做了一次系统性修复与扩展，共 6 个 commit、11 个文件、+403/−91：

1. **修复配置丢失类缺陷**——配置保存改原子写、损坏时保留现场、保存提示反映真实结果；
2. **修复平铺引擎 4 个严重 bug**——最小化快照坐标越界、HWND 复用误伤、虚拟桌面 API 失败静默丢窗、平铺/还原抢焦点；
3. **多显示器语义改造**——按显示器分区平铺，每屏独立套用布局；
4. **新增布局规则**——超编按任务栏顺序截断、缺编占满网格不留空位；
5. **新增用户设置**——屏幕四边边距、窗口间距、平铺日志记录窗口标题。

## 变更明细

### Bug修复

#### 1. 配置保存链路加固

| 问题 | 修法 |
|---|---|
| `SaveConfig` 裸 `File.WriteAllText`，写入中断产生截断文件，下次启动反序列化失败被静默 catch 吞掉、回落默认配置 | 改**原子写**：先写 `config.json.tmp`，再 `File.Replace`，同时保留上一份为 `.bak` |
| 回落默认后退出时 `OnExit` 无条件保存，把默认配置写回磁盘，丢失不可逆 | 回落时置 `IsFallbackConfig` 标志：跳过迁移落盘与退出写盘，损坏文件另存为 `config.json.corrupt.<时间戳>` 保留现场 |
| "配置已成功保存至硬盘！"无条件弹出，误导用户 | 仅在真正写盘成功时弹出，失败时报错 |
| 平铺布局下拉为纯 TwoWay 绑定，修改不触发落盘 | 三处 ComboBox 挂 `SelectionChanged` → `ScheduleAutoSave`；类型切换时同步更新动作名（不再产生"名为平铺、实为 OCR"的数据） |

#### 2. 平铺引擎修复

- **B1 最小化快照坐标 -32000**：`GetWindowRect` 移到 `ShowWindow` 还原之后，Restore 不再把窗口扔到屏幕外；
- **B2 HWND 复用误伤**：快照结构体化为 `{Rect, Pid}`，还原时校验 `IsWindow` + PID，写新快照时清理死条目；
- **B3 虚拟桌面 API 失败静默丢窗**：`IsOnCurrentVirtualDesktop` 改 fail-open——仅 HRESULT 成功才信任 BOOL 结果，VDM 不可用/COM 错误视为在桌面并一次性记警告；兜底枚举路径触发时留痕且尊重"包含最小化"开关；
- **B4 抢焦点**：平铺/还原的 `SW_RESTORE` 改 `SW_SHOWNOACTIVATE`；
- **多显示器语义**：平铺目标按显示器分区（保持任务栏顺序），每分区独立套用布局——双屏各 2 窗做 2L 现在是每屏各自完整左右对半。

### 布局规则

固定布局（2L/2T/3L12/3R21/3R/4G/6G）：

| 场景 | 旧行为 | 新行为 |
|---|---|---|
| 窗口数 **超过** 名义格数 | 全部窗口重排为 n 格网格（3 窗 2L 变三等分） | **按任务栏顺序只平铺前 N 个**，多余窗口原地不动 |
| 窗口数 **少于** 名义格数 | 取名义网格前 n 格，其余空位（2 窗 4G 只有上半屏有窗） | **`FillGridCells` 占满网格**：行优先 + 末行摊平，任意数量铺满工作区无空位 |

动态布局（ML/MR/MT/MB/HS/VS/COL/BSP/AG/MO）行为不变。

### 新增设置

「平铺窗口高级设置」卡片新增（输入即存、四语界面）：

- **屏幕边距**（上/下/左/右，0~1000 物理像素）：整体平铺区域向内收缩；
- **窗口间距**（0~500 物理像素）：格子内边缘各缩 gap/2，外边缘不缩——相邻窗间隔 = gap，贴边窗只受边距控制，两个参数互不干扰。

### 日志增强

平铺目标清单与放置日志追加窗口标题：

```
[Tile]   target hwnd=0x1A0B2C exe=chrome title="文档 - 记事本"
[Tile] #2 hwnd=0x1A0B2C exe=notepad title="文档 - 记事本" rect=(960,40,950,1040) ok=True
```

用户可对照日志将不需要参与的程序加入排除名单。

## 预览
<img width="1307" height="853" alt="Snipaste1" src="https://github.com/user-attachments/assets/f20b780a-df9e-4b17-affe-97a356f6aefd" />
<img width="634" height="717" alt="Snipaste2" src="https://github.com/user-attachments/assets/e65725f9-10d6-4bba-bdfa-030b770f6eb1" />


## 测试情况

- ✅ `dotnet build -c Release` **0 错误**（502 个警告均为原有 P/Invoke 结构体未赋值，与本次无关）；
- ✅ `FillGridCells` 网格算法经脚本验证 n=1~24 无空隙、无重叠、无越界；
- ✅ 原子写语义经独立 net8 控制台程序实测：首次保存走 `File.Move`、后续走 `File.Replace` 生成 `.bak`、`File.Replace` 目标缺失抛 `FileNotFoundException`（证实 `File.Exists` 分支必需）、截断 JSON 触发回落路径；