### PR TITLE
feat: 启动程序动作默认继承目标程序图标

### DIFF
--- a/WinPieGestures/SettingsWindow.xaml.cs
+++ b/WinPieGestures/SettingsWindow.xaml.cs
@@ -3619,6 +3619,7 @@ public partial class SettingsWindow : Window
 		if (iconPickerWindow.ShowDialog() == true)
 		{
 			item.IconKey = iconPickerWindow.SelectedIconKey ?? "";
+			item.InheritAppIconPath = "";
 			UpdateFocusEditorUi();
 			RefreshSlots();
 			RenderMappingsWheelPreview();
@@ -4174,6 +4175,9 @@ public partial class SettingsWindow : Window
 		if (programPicker.ShowDialog() == true && !string.IsNullOrEmpty(programPicker.SelectedPath))
 		{
 			item.Parameter = programPicker.SelectedPath;
+			item.InheritAppIconPath = programPicker.SelectedPath;
+			item.IconKey = "";
+			item.CustomIconSvg = "";
 			FocusLaunchPathTextBox.Text = programPicker.SelectedPath;
 			if (string.IsNullOrWhiteSpace(item.Name) || item.Name.StartsWith("快捷动作") || item.Name.StartsWith("启动"))
 			{
@@ -4200,6 +4204,9 @@ public partial class SettingsWindow : Window
 		if (picker.ShowDialog() == true && !string.IsNullOrEmpty(picker.SelectedPath))
 		{
 			item.Parameter = picker.SelectedPath;
+			item.InheritAppIconPath = picker.SelectedPath;
+			item.IconKey = "";
+			item.CustomIconSvg = "";
 			FocusLaunchPathTextBox.Text = picker.SelectedPath;
 			if (string.IsNullOrWhiteSpace(item.Name) || item.Name.StartsWith("快捷动作") || item.Name.StartsWith("启动"))
 			{
@@ -4229,6 +4236,9 @@ public partial class SettingsWindow : Window
 		if (dlg.ShowDialog(this) == true)
 		{
 			item.Parameter = dlg.FileName;
+			item.InheritAppIconPath = dlg.FileName;
+			item.IconKey = "";
+			item.CustomIconSvg = "";
 			FocusLaunchPathTextBox.Text = dlg.FileName;
 			if (string.IsNullOrWhiteSpace(item.Name) || item.Name.StartsWith("快捷动作") || item.Name.StartsWith("启动"))
 			{
@@ -9931,6 +9941,9 @@ public partial class SettingsWindow : Window
 		if (programPickerWindow.ShowDialog() == true && !string.IsNullOrEmpty(programPickerWindow.SelectedPath))
 		{
 			dataContext.Parameter = programPickerWindow.SelectedPath;
+			dataContext.InheritAppIconPath = programPickerWindow.SelectedPath;
+			dataContext.IconKey = "";
+			dataContext.CustomIconSvg = "";
 			if (string.IsNullOrEmpty(dataContext.Name) || dataContext.Name.StartsWith("动作") || dataContext.Name == "快捷动作")
 			{
 				dataContext.Name = ((!string.IsNullOrEmpty(programPickerWindow.SelectedName)) ? programPickerWindow.SelectedName : System.IO.Path.GetFileNameWithoutExtension(programPickerWindow.SelectedPath));

--- a/WinPieGestures/SlotViewModel.cs
+++ b/WinPieGestures/SlotViewModel.cs
@@ -568,6 +568,23 @@ public class SlotViewModel : INotifyPropertyChanged, IDisposable
 		}
 	}
 
+	public string InheritAppIconPath
+	{
+		get
+		{
+			return Action.InheritAppIconPath ?? "";
+		}
+		set
+		{
+			if (Action.InheritAppIconPath != value)
+			{
+				Action.InheritAppIconPath = value;
+				OnPropertyChanged("InheritAppIconPath");
+				OnPropertyChanged("IconDisplayText");
+			}
+		}
+	}
+
 	public string IconDisplayText
 	{
 		get
@@ -579,6 +596,10 @@ public class SlotViewModel : INotifyPropertyChanged, IDisposable
 			if (!string.IsNullOrEmpty(CustomIconSvg))
 			{
 				return "自定义SVG";
+			}
+			if (!string.IsNullOrEmpty(InheritAppIconPath))
+			{
+				return "程序图标";
 			}
 			return "图标...";
 		}

--- a/WinPieGestures/SubActionEditorWindow.xaml.cs
+++ b/WinPieGestures/SubActionEditorWindow.xaml.cs
@@ -108,6 +108,7 @@ public partial class SubActionEditorWindow : Window
 			if (iconPickerWindow.ShowDialog() == true)
 			{
 				dataContext.IconKey = iconPickerWindow.SelectedIconKey ?? "";
+				dataContext.InheritAppIconPath = "";
 			}
 		}
 	}
@@ -123,6 +124,9 @@ public partial class SubActionEditorWindow : Window
 		if (programPickerWindow.ShowDialog() == true && !string.IsNullOrEmpty(programPickerWindow.SelectedPath))
 		{
 			dataContext.Parameter = programPickerWindow.SelectedPath;
+			dataContext.InheritAppIconPath = programPickerWindow.SelectedPath;
+			dataContext.IconKey = "";
+			dataContext.CustomIconSvg = "";
 			if (string.IsNullOrEmpty(dataContext.Name) || dataContext.Name.StartsWith("子动作"))
 			{
 				dataContext.Name = ((!string.IsNullOrEmpty(programPickerWindow.SelectedName)) ? programPickerWindow.SelectedName : Path.GetFileNameWithoutExtension(programPickerWindow.SelectedPath));

--- a/WinPieGestures/SubSlotViewModel.cs
+++ b/WinPieGestures/SubSlotViewModel.cs
@@ -183,6 +183,23 @@ public class SubSlotViewModel : INotifyPropertyChanged
 		}
 	}
 
+	public string InheritAppIconPath
+	{
+		get
+		{
+			return Action.InheritAppIconPath ?? "";
+		}
+		set
+		{
+			if (Action.InheritAppIconPath != value)
+			{
+				Action.InheritAppIconPath = value;
+				OnPropertyChanged("InheritAppIconPath");
+				OnPropertyChanged("IconDisplayText");
+			}
+		}
+	}
+
 	public string IconDisplayText
 	{
 		get
@@ -194,6 +211,10 @@ public class SubSlotViewModel : INotifyPropertyChanged
 			if (!string.IsNullOrEmpty(CustomIconSvg))
 			{
 				return "自定义SVG";
+			}
+			if (!string.IsNullOrEmpty(InheritAppIconPath))
+			{
+				return "程序图标";
 			}
 			return "图标...";
 		}


### PR DESCRIPTION
## 背景

动作类型为「启动程序」的条目，Parameter 指向目标程序，但条目图标不会随所选程序变化：
从图标库或其他条目带过来的自定义图标会一直残留，用户选完程序还需要再手动选一次图标。
本 PR 让「选择程序」这一操作同时把条目图标默认切换为目标程序图标，之后仍可随时用图标选择器自定义覆盖。

## 修改内容（4 文件，+59 行）

1. `SettingsWindow.xaml.cs`
   - 焦点卡片三个选程序入口（`FocusPickProgramFromLibrary_Click` 软件库 / `FocusCaptureRunningWindow_Click` 抓取运行窗口 / `FocusBrowseLaunchExe_Click` 浏览 exe）：写入 `Parameter` 时同步写入 `InheritAppIconPath` 并清除 `IconKey`/`CustomIconSvg`，条目图标立即切换为目标程序图标；
   - 槽位卡片编辑器 `Browse_Click`：同上；
   - 手动选图标入口 `FocusPickIcon_Click`：清除 `InheritAppIconPath`（图标选择与继承互斥，后选生效）。
2. `SubActionEditorWindow.xaml.cs`
   - `SubBrowseApp_Click` 子动作选程序自动继承；`SubPickIcon_Click` 手动选图标取消继承。
3. `SlotViewModel.cs` / `SubSlotViewModel.cs`
   - 新增 `InheritAppIconPath` 透传属性（带 OnPropertyChanged）；
   - `IconDisplayText` 在继承时显示「程序图标」，用户能直接看出当前图标来源。

设计约束：**不修改 `ConfigManager.LoadConfig`，不回填存量条目**——图标继承只在用户显式选择程序/图标的时刻发生，经既有的保存路径持久化，启动与退出对既有配置零改写。

## 验证


https://github.com/user-attachments/assets/63f72f46-7785-4f69-8c84-03b8cdda6fe2


- 本 PR 未修改任何测试文件；现有 GUI 套件依赖真实桌面环境，CI 维持构建验证。

## AI 自查声明

本 PR 由 AI（ZCode）辅助完成，已自查以下事项：

| 检查项 | 结果 |
| --- | --- |
| 不修改 ConfigManager/加载路径，无启动回填 | ✅ 本次 diff 未触碰 ConfigManager.cs |
| 手动选图标与自动继承互斥（两个方向） | ✅ 选程序清 IconKey/CustomIconSvg；选图标清 InheritAppIconPath |
| 手势映射编辑器行为不变 | ✅ 未触碰（上游有意靠 Parameter 回退显示） |
| 渲染端零改动（复用上游 InheritAppIconPath/Parameter 回退） | ✅ |
| 既有配置兼容性 | ✅ 字段本就存在（ActionItem.InheritAppIconPath），存量条目不受影响 |
| 构建 | ✅ 0 错误，警告为既有基线 |

---

### 附：给维护者的备注（调研中发现的两个上游现象，与本 PR 无关，仅供参考）

1. **打开设置窗口可能改写 Global[0] 槽位**：在 v1.6.8（19d280c）复现——当 Global 配置第一个动作不是窗口管理类时，打开设置窗口后该动作会被改写为 `Type=Tile / Parameter=2L / IconKey=Tile`（疑似 `SettingsWindow.xaml` 中 `SelectedValue="{Binding AggregatedType, Mode=TwoWay}"` 的行虚拟化回收问题，某行组合框初始化时把 "WindowManager" 推进了目标行）。用改动前二进制同样复现，与本 PR 无关。若需要，我可以整理成独立 issue/PR。
2. `LoadConfig` 的 catch 会静默将 CurrentConfig 置为默认配置，而 App.OnExit 无条件 `SaveConfig()`——任何加载期异常都可能导致下次退出时用默认配置覆盖真实 config.json。可考虑加载失败时跳过退出存盘或先备份。