### PR TITLE
feat: 启动程序动作选取目标程序时自动继承其图标

### DIFF
--- a/WinPieGestures/SettingsWindow.xaml.cs
+++ b/WinPieGestures/SettingsWindow.xaml.cs
@@ -3741,6 +3741,7 @@ public partial class SettingsWindow : Window
 		if (iconPickerWindow.ShowDialog() == true)
 		{
 			item.IconKey = iconPickerWindow.SelectedIconKey ?? "";
+			item.InheritAppIconPath = "";
 			UpdateFocusEditorUi();
 			RefreshSlots();
 			RenderMappingsWheelPreview();
@@ -4331,6 +4332,9 @@ public partial class SettingsWindow : Window
 		{
 			item.Parameter = programPicker.SelectedPath;
 			FocusLaunchPathTextBox.Text = programPicker.SelectedPath;
+			item.InheritAppIconPath = programPicker.SelectedPath;
+			item.IconKey = "";
+			item.CustomIconSvg = "";
 			if (string.IsNullOrWhiteSpace(item.Name) || item.Name.StartsWith("快捷动作") || item.Name.StartsWith("启动"))
 			{
 				string autoName = !string.IsNullOrEmpty(programPicker.SelectedName) 
@@ -4339,6 +4343,7 @@ public partial class SettingsWindow : Window
 				item.Name = autoName;
 				FocusActionNameTextBox.Text = autoName;
 			}
+			UpdateFocusEditorUi();
 			RefreshSlots();
 			RenderMappingsWheelPreview();
 			ScheduleAutoSave();
@@ -4357,6 +4362,9 @@ public partial class SettingsWindow : Window
 		{
 			item.Parameter = picker.SelectedPath;
 			FocusLaunchPathTextBox.Text = picker.SelectedPath;
+			item.InheritAppIconPath = picker.SelectedPath;
+			item.IconKey = "";
+			item.CustomIconSvg = "";
 			if (string.IsNullOrWhiteSpace(item.Name) || item.Name.StartsWith("快捷动作") || item.Name.StartsWith("启动"))
 			{
 				string autoName = !string.IsNullOrEmpty(picker.SelectedTitle)
@@ -4365,6 +4373,7 @@ public partial class SettingsWindow : Window
 				item.Name = autoName;
 				FocusActionNameTextBox.Text = autoName;
 			}
+			UpdateFocusEditorUi();
 			RefreshSlots();
 			RenderMappingsWheelPreview();
 			ScheduleAutoSave();
@@ -4386,12 +4395,16 @@ public partial class SettingsWindow : Window
 		{
 			item.Parameter = dlg.FileName;
 			FocusLaunchPathTextBox.Text = dlg.FileName;
+			item.InheritAppIconPath = dlg.FileName;
+			item.IconKey = "";
+			item.CustomIconSvg = "";
 			if (string.IsNullOrWhiteSpace(item.Name) || item.Name.StartsWith("快捷动作") || item.Name.StartsWith("启动"))
 			{
 				string autoName = System.IO.Path.GetFileNameWithoutExtension(dlg.FileName);
 				item.Name = autoName;
 				FocusActionNameTextBox.Text = autoName;
 			}
+			UpdateFocusEditorUi();
 			RefreshSlots();
 			RenderMappingsWheelPreview();
 			ScheduleAutoSave();
@@ -8977,6 +8990,7 @@ public partial class SettingsWindow : Window
 		if (iconPickerWindow.ShowDialog() == true)
 		{
 			dataContext.IconKey = iconPickerWindow.SelectedIconKey ?? "";
+			dataContext.InheritAppIconPath = "";
 			Grid appearanceSettingsGrid = AppearanceSettingsGrid;
 			if (appearanceSettingsGrid != null && appearanceSettingsGrid.Visibility == Visibility.Visible)
 			{

--- a/WinPieGestures/SubActionEditorWindow.xaml.cs
+++ b/WinPieGestures/SubActionEditorWindow.xaml.cs
@@ -41,6 +41,7 @@ public partial class SubActionEditorWindow : Window
 						Arguments = existingSubAction.Arguments,
 						IconKey = existingSubAction.IconKey,
 						CustomIconSvg = existingSubAction.CustomIconSvg,
+						InheritAppIconPath = existingSubAction.InheritAppIconPath,
 						CommandTerminal = existingSubAction.CommandTerminal
 					}
 				});
@@ -120,6 +121,7 @@ public partial class SubActionEditorWindow : Window
 			if (iconPickerWindow.ShowDialog() == true)
 			{
 				dataContext.IconKey = iconPickerWindow.SelectedIconKey ?? "";
+				dataContext.InheritAppIconPath = "";
 			}
 		}
 	}
@@ -135,6 +137,9 @@ public partial class SubActionEditorWindow : Window
 		if (programPickerWindow.ShowDialog() == true && !string.IsNullOrEmpty(programPickerWindow.SelectedPath))
 		{
 			dataContext.Parameter = programPickerWindow.SelectedPath;
+			dataContext.InheritAppIconPath = programPickerWindow.SelectedPath;
+			dataContext.IconKey = "";
+			dataContext.CustomIconSvg = "";
 			if (string.IsNullOrEmpty(dataContext.Name) || dataContext.Name.StartsWith("子动作"))
 			{
 				dataContext.Name = ((!string.IsNullOrEmpty(programPickerWindow.SelectedName)) ? programPickerWindow.SelectedName : Path.GetFileNameWithoutExtension(programPickerWindow.SelectedPath));


### PR DESCRIPTION
## 背景

「关联外部程序图标」能力（Issue #11）目前只有手动填路径一种手法，且焦点编辑器的关联面板明确排除了 Launch/App 类型动作（`canInherit = type != "Launch" && type != "App"`）。另一方面，全部 5 个「选取目标程序」的入口——焦点卡片的软件库/捕捉运行窗口/浏览 exe、槽位卡片浏览按钮、子动作编辑器浏览按钮——都只写入 `Parameter`，不触碰任何图标字段。

对启动类动作而言，「选程序」与「程序图标」本是一件事，用户却需要在选完程序后再手动选一次图标（而 Launch 类型恰恰连手动关联的入口都没有）。

本 PR 让「选取目标程序」这一步顺带完成图标继承：选了程序，条目图标立即跟随目标程序。

## 修改内容

共 2 个文件、+19 行，全部为纯插入，不涉及 XAML / ViewModel / 数据模型 / LoadConfig：

1. **五个选程序入口自动继承**：写入 `Parameter` 的同时写入 `InheritAppIconPath`，并清除 `IconKey`/`CustomIconSvg`（保证条目图标唯一来源）：
   - `FocusPickProgramFromLibrary_Click` / `FocusCaptureRunningWindow_Click` / `FocusBrowseLaunchExe_Click`（SettingsWindow.xaml.cs）
   - `Browse_Click`（槽位卡片浏览按钮，SettingsWindow.xaml.cs）
   - `SubBrowseApp_Click`（SubActionEditorWindow.xaml.cs）
2. **三个图标库选择入口反向清除**：`FocusPickIcon_Click` / `PickIcon_Click` / `SubPickIcon_Click` 选取图标时清除 `InheritAppIconPath`——图标选择与继承互斥、后选生效；
3. **焦点卡片三个选程序入口补调 `UpdateFocusEditorUi()`**：与既有手动关联处理器保持同一刷新序列（UpdateFocusEditorUi → RefreshSlots → RenderMappingsWheelPreview → ScheduleAutoSave），选中后焦点卡大图标即时刷新；
4. **伴随修复**：子动作编辑器构造函数拷贝既有子动作时遗漏 `InheritAppIconPath`，导致带继承图标的子动作一进编辑器保存即丢失关联，已补上。

刻意不做的事：

- 不修改 `LoadConfig`、不回填存量条目：启动与退出路径零改写，仅响应用户显式选择；
- 手动键入路径文本框（`FocusLaunchPathTextBox_TextChanged`）不触发继承，避免半输入路径产生失效关联；
- Launch 条目的关联面板显隐逻辑保持上游现状不变。

> 说明：清除 `IconKey` 并非 v1.6.9 渲染所必需（运行时轮盘解析顺序为 CustomIconSvg > InheritAppIconPath > IconKey），但清掉可保证条目图标只有唯一来源，与互斥语义一致，也避免日后清除继承时旧图标意外回显。

## 验证

- `dotnet build WinPieGestures/WinPieGestures.csproj -c Release`：0 错误（警告为仓库既有基线，与改动前一致）；
- `tests/test_settings.py` 现状不含动作级图标字段断言（无既有覆盖），GUI 验证按仓库惯例在真实桌面环境执行，清单如下；
- 手动验证清单：
  - [ ] 焦点卡片软件库选程序 → 焦点卡大图标 / 槽位卡 / 轮盘预览立即变为目标程序图标，文字标签显示程序名；
  - [ ] 捕捉运行窗口、浏览 exe 两个入口同上；
  - [ ] 槽位卡片浏览按钮、子动作编辑器浏览按钮同上；
  - [ ] 选完程序后再从图标库任选图标 → 继承被清除，显示所选图标；反向（先选图标后选程序）同样后选生效；
  - [ ] 重启应用后继承关系保持（config.json 中 `InheritAppIconPath` 落盘）；
  - [ ] 带继承图标的子动作进入编辑器再保存，关联不丢失。

##视频

https://github.com/user-attachments/assets/08af5359-52ad-41d3-8a20-2220925a554f



## AI 自查声明

本 PR 由 AI（ZCode）辅助编写，并已完成一轮代码自查：

| 检查项 | 结果 |
|---|---|
| 纯插入、不改动既有行为分支 | ✅ +19 行，无删改 |
| 不触碰 LoadConfig / 启动与退出路径 | ✅ |
| 新增 UI 字符串 | 无（未新增文案，无需改 I18n.cs） |
| 图标互斥双向覆盖（选程序清图标 / 选图标清继承） | ✅ 5 + 3 入口 |
| 刷新序列与既有手动关联处理器一致 | ✅ |
| 构建 | ✅ 0 错误 |
