### PR TITLE
perf: 解耦 SettingsWindow 生命周期并修复按需重建相关问题

### DIFF
--- a/WinPieGestures/ActionExecutor.cs
+++ b/WinPieGestures/ActionExecutor.cs
@@ -1620,7 +1620,7 @@ public static class ActionExecutor
 		case "控制台":
 			Application.Current?.Dispatcher?.BeginInvoke((Action)delegate
 			{
-				App.MainSettingsWindow?.ShowSettings();
+				App.ShowSettingsWindow();
 			});
 			break;
 		case "settings":

--- a/WinPieGestures/App.xaml
+++ b/WinPieGestures/App.xaml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Application x:Class="WinPieGestures.App" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:local="clr-namespace:WinPieGestures">
+<Application x:Class="WinPieGestures.App" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:local="clr-namespace:WinPieGestures" ShutdownMode="OnExplicitShutdown">
   <Application.Resources>
     <ResourceDictionary>
       <SolidColorBrush x:Key="WindowBackgroundBrush" Color="#F8FAFC" />

--- a/WinPieGestures/App.xaml.cs
+++ b/WinPieGestures/App.xaml.cs
@@ -17,6 +17,10 @@ public partial class App : Application
 	private static EventWaitHandle? _instanceWakeEvent;
 	private static RegisteredWaitHandle? _waitHandleRegistration;
 	private static bool _isDuplicateInstance;
+	private static bool _isExiting;
+	private static bool _startupCompleted;
+	private static bool _pendingSettingsRequest;
+	private static int _pendingSettingsTabIndex = -1;
 
 	private const string MutexName = "Global\\StarPie_SingleInstance_Mutex_9B8A7C";
 	private const string WakeEventName = "Global\\StarPie_Wakeup_Event_9B8A7C";
@@ -26,6 +30,8 @@ public partial class App : Application
 	public static MouseHook? MainMouseHook { get; private set; }
 	public static KeyboardHook? MainKeyboardHook { get; private set; }
 	public static SettingsWindow? MainSettingsWindow { get; private set; }
+	public static TrayController? MainTrayController { get; private set; }
+	public static bool IsExiting => _isExiting;
 
 	[DllImport("shell32.dll", SetLastError = true)]
 	private static extern void SetCurrentProcessExplicitAppUserModelID([MarshalAs(UnmanagedType.LPWStr)] string AppID);
@@ -144,14 +150,24 @@ public partial class App : Application
 			MainKeyboardHook.Start();
 			AppLogger.LogInfo("MainKeyboardHook started");
 			MainGestureController = new GestureController(MainMouseHook, MainKeyboardHook);
-			MainSettingsWindow = new SettingsWindow();
-			base.MainWindow = MainSettingsWindow;
-			if (!SettingsWindow.IsSilentLaunch())
+			MainTrayController = new TrayController();
+			MainTrayController.OpenSettingsRequested += ShowSettingsWindow;
+			MainTrayController.TogglePauseRequested += TogglePauseGestures;
+			MainTrayController.ElevateRequested += RestartElevated;
+			MainTrayController.ExitRequested += ExitApplication;
+			MainTrayController.Initialize(MainMouseHook.IsPaused, IsCurrentThemeDark());
+			AppLogger.LogInfo("TrayController initialized");
+			_startupCompleted = true;
+			if (!SettingsWindow.IsSilentLaunch() || _pendingSettingsRequest)
 			{
-				MainSettingsWindow.Show();
+				int requestedTab = _pendingSettingsRequest ? _pendingSettingsTabIndex : -1;
+				_pendingSettingsRequest = false;
+				_pendingSettingsTabIndex = -1;
+				ShowSettingsWindow(requestedTab);
 			}
 			else
 			{
+				AppLogger.LogInfo("Silent launch: SettingsWindow creation deferred until first use");
 				// 静默启动或开机自启时，在挂载完轻量级钩子后等待后台就绪（1.5秒后）执行一次工作集规整，将静默占用压至极限
 				_ = System.Threading.Tasks.Task.Run(async () =>
 				{
@@ -176,11 +192,40 @@ public partial class App : Application
 
 	public static void WakeUpSettingsWindow()
 	{
-		if (MainSettingsWindow == null)
+		ShowSettingsWindow();
+	}
+
+	public static void ShowSettingsWindow(int tabIndex = -1)
+	{
+		if (_isExiting || Application.Current == null)
 		{
 			return;
 		}
-		MainSettingsWindow.ShowSettings();
+		if (!Application.Current.Dispatcher.CheckAccess())
+		{
+			Application.Current.Dispatcher.BeginInvoke((Action)(() => ShowSettingsWindow(tabIndex)));
+			return;
+		}
+		if (!_startupCompleted)
+		{
+			_pendingSettingsRequest = true;
+			if (tabIndex >= 0)
+			{
+				_pendingSettingsTabIndex = tabIndex;
+			}
+			return;
+		}
+
+		if (MainSettingsWindow == null)
+		{
+			SettingsWindow window = new SettingsWindow();
+			window.Closed += SettingsWindow_Closed;
+			MainSettingsWindow = window;
+			Application.Current.MainWindow = window;
+			AppLogger.LogInfo("SettingsWindow created on demand");
+		}
+
+		MainSettingsWindow.ShowSettings(tabIndex);
 		try
 		{
 			nint handle = new WindowInteropHelper(MainSettingsWindow).Handle;
@@ -192,6 +237,95 @@ public partial class App : Application
 		catch
 		{
 		}
+	}
+
+	private static void SettingsWindow_Closed(object? sender, EventArgs e)
+	{
+		if (sender is not SettingsWindow closedWindow)
+		{
+			return;
+		}
+		closedWindow.Closed -= SettingsWindow_Closed;
+		if (ReferenceEquals(MainSettingsWindow, closedWindow))
+		{
+			MainSettingsWindow = null;
+		}
+		if (Application.Current != null && ReferenceEquals(Application.Current.MainWindow, closedWindow))
+		{
+			Application.Current.MainWindow = null;
+		}
+		AppLogger.LogInfo("SettingsWindow closed and released");
+		if (!_isExiting && Application.Current != null)
+		{
+			Application.Current.Dispatcher.BeginInvoke(
+				(Action)(() => MemoryOptimizer.TrimMemory(force: false)),
+				DispatcherPriority.ApplicationIdle);
+		}
+	}
+
+	public static void RefreshTrayMenu()
+	{
+		MainTrayController?.RefreshMenu();
+	}
+
+	public static void ApplyTrayTheme(bool isDark)
+	{
+		MainTrayController?.ApplyTheme(isDark);
+	}
+
+	public static void ShowTrayBalloon(int timeout, string title, string message, System.Windows.Forms.ToolTipIcon icon)
+	{
+		MainTrayController?.ShowBalloonTip(timeout, title, message, icon);
+	}
+
+	private static bool IsCurrentThemeDark()
+	{
+		string theme = ConfigManager.CurrentConfig?.AppTheme ?? "System";
+		if (string.Equals(theme, "System", StringComparison.OrdinalIgnoreCase) || string.IsNullOrEmpty(theme))
+		{
+			return AppThemeManager.IsWindowsInDarkTheme();
+		}
+		return !string.Equals(theme, "Light", StringComparison.OrdinalIgnoreCase);
+	}
+
+	private static void TogglePauseGestures()
+	{
+		if (MainMouseHook == null)
+		{
+			return;
+		}
+		MainMouseHook.IsPaused = !MainMouseHook.IsPaused;
+		MainTrayController?.UpdatePauseState(MainMouseHook.IsPaused);
+	}
+
+	public static void RestartElevated()
+	{
+		try
+		{
+			string fileName = Environment.ProcessPath ?? Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "StarPie.exe");
+			Process.Start(new ProcessStartInfo
+			{
+				FileName = fileName,
+				UseShellExecute = true,
+				Verb = "runas"
+			});
+			ExitApplication();
+		}
+		catch (Exception ex)
+		{
+			MessageBox.Show("提权重启失败或已取消: " + ex.Message, "管理员提权", MessageBoxButton.OK, MessageBoxImage.Exclamation);
+		}
+	}
+
+	public static void ExitApplication()
+	{
+		if (_isExiting)
+		{
+			return;
+		}
+		_isExiting = true;
+		MainTrayController?.Dispose();
+		Application.Current?.Shutdown();
 	}
 
 	private void App_DispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
@@ -232,6 +366,9 @@ public partial class App : Application
 			return;
 		}
 		AppLogger.LogInfo("=== StarPie Exiting ===");
+		_isExiting = true;
+		MainTrayController?.Dispose();
+		MainTrayController = null;
 		// 退出前自动还原所有窗口到首次平铺前的样式
 		try
 		{

--- a/WinPieGestures/SettingsWindow.xaml.cs
+++ b/WinPieGestures/SettingsWindow.xaml.cs
@@ -317,6 +317,9 @@ public partial class SettingsWindow : Window
 
 	private bool _isUiInitializing = false;
 	private bool _isUiInitialized = false;
+	private bool _isLoadingAutoStartState = false;
+	private bool _loadedAutoStartEnabled;
+	private bool _loadedAutoStartAsAdmin;
 
 	private static int _lastSelectedTabIndex;
 
@@ -1136,10 +1139,20 @@ public partial class SettingsWindow : Window
 		}
 
 		// AutoStart
-		AutoStartCheckBox.IsChecked = ConfigManager.IsAutoStartEnabled();
-		if (AutoStartAsAdminCheckBox != null)
+		_isLoadingAutoStartState = true;
+		try
 		{
-			AutoStartAsAdminCheckBox.IsChecked = ConfigManager.CurrentConfig.AutoStartAsAdmin;
+			_loadedAutoStartEnabled = ConfigManager.IsAutoStartEnabled();
+			_loadedAutoStartAsAdmin = ConfigManager.CurrentConfig.AutoStartAsAdmin;
+			AutoStartCheckBox.IsChecked = _loadedAutoStartEnabled;
+			if (AutoStartAsAdminCheckBox != null)
+			{
+				AutoStartAsAdminCheckBox.IsChecked = _loadedAutoStartAsAdmin;
+			}
+		}
+		finally
+		{
+			_isLoadingAutoStartState = false;
 		}
 
 		// Language & Previews
@@ -10967,28 +10980,38 @@ public partial class SettingsWindow : Window
 
 	private void AutoStartCheckBox_Changed(object sender, RoutedEventArgs e)
 	{
-		if (!_isUpdatingUi)
+		if (!_isUpdatingUi && !_isUiInitializing && !_isLoadingAutoStartState)
 		{
 			bool valueOrDefault = AutoStartCheckBox.IsChecked == true;
 			bool asAdmin = (AutoStartAsAdminCheckBox?.IsChecked == true);
+			if (valueOrDefault == _loadedAutoStartEnabled && asAdmin == _loadedAutoStartAsAdmin)
+			{
+				return;
+			}
 			ConfigManager.SetAutoStart(valueOrDefault, asAdmin);
+			_loadedAutoStartEnabled = valueOrDefault;
+			_loadedAutoStartAsAdmin = asAdmin;
 			SyncUiToConfigAndSave();
 		}
 	}
 
 	private void AutoStartAsAdminCheckBox_Changed(object sender, RoutedEventArgs e)
 	{
-		if (!_isUpdatingUi)
+		if (!_isUpdatingUi && !_isUiInitializing && !_isLoadingAutoStartState)
 		{
 			bool flag = (AutoStartAsAdminCheckBox?.IsChecked == true);
+			bool enabled = AutoStartCheckBox.IsChecked == true;
+			if (flag == _loadedAutoStartAsAdmin && enabled == _loadedAutoStartEnabled)
+			{
+				return;
+			}
 			if (ConfigManager.CurrentConfig != null)
 			{
 				ConfigManager.CurrentConfig.AutoStartAsAdmin = flag;
 			}
-			if (AutoStartCheckBox.IsChecked == true)
-			{
-				ConfigManager.SetAutoStart(enable: true, flag);
-			}
+			ConfigManager.SetAutoStart(enabled, flag);
+			_loadedAutoStartEnabled = enabled;
+			_loadedAutoStartAsAdmin = flag;
 			SyncUiToConfigAndSave();
 		}
 	}

--- a/WinPieGestures/SettingsWindow.xaml.cs
+++ b/WinPieGestures/SettingsWindow.xaml.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Drawing;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -22,7 +21,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Effects;
 using System.Windows.Media.Imaging;
-using System.Windows.Resources;
 using System.Windows.Shapes;
 using System.Windows.Threading;
 using System.Net.Http;
@@ -79,9 +77,7 @@ public partial class SettingsWindow : Window
 
 	private bool _isRecordingTrigger;
 
-	private NotifyIcon _notifyIcon;
-
-	private bool _isClosingFromTray;
+	private System.Windows.Media.Brush? _originalBadgeBorderBrush;
 
 	private WheelProfile? _selectedProfile;
 
@@ -180,6 +176,7 @@ public partial class SettingsWindow : Window
 
 	private ReleaseInfo? _latestReleaseInfo = null;
 	private CancellationTokenSource? _downloadCts = null;
+	private readonly CancellationTokenSource _lifetimeCts = new CancellationTokenSource();
 	private string? _downloadedZipPath = null;
 
 	private static readonly string[] Directions4 = new string[4] { "右 (E / 0°)", "下 (S / 90°)", "左 (W / 180°)", "上 (N / 270°)" };
@@ -312,8 +309,6 @@ public partial class SettingsWindow : Window
 		}
 	};
 
-	private ToolStripMenuItem? _pauseResumeMenuItem;
-
 	private DispatcherTimer? _autoSaveDebounceTimer;
 
 	private bool _isChangingSectorCount;
@@ -322,6 +317,12 @@ public partial class SettingsWindow : Window
 
 	private bool _isUiInitializing = false;
 	private bool _isUiInitialized = false;
+
+	private static int _lastSelectedTabIndex;
+
+	private DispatcherTimer? _deferredCloseTimer;
+
+	private bool _isClosingForRelease;
 
 	public static bool IsSilentLaunch()
 	{
@@ -389,7 +390,7 @@ public partial class SettingsWindow : Window
 			UpdateSidebarThemeVisualState(ConfigManager.CurrentConfig?.AppTheme ?? "System");
 			bool isDark = IsCurrentThemeDark();
 			UpdateLogoTheme(isDark);
-			ApplyTrayMenuTheme(isDark);
+			App.ApplyTrayTheme(isDark);
 
 			if (App.MainKeyboardHook != null)
 			{
@@ -435,7 +436,6 @@ public partial class SettingsWindow : Window
 		catch
 		{
 		}
-		InitializeTrayIcon();
 		string text = "v" + (Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "1.7.0");
 		if (SidebarVersionText != null)
 		{
@@ -460,7 +460,7 @@ public partial class SettingsWindow : Window
 			UpdateSidebarThemeVisualState(ConfigManager.CurrentConfig?.AppTheme ?? "System");
 			bool isDark = IsCurrentThemeDark();
 			UpdateLogoTheme(isDark);
-			ApplyTrayMenuTheme(isDark);
+			App.ApplyTrayTheme(isDark);
 			if (AppearanceSettingsGrid.Visibility == Visibility.Visible)
 			{
 				RenderLiveWheelPreview();
@@ -471,13 +471,30 @@ public partial class SettingsWindow : Window
 			{
 				Task.Run(async () =>
 				{
-					await Task.Delay(2500);
-					await Dispatcher.InvokeAsync(() => CheckForUpdateInternalAsync(silent: true));
+					try
+					{
+						await Task.Delay(2500, _lifetimeCts.Token);
+						if (!_lifetimeCts.IsCancellationRequested)
+						{
+							await Dispatcher.InvokeAsync(() => CheckForUpdateInternalAsync(silent: true));
+						}
+					}
+					catch (OperationCanceledException)
+					{
+					}
 				});
 			}
 		};
 		base.Deactivated += delegate { CancelExclusiveRecordingIfActive(); };
-		base.Closing += delegate { CancelExclusiveRecordingIfActive(); };
+	}
+
+	private void CancelDeferredClose()
+	{
+		_deferredCloseTimer?.Stop();
+		_deferredCloseTimer = null;
+		_isClosingForRelease = false;
+		BeginAnimation(UIElement.OpacityProperty, null);
+		Opacity = 1.0;
 	}
 
 	private void SidebarToggleButton_Click(object sender, RoutedEventArgs e)
@@ -758,7 +775,7 @@ public partial class SettingsWindow : Window
 		UpdateSidebarThemeVisualState(ConfigManager.CurrentConfig.AppTheme ?? "System");
 		bool isDark = IsCurrentThemeDark();
 		UpdateLogoTheme(isDark);
-		ApplyTrayMenuTheme(isDark);
+		App.ApplyTrayTheme(isDark);
 		ReloadThemePresets();
 		SetComboBoxSelectedValue(ThemeComboBox, ConfigManager.CurrentConfig.Theme);
 		SetComboBoxSelectedValue(UiStyleComboBox, ConfigManager.CurrentConfig.UiStyle);
@@ -1184,273 +1201,6 @@ public partial class SettingsWindow : Window
 	[DllImport("user32.dll")]
 	[return: MarshalAs(UnmanagedType.Bool)]
 	private static extern bool SetForegroundWindow(nint hWnd);
-
-	[DllImport("user32.dll", SetLastError = true)]
-	[return: MarshalAs(UnmanagedType.Bool)]
-	private static extern bool ChangeWindowMessageFilter(uint message, uint dwFlag);
-
-	[DllImport("user32.dll", SetLastError = true)]
-	[return: MarshalAs(UnmanagedType.Bool)]
-	private static extern bool ChangeWindowMessageFilterEx(nint hWnd, uint message, uint action, nint changeInfo);
-
-	private const uint MSGFLT_ADD = 1;
-	private const uint MSGFLT_ALLOW = 1;
-
-	private void InitializeTrayIcon()
-	{
-		Icon icon = null;
-		System.Drawing.Size smallSize = System.Windows.Forms.SystemInformation.SmallIconSize;
-		if (smallSize.Width <= 0 || smallSize.Height <= 0) smallSize = new System.Drawing.Size(16, 16);
-
-		// 1. First priority: Load dedicated ultra-sharp circular wheel tray icon from pack resources
-		try
-		{
-			StreamResourceInfo resourceStream = System.Windows.Application.GetResourceStream(new Uri("pack://application:,,,/tray_icon.ico"));
-			if (resourceStream != null)
-			{
-				using Stream stream = resourceStream.Stream;
-				icon = new Icon(stream, smallSize);
-			}
-		}
-		catch
-		{
-		}
-
-		// 2. Secondary priority: Load tray_icon.ico from file on disk
-		if (icon == null)
-		{
-			try
-			{
-				string trayPath = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tray_icon.ico");
-				if (File.Exists(trayPath))
-				{
-					using var fs = File.OpenRead(trayPath);
-					icon = new Icon(fs, smallSize);
-				}
-			}
-			catch
-			{
-			}
-		}
-
-		// 3. Third priority: Load app_icon.ico with exact smallSize matching native DPI
-		if (icon == null)
-		{
-			try
-			{
-				StreamResourceInfo resourceStream = System.Windows.Application.GetResourceStream(new Uri("pack://application:,,,/app_icon.ico"));
-				if (resourceStream != null)
-				{
-					using Stream stream = resourceStream.Stream;
-					icon = new Icon(stream, smallSize);
-				}
-			}
-			catch
-			{
-			}
-		}
-
-		// 4. Fourth priority: app_icon.ico on disk
-		if (icon == null)
-		{
-			try
-			{
-				string text2 = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "app_icon.ico");
-				if (File.Exists(text2))
-				{
-					using var fs = File.OpenRead(text2);
-					icon = new Icon(fs, smallSize);
-				}
-			}
-			catch
-			{
-			}
-		}
-
-		// 5. Fallback: Process associated icon
-		if (icon == null)
-		{
-			try
-			{
-				string text = Environment.ProcessPath;
-				if (string.IsNullOrEmpty(text))
-				{
-					text = Process.GetCurrentProcess().MainModule?.FileName;
-				}
-				if (!string.IsNullOrEmpty(text) && File.Exists(text))
-				{
-					icon = System.Drawing.Icon.ExtractAssociatedIcon(text);
-				}
-			}
-			catch
-			{
-			}
-		}
-
-		if (icon == null)
-		{
-			icon = SystemIcons.Application;
-		}
-		_notifyIcon = new NotifyIcon
-		{
-			Icon = icon,
-			Visible = true,
-			Text = I18n.T("TrayTooltip")
-		};
-		_notifyIcon.DoubleClick += delegate
-		{
-			ShowSettings();
-		};
-		BuildTrayContextMenu();
-		ApplyTrayUipiProtection();
-	}
-
-	private void ApplyTrayUipiProtection()
-	{
-		try
-		{
-			// 1. 进程级放行来自标准权限 Explorer.exe 的拖放、复制、广播与通知消息通道
-			uint[] globalMessages = new uint[]
-			{
-				0x0233, // WM_DROPFILES
-				0x004A, // WM_COPYDATA
-				0x0049, // WM_COPYGLOBALDATA
-				0x001A, // WM_SETTINGCHANGE
-				0x007E, // WM_DISPLAYCHANGE
-				0x0111, // WM_COMMAND
-				0x0400, // WM_USER
-				0x0401  // WM_USER + 1
-			};
-
-			foreach (uint msg in globalMessages)
-			{
-				try
-				{
-					ChangeWindowMessageFilter(msg, MSGFLT_ADD);
-				}
-				catch { }
-			}
-
-			// 2. 获取 NotifyIcon 内部原生 NativeWindow 句柄并放行句柄级消息过滤
-			if (_notifyIcon != null)
-			{
-				try
-				{
-					var windowField = typeof(NotifyIcon).GetField("window", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-					if (windowField?.GetValue(_notifyIcon) is NativeWindow nativeWindow && nativeWindow.Handle != IntPtr.Zero)
-					{
-						nint trayHwnd = nativeWindow.Handle;
-						uint[] hwndMessages = new uint[]
-						{
-							0x0233, // WM_DROPFILES
-							0x004A, // WM_COPYDATA
-							0x0049, // WM_COPYGLOBALDATA
-							0x001A, // WM_SETTINGCHANGE
-							0x007E, // WM_DISPLAYCHANGE
-							0x0111, // WM_COMMAND
-							0x0400, // WM_USER
-							0x0401, // WM_USER + 1
-							0x0200, // WM_MOUSEMOVE
-							0x0201, // WM_LBUTTONDOWN
-							0x0202, // WM_LBUTTONUP
-							0x0204, // WM_RBUTTONDOWN
-							0x0205  // WM_RBUTTONUP
-						};
-
-						foreach (uint msg in hwndMessages)
-						{
-							try
-							{
-								ChangeWindowMessageFilterEx(trayHwnd, msg, MSGFLT_ALLOW, IntPtr.Zero);
-							}
-							catch { }
-						}
-					}
-				}
-				catch { }
-			}
-		}
-		catch { }
-	}
-
-	private void BuildTrayContextMenu()
-	{
-		if (_notifyIcon != null)
-		{
-			ContextMenuStrip contextMenuStrip = new ContextMenuStrip
-			{
-				ShowImageMargin = false,
-				ShowCheckMargin = false,
-				Font = new System.Drawing.Font("Segoe UI", 9.5f, System.Drawing.FontStyle.Regular),
-				Padding = new System.Windows.Forms.Padding(3, 4, 3, 4)
-			};
-
-			ToolStripMenuItem versionItem = new ToolStripMenuItem("StarPie v" + (Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "1.7.0"))
-			{
-				Enabled = false,
-				Font = new System.Drawing.Font("Segoe UI", 9.5f, System.Drawing.FontStyle.Bold),
-				Padding = new System.Windows.Forms.Padding(12, 6, 12, 6)
-			};
-			contextMenuStrip.Items.Add(versionItem);
-
-			var sep1 = new ToolStripSeparator { Margin = new System.Windows.Forms.Padding(0, 3, 0, 3) };
-			contextMenuStrip.Items.Add(sep1);
-
-			string text = ((App.MainMouseHook != null && App.MainMouseHook.IsPaused) ? I18n.T("TrayResume") : I18n.T("TrayPause"));
-			_pauseResumeMenuItem = new ToolStripMenuItem(text, null, delegate
-			{
-				TogglePauseGestures();
-			})
-			{
-				Padding = new System.Windows.Forms.Padding(12, 5, 12, 5)
-			};
-			contextMenuStrip.Items.Add(_pauseResumeMenuItem);
-
-			contextMenuStrip.Items.Add(CreateTrayMenuItem(I18n.T("TrayPreferences"), () => ShowSettings()));
-			contextMenuStrip.Items.Add(CreateTrayMenuItem(I18n.T("TrayAppearance"), () => ShowSettings(1)));
-			contextMenuStrip.Items.Add(CreateTrayMenuItem(I18n.T("TrayGestures"), () => ShowSettings(2)));
-			contextMenuStrip.Items.Add(CreateTrayMenuItem(I18n.T("TrayAbout"), () => ShowSettings(4)));
-			contextMenuStrip.Items.Add(CreateTrayMenuItem(I18n.T("TrayElevate"), () => ElevatePrivileges_Click(null, new RoutedEventArgs())));
-
-			var sep2 = new ToolStripSeparator { Margin = new System.Windows.Forms.Padding(0, 3, 0, 3) };
-			contextMenuStrip.Items.Add(sep2);
-
-			contextMenuStrip.Items.Add(CreateTrayMenuItem(I18n.T("TrayExit"), () => ExitApplication()));
-
-			_notifyIcon.ContextMenuStrip = contextMenuStrip;
-			ApplyTrayMenuTheme(IsCurrentThemeDark());
-		}
-	}
-
-	private ToolStripMenuItem CreateTrayMenuItem(string text, Action onClick)
-	{
-		return new ToolStripMenuItem(text, null, (s, e) => onClick?.Invoke())
-		{
-			Padding = new System.Windows.Forms.Padding(12, 5, 12, 5)
-		};
-	}
-
-	public void ApplyTrayMenuTheme(bool isDark)
-	{
-		if (_notifyIcon?.ContextMenuStrip == null) return;
-
-		var cms = _notifyIcon.ContextMenuStrip;
-		cms.Renderer = new ModernTrayRenderer(isDark);
-		cms.BackColor = isDark ? System.Drawing.Color.FromArgb(24, 24, 27) : System.Drawing.Color.FromArgb(255, 255, 255);
-
-		System.Drawing.Color enabledColor = isDark ? System.Drawing.Color.FromArgb(244, 244, 245) : System.Drawing.Color.FromArgb(15, 23, 42);
-		System.Drawing.Color disabledColor = isDark ? System.Drawing.Color.FromArgb(148, 163, 184) : System.Drawing.Color.FromArgb(100, 116, 139);
-
-		foreach (ToolStripItem item in cms.Items)
-		{
-			if (item is ToolStripMenuItem menuItem)
-			{
-				menuItem.ForeColor = menuItem.Enabled ? enabledColor : disabledColor;
-			}
-		}
-
-		cms.Invalidate();
-	}
 
 	public bool IsCurrentThemeDark()
 	{
@@ -2281,32 +2031,7 @@ public partial class SettingsWindow : Window
 		{
 			AdvancedPageSubheader.Text = I18n.T("AdvancedPageSubheader");
 		}
-		BuildTrayContextMenu();
-	}
-
-	private void TogglePauseGestures()
-	{
-		if (App.MainMouseHook == null)
-		{
-			return;
-		}
-		App.MainMouseHook.IsPaused = !App.MainMouseHook.IsPaused;
-		if (App.MainMouseHook.IsPaused)
-		{
-			if (_pauseResumeMenuItem != null)
-			{
-				_pauseResumeMenuItem.Text = I18n.T("TrayResume");
-			}
-			_notifyIcon.Text = "StarPie (" + I18n.T("TrayPause") + ")";
-		}
-		else
-		{
-			if (_pauseResumeMenuItem != null)
-			{
-				_pauseResumeMenuItem.Text = I18n.T("TrayPause");
-			}
-			_notifyIcon.Text = I18n.T("TrayTooltip");
-		}
+		App.RefreshTrayMenu();
 	}
 
 	public void ShowSettings(int tabIndex = -1)
@@ -2319,11 +2044,9 @@ public partial class SettingsWindow : Window
 			});
 			return;
 		}
+		CancelDeferredClose();
 		EnsureUiInitialized();
-		if (tabIndex >= 0)
-		{
-			SwitchToTab(tabIndex);
-		}
+		SwitchToTab(tabIndex >= 0 ? tabIndex : _lastSelectedTabIndex);
 		BeginAnimation(UIElement.OpacityProperty, null);
 		base.Opacity = 1.0;
 		if (base.Visibility != Visibility.Visible)
@@ -2363,6 +2086,8 @@ public partial class SettingsWindow : Window
 		{
 			return;
 		}
+		index = Math.Clamp(index, 0, 4);
+		_lastSelectedTabIndex = index;
 		TriggerSettingsGrid.Visibility = ((index != 0) ? Visibility.Collapsed : Visibility.Visible);
 		AppearanceSettingsGrid.Visibility = ((index != 1) ? Visibility.Collapsed : Visibility.Visible);
 		MappingsSettingsGrid.Visibility = ((index != 2) ? Visibility.Collapsed : Visibility.Visible);
@@ -2677,9 +2402,19 @@ public partial class SettingsWindow : Window
 		}
 	}
 
-	private void ExitApplication()
+	private void Window_Closing(object sender, CancelEventArgs e)
 	{
-		_isClosingFromTray = true;
+		if (!_isClosingForRelease && !App.IsExiting)
+		{
+			e.Cancel = true;
+			SyncUiToConfigAndSave();
+			Hide();
+			Opacity = 1.0;
+			ScheduleDeferredClose();
+			App.ShowTrayBalloon(2000, "StarPie", "设置窗口已隐藏，应用将在后台继续运行鼠标手势监视。", ToolTipIcon.Info);
+			return;
+		}
+
 		try
 		{
 			if (_isUiInitialized)
@@ -2690,33 +2425,52 @@ public partial class SettingsWindow : Window
 		catch
 		{
 		}
-		_notifyIcon.Visible = false;
-		_notifyIcon.Dispose();
-		System.Windows.Application.Current.Shutdown();
+
+		ReleaseWindowResources();
 	}
 
-	private void Window_Closing(object sender, CancelEventArgs e)
+	private void ScheduleDeferredClose()
 	{
-		if (_isUiInitialized)
+		_deferredCloseTimer?.Stop();
+		_deferredCloseTimer = new DispatcherTimer
 		{
-			SyncUiToConfigAndSave();
-		}
-		if (_isClosingFromTray)
+			Interval = TimeSpan.FromSeconds(30)
+		};
+		_deferredCloseTimer.Tick += DeferredCloseTimer_Tick;
+		_deferredCloseTimer.Start();
+	}
+
+	private void DeferredCloseTimer_Tick(object? sender, EventArgs e)
+	{
+		_deferredCloseTimer?.Stop();
+		_deferredCloseTimer = null;
+		_isClosingForRelease = true;
+		Close();
+	}
+
+	private void ReleaseWindowResources()
+	{
+		_deferredCloseTimer?.Stop();
+		_deferredCloseTimer = null;
+		_isClosingForRelease = true;
+		_lifetimeCts.Cancel();
+		_lifetimeCts.Dispose();
+
+		_autoSaveDebounceTimer?.Stop();
+		_autoSaveDebounceTimer = null;
+
+		_downloadCts?.Cancel();
+		_downloadCts?.Dispose();
+		_downloadCts = null;
+
+		if (_isUiInitialized && App.MainKeyboardHook != null)
 		{
-			DisposeSlotViewModels();
+			App.MainKeyboardHook.OnExclusiveRecordCompleted -= MainKeyboardHook_OnExclusiveRecordCompleted;
+			App.MainKeyboardHook.OnExclusiveRecordCancelled -= MainKeyboardHook_OnExclusiveRecordCancelled;
+			App.MainKeyboardHook.OnExclusiveRecordModifiersChanged -= MainKeyboardHook_OnExclusiveRecordModifiersChanged;
 		}
-		if (!_isClosingFromTray)
-		{
-			e.Cancel = true;
-			DoubleAnimation doubleAnimation = new DoubleAnimation(1.0, 0.0, new Duration(TimeSpan.FromMilliseconds(120.0)));
-			doubleAnimation.Completed += delegate
-			{
-				Hide();
-				base.Opacity = 1.0;
-			};
-			BeginAnimation(UIElement.OpacityProperty, doubleAnimation);
-			_notifyIcon.ShowBalloonTip(2000, "WinPieGestures", "应用已最小化至系统托盘，将在后台继续运行鼠标笔势监视。", ToolTipIcon.Info);
-		}
+		CancelExclusiveRecordingIfActive();
+		DisposeSlotViewModels();
 	}
 
 	private void ProfilesListBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -4807,7 +4561,7 @@ public partial class SettingsWindow : Window
 		AppLogger.LogInfo("Activated exclusive hotkey recording mode (suppressing desktop and app hotkeys)");
 		try
 		{
-			_notifyIcon?.ShowBalloonTip(2000, "StarPie", "⏸️ 已暂时暂停桌面系统及其他软件全局快捷键，在此按下目标按键组合进行录入（按 Esc 取消）", System.Windows.Forms.ToolTipIcon.Info);
+			App.ShowTrayBalloon(2000, "StarPie", "⏸️ 已暂时暂停桌面系统及其他软件全局快捷键，在此按下目标按键组合进行录入（按 Esc 取消）", System.Windows.Forms.ToolTipIcon.Info);
 		}
 		catch { }
 	}
@@ -4823,7 +4577,7 @@ public partial class SettingsWindow : Window
 			CancelExclusiveRecordingIfActive();
 			try
 			{
-				_notifyIcon?.ShowBalloonTip(1000, "StarPie", "▶️ 已恢复全局热键与按键正常监听", System.Windows.Forms.ToolTipIcon.Info);
+				App.ShowTrayBalloon(1000, "StarPie", "▶️ 已恢复全局热键与按键正常监听", System.Windows.Forms.ToolTipIcon.Info);
 			}
 			catch { }
 		}
@@ -4885,7 +4639,7 @@ public partial class SettingsWindow : Window
 			AppLogger.LogInfo($"Exclusive hotkey recorded successfully: {hotkeyStr}");
 			try
 			{
-				_notifyIcon?.ShowBalloonTip(1500, "StarPie", $"✅ 已录制快捷键: {hotkeyStr}（已恢复全局热键）", System.Windows.Forms.ToolTipIcon.Info);
+				App.ShowTrayBalloon(1500, "StarPie", $"✅ 已录制快捷键: {hotkeyStr}（已恢复全局热键）", System.Windows.Forms.ToolTipIcon.Info);
 			}
 			catch { }
 		});
@@ -4898,7 +4652,7 @@ public partial class SettingsWindow : Window
 			CancelExclusiveRecordingIfActive();
 			try
 			{
-				_notifyIcon?.ShowBalloonTip(1000, "StarPie", "已取消快捷键录制，已恢复全局热键", System.Windows.Forms.ToolTipIcon.Info);
+				App.ShowTrayBalloon(1000, "StarPie", "已取消快捷键录制，已恢复全局热键", System.Windows.Forms.ToolTipIcon.Info);
 			}
 			catch { }
 		});
@@ -10479,7 +10233,7 @@ public partial class SettingsWindow : Window
 			UpdateSidebarThemeVisualState(themeTag);
 			bool isDark = IsCurrentThemeDark();
 			UpdateLogoTheme(isDark);
-			ApplyTrayMenuTheme(isDark);
+			App.ApplyTrayTheme(isDark);
 			if (AppearanceSettingsGrid != null && AppearanceSettingsGrid.Visibility == Visibility.Visible)
 			{
 				RenderLiveWheelPreview();
@@ -11241,21 +10995,7 @@ public partial class SettingsWindow : Window
 
 	private void ElevatePrivileges_Click(object sender, RoutedEventArgs e)
 	{
-		try
-		{
-			string fileName = Environment.ProcessPath ?? System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "WinPieGestures.exe");
-			Process.Start(new ProcessStartInfo
-			{
-				FileName = fileName,
-				UseShellExecute = true,
-				Verb = "runas"
-			});
-			ExitApplication();
-		}
-		catch (Exception ex)
-		{
-			System.Windows.MessageBox.Show("提权重启失败或已取消: " + ex.Message, "管理员提权", MessageBoxButton.OK, MessageBoxImage.Exclamation);
-		}
+		App.RestartElevated();
 	}
 
 	private void ExportConfigButton_Click(object sender, RoutedEventArgs e)

--- a/WinPieGestures/TrayController.cs
+++ b/WinPieGestures/TrayController.cs
@@ -1,0 +1,360 @@
+using System;
+using System.Diagnostics;
+using System.Drawing;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+using System.Windows.Resources;
+using GdiColor = System.Drawing.Color;
+using GdiSize = System.Drawing.Size;
+
+namespace WinPieGestures;
+
+/// <summary>
+/// 进程级系统托盘控制器。托盘生命周期独立于 SettingsWindow，
+/// 确保静默启动和设置窗口关闭后仍可操作后台核心。
+/// </summary>
+public sealed class TrayController : IDisposable
+{
+	[DllImport("user32.dll", SetLastError = true)]
+	[return: MarshalAs(UnmanagedType.Bool)]
+	private static extern bool ChangeWindowMessageFilter(uint message, uint dwFlag);
+
+	[DllImport("user32.dll", SetLastError = true)]
+	[return: MarshalAs(UnmanagedType.Bool)]
+	private static extern bool ChangeWindowMessageFilterEx(nint hWnd, uint message, uint action, nint changeInfo);
+
+	private const uint MSGFLT_ADD = 1;
+	private const uint MSGFLT_ALLOW = 1;
+
+	private NotifyIcon? _notifyIcon;
+	private ToolStripMenuItem? _pauseResumeMenuItem;
+	private Icon? _ownedIcon;
+	private bool _isPaused;
+	private bool _isDark;
+	private bool _disposed;
+
+	public event Action<int>? OpenSettingsRequested;
+	public event Action? TogglePauseRequested;
+	public event Action? ElevateRequested;
+	public event Action? ExitRequested;
+
+	public void Initialize(bool isPaused, bool isDark)
+	{
+		ObjectDisposedException.ThrowIf(_disposed, this);
+		if (_notifyIcon != null)
+		{
+			UpdatePauseState(isPaused);
+			ApplyTheme(isDark);
+			return;
+		}
+
+		_isPaused = isPaused;
+		_isDark = isDark;
+		_ownedIcon = LoadTrayIcon();
+		_notifyIcon = new NotifyIcon
+		{
+			Icon = _ownedIcon,
+			Visible = true,
+			Text = I18n.T("TrayTooltip")
+		};
+		_notifyIcon.DoubleClick += NotifyIcon_DoubleClick;
+		RefreshMenu();
+		ApplyUipiProtection();
+	}
+
+	public void RefreshMenu()
+	{
+		if (_disposed || _notifyIcon == null)
+		{
+			return;
+		}
+
+		ContextMenuStrip menu = new ContextMenuStrip
+		{
+			ShowImageMargin = false,
+			ShowCheckMargin = false,
+			Font = new Font("Segoe UI", 9.5f, FontStyle.Regular),
+			Padding = new Padding(3, 4, 3, 4)
+		};
+
+		ToolStripMenuItem versionItem = new ToolStripMenuItem(
+			"StarPie v" + (Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "1.7.0"))
+		{
+			Enabled = false,
+			Font = new Font("Segoe UI", 9.5f, FontStyle.Bold),
+			Padding = new Padding(12, 6, 12, 6)
+		};
+		menu.Items.Add(versionItem);
+		menu.Items.Add(new ToolStripSeparator { Margin = new Padding(0, 3, 0, 3) });
+
+		_pauseResumeMenuItem = new ToolStripMenuItem(
+			_isPaused ? I18n.T("TrayResume") : I18n.T("TrayPause"),
+			null,
+			(_, _) => TogglePauseRequested?.Invoke())
+		{
+			Padding = new Padding(12, 5, 12, 5)
+		};
+		menu.Items.Add(_pauseResumeMenuItem);
+
+		menu.Items.Add(CreateMenuItem(I18n.T("TrayPreferences"), () => OpenSettingsRequested?.Invoke(-1)));
+		menu.Items.Add(CreateMenuItem(I18n.T("TrayAppearance"), () => OpenSettingsRequested?.Invoke(1)));
+		menu.Items.Add(CreateMenuItem(I18n.T("TrayGestures"), () => OpenSettingsRequested?.Invoke(2)));
+		menu.Items.Add(CreateMenuItem(I18n.T("TrayAbout"), () => OpenSettingsRequested?.Invoke(4)));
+		menu.Items.Add(CreateMenuItem(I18n.T("TrayElevate"), () => ElevateRequested?.Invoke()));
+		menu.Items.Add(new ToolStripSeparator { Margin = new Padding(0, 3, 0, 3) });
+		menu.Items.Add(CreateMenuItem(I18n.T("TrayExit"), () => ExitRequested?.Invoke()));
+
+		ContextMenuStrip? previousMenu = _notifyIcon.ContextMenuStrip;
+		_notifyIcon.ContextMenuStrip = menu;
+		previousMenu?.Dispose();
+		ApplyTheme(_isDark);
+		UpdatePauseState(_isPaused);
+	}
+
+	public void ApplyTheme(bool isDark)
+	{
+		_isDark = isDark;
+		if (_disposed || _notifyIcon?.ContextMenuStrip == null)
+		{
+			return;
+		}
+
+		ContextMenuStrip menu = _notifyIcon.ContextMenuStrip;
+		menu.Renderer = new ModernTrayRenderer(isDark);
+		menu.BackColor = isDark
+			? GdiColor.FromArgb(24, 24, 27)
+			: GdiColor.FromArgb(255, 255, 255);
+
+		GdiColor enabledColor = isDark
+			? GdiColor.FromArgb(244, 244, 245)
+			: GdiColor.FromArgb(15, 23, 42);
+		GdiColor disabledColor = isDark
+			? GdiColor.FromArgb(148, 163, 184)
+			: GdiColor.FromArgb(100, 116, 139);
+
+		foreach (ToolStripItem item in menu.Items)
+		{
+			if (item is ToolStripMenuItem menuItem)
+			{
+				menuItem.ForeColor = menuItem.Enabled ? enabledColor : disabledColor;
+			}
+		}
+		menu.Invalidate();
+	}
+
+	public void UpdatePauseState(bool isPaused)
+	{
+		_isPaused = isPaused;
+		if (_disposed || _notifyIcon == null)
+		{
+			return;
+		}
+
+		if (_pauseResumeMenuItem != null)
+		{
+			_pauseResumeMenuItem.Text = isPaused ? I18n.T("TrayResume") : I18n.T("TrayPause");
+		}
+		_notifyIcon.Text = isPaused
+			? "StarPie (" + I18n.T("TrayPause") + ")"
+			: I18n.T("TrayTooltip");
+	}
+
+	public void ShowBalloonTip(int timeout, string title, string message, ToolTipIcon icon)
+	{
+		if (_disposed || _notifyIcon == null)
+		{
+			return;
+		}
+		try
+		{
+			_notifyIcon.ShowBalloonTip(timeout, title, message, icon);
+		}
+		catch
+		{
+		}
+	}
+
+	private void ApplyUipiProtection()
+	{
+		try
+		{
+			uint[] globalMessages =
+			{
+				0x0233, // WM_DROPFILES
+				0x004A, // WM_COPYDATA
+				0x0049, // WM_COPYGLOBALDATA
+				0x001A, // WM_SETTINGCHANGE
+				0x007E, // WM_DISPLAYCHANGE
+				0x0111, // WM_COMMAND
+				0x0400, // WM_USER
+				0x0401  // WM_USER + 1
+			};
+
+			foreach (uint message in globalMessages)
+			{
+				try
+				{
+					ChangeWindowMessageFilter(message, MSGFLT_ADD);
+				}
+				catch
+				{
+				}
+			}
+
+			if (_notifyIcon == null)
+			{
+				return;
+			}
+
+			try
+			{
+				FieldInfo? windowField = typeof(NotifyIcon).GetField(
+					"window",
+					BindingFlags.NonPublic | BindingFlags.Instance);
+				if (windowField?.GetValue(_notifyIcon) is not NativeWindow nativeWindow || nativeWindow.Handle == IntPtr.Zero)
+				{
+					return;
+				}
+
+				uint[] windowMessages =
+				{
+					0x0233, // WM_DROPFILES
+					0x004A, // WM_COPYDATA
+					0x0049, // WM_COPYGLOBALDATA
+					0x001A, // WM_SETTINGCHANGE
+					0x007E, // WM_DISPLAYCHANGE
+					0x0111, // WM_COMMAND
+					0x0400, // WM_USER
+					0x0401, // WM_USER + 1
+					0x0200, // WM_MOUSEMOVE
+					0x0201, // WM_LBUTTONDOWN
+					0x0202, // WM_LBUTTONUP
+					0x0204, // WM_RBUTTONDOWN
+					0x0205  // WM_RBUTTONUP
+				};
+
+				foreach (uint message in windowMessages)
+				{
+					try
+					{
+						ChangeWindowMessageFilterEx(nativeWindow.Handle, message, MSGFLT_ALLOW, IntPtr.Zero);
+					}
+					catch
+					{
+					}
+				}
+			}
+			catch
+			{
+			}
+		}
+		catch
+		{
+		}
+	}
+
+	private void NotifyIcon_DoubleClick(object? sender, EventArgs e)
+	{
+		OpenSettingsRequested?.Invoke(-1);
+	}
+
+	private static ToolStripMenuItem CreateMenuItem(string text, Action onClick)
+	{
+		return new ToolStripMenuItem(text, null, (_, _) => onClick())
+		{
+			Padding = new Padding(12, 5, 12, 5)
+		};
+	}
+
+	private static Icon LoadTrayIcon()
+	{
+		GdiSize smallSize = SystemInformation.SmallIconSize;
+		if (smallSize.Width <= 0 || smallSize.Height <= 0)
+		{
+			smallSize = new GdiSize(16, 16);
+		}
+
+		Icon? icon = TryLoadPackIcon("tray_icon.ico", smallSize)
+			?? TryLoadFileIcon("tray_icon.ico", smallSize)
+			?? TryLoadPackIcon("app_icon.ico", smallSize)
+			?? TryLoadFileIcon("app_icon.ico", smallSize);
+
+		if (icon != null)
+		{
+			return icon;
+		}
+
+		try
+		{
+			string? processPath = Environment.ProcessPath ?? Process.GetCurrentProcess().MainModule?.FileName;
+			if (!string.IsNullOrEmpty(processPath) && File.Exists(processPath))
+			{
+				return Icon.ExtractAssociatedIcon(processPath) ?? (Icon)SystemIcons.Application.Clone();
+			}
+		}
+		catch
+		{
+		}
+		return (Icon)SystemIcons.Application.Clone();
+	}
+
+	private static Icon? TryLoadPackIcon(string fileName, GdiSize size)
+	{
+		try
+		{
+			StreamResourceInfo? resource = System.Windows.Application.GetResourceStream(
+				new Uri($"pack://application:,,,/{fileName}"));
+			if (resource == null)
+			{
+				return null;
+			}
+			using Stream stream = resource.Stream;
+			return new Icon(stream, size);
+		}
+		catch
+		{
+			return null;
+		}
+	}
+
+	private static Icon? TryLoadFileIcon(string fileName, GdiSize size)
+	{
+		try
+		{
+			string path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, fileName);
+			if (!File.Exists(path))
+			{
+				return null;
+			}
+			using FileStream stream = File.OpenRead(path);
+			return new Icon(stream, size);
+		}
+		catch
+		{
+			return null;
+		}
+	}
+
+	public void Dispose()
+	{
+		if (_disposed)
+		{
+			return;
+		}
+		_disposed = true;
+
+		if (_notifyIcon != null)
+		{
+			_notifyIcon.DoubleClick -= NotifyIcon_DoubleClick;
+			_notifyIcon.Visible = false;
+			_notifyIcon.ContextMenuStrip?.Dispose();
+			_notifyIcon.Dispose();
+			_notifyIcon = null;
+		}
+		_pauseResumeMenuItem = null;
+		_ownedIcon?.Dispose();
+		_ownedIcon = null;
+	}
+}


### PR DESCRIPTION
## 变更概述

优化 StarPie 设置窗口与系统托盘的生命周期，避免静默启动和后台运行时长期保留完整的 `SettingsWindow` 控件树。

本次将托盘功能从 `SettingsWindow` 中拆分为独立的 `TrayController`，使设置窗口可以按需创建和延迟释放；同时修复设置窗口重建后产生的自启动任务误操作，以及轮盘“打开 StarPie 控制台”动作失效的问题。

本 PR 不修改轮盘绘制、手势命中、快捷键注入和动作执行的核心逻辑。

---

## 主要变更

### 1. 按需创建和延迟释放 SettingsWindow

原来的运行逻辑：

    程序启动
    → 无条件创建 SettingsWindow
    → 静默启动时仅隐藏窗口
    → 关闭设置时继续 Hide
    → 完整设置窗口始终常驻

修改后的运行逻辑：

    程序启动
    → 初始化配置、Hook、手势控制器和托盘
    → 静默启动时不创建 SettingsWindow
    → 用户打开控制台时按需创建
    → 关闭设置后先隐藏并保留 30 秒
    → 30 秒内重新打开则直接复用
    → 空闲超过 30 秒后真正关闭并释放

具体调整：

- 静默启动和开机自启时不再构造 `SettingsWindow`；
- 普通启动、托盘菜单和第二实例唤醒统一通过 `App.ShowSettingsWindow()` 打开设置；
- 设置窗口关闭后先隐藏，保留 30 秒用于快速重新打开；
- 30 秒内再次打开会取消释放计时器并复用当前窗口；
- 超过 30 秒未打开则真正关闭窗口，并清除 `App.MainSettingsWindow` 与 `Application.MainWindow` 引用；
- 重新创建窗口后恢复上次使用的设置标签页；
- 使用 `ShutdownMode="OnExplicitShutdown"`，确保设置窗口释放后后台核心继续运行。

### 2. 将托盘生命周期拆分到 TrayController

新增独立模块：

    WinPieGestures/TrayController.cs

`TrayController` 负责：

- 系统托盘图标；
- 托盘右键菜单；
- 打开设置及指定标签页；
- 暂停和恢复鼠标手势；
- 托盘菜单主题与语言刷新；
- 托盘气泡通知；
- 管理员提权重启；
- 应用退出；
- 托盘图标和菜单资源释放。

因此，托盘不再依赖 `SettingsWindow` 对象长期存在。

同时保留并迁移 v1.7.0 的托盘 UIPI 消息过滤逻辑，避免管理员权限运行时与普通权限 Explorer 之间的托盘交互、拖放或消息通信出现卡死。

### 3. 设置窗口最终释放时清理资源

窗口空闲超过 30 秒并真正释放时，会执行：

- 停止延迟释放计时器；
- 停止自动保存防抖计时器；
- 取消延迟自动更新检查；
- 取消并释放更新下载任务；
- 解除 `KeyboardHook` 独占录制事件订阅；
- 取消正在进行的快捷键录制；
- 释放 `SlotViewModel`；
- 清除应用对设置窗口的强引用；
- 执行 `MemoryOptimizer.TrimMemory(force: false)` 的轻量内存整理。

这里不再执行强制 Full GC 和工作集剥离，避免设置窗口关闭后影响轮盘下一次唤起的流畅度。

---

## Bug 修复

### 1. 修复设置初始化误触发计划任务变更

之前创建 `SettingsWindow` 时，程序会通过代码设置：

    AutoStartCheckBox.IsChecked
    AutoStartAsAdminCheckBox.IsChecked

这两个控件同时绑定了 `Checked/Unchecked` 事件。WPF 在初始化赋值时可能触发这些事件，并将初始化赋值误认为用户主动修改，进而执行：

    schtasks.exe /delete /tn "StarPie_AdminAutoStart" /f

导致每次打开设置窗口都可能弹出管理员权限确认。

本次增加：

    _isLoadingAutoStartState
    _loadedAutoStartEnabled
    _loadedAutoStartAsAdmin

修复后：

- 设置窗口初始化只读取并显示自启动状态；
- 初始化赋值不会调用 `SetAutoStart()`；
- 新旧状态相同时不会重复修改注册表或计划任务；
- 只有用户实际改变开关状态时才执行自启动配置操作；
- 打开设置窗口时不再误执行 `schtasks` 删除计划任务。

### 2. 修复设置窗口释放后轮盘控制台动作失效

之前“打开 StarPie 控制台”动作使用：

    App.MainSettingsWindow?.ShowSettings();

当窗口空闲 30 秒后已经释放时，`MainSettingsWindow` 为 `null`，空条件调用会静默跳过。

现改为：

    App.ShowSettingsWindow();

修复后：

- 窗口存在时直接复用并显示；
- 窗口不存在时由 `App` 按需重新创建；
- `OpenSettings`、`OpenStarPie`、`StarPie`、`StarPie控制台` 和 `控制台` 等动作别名均可正常工作。

---

## 涉及文件

- `WinPieGestures/ActionExecutor.cs`
- `WinPieGestures/App.xaml`
- `WinPieGestures/App.xaml.cs`
- `WinPieGestures/SettingsWindow.xaml.cs`
- `WinPieGestures/TrayController.cs`

---

## 影响范围

本 PR 主要影响：

- 应用启动与退出生命周期；
- 系统托盘生命周期；
- 设置窗口创建、隐藏、复用和释放；
- 自启动配置控件初始化；
- “打开 StarPie 控制台”系统动作。

本 PR 不修改：

- `MouseHook` 和 `KeyboardHook` 底层实现；
- `GestureController` 手势状态机；
- `RadialWindow` 轮盘渲染；
- 极坐标扇区命中算法；
- `SendInput` 快捷键注入；
- 动作配置 JSON 格式；
- OCR、窗口平铺和多级轮盘核心逻辑。

---

## 包含提交

- `c721004 perf: 延迟创建并释放设置窗口`
- `a8d1b42 fix: 防止设置初始化误触发自启动任务变更`
- `8316d1c fix: 修复 SettingsWindow 释放后无法通过轮盘动作重新打开`