### PR TITLE
fix(1.7.0): 修复 SettingsWindow 原始输入订阅泄漏并完善释放流程

### DIFF
--- a/WinPieGestures/SettingsWindow.xaml.cs
+++ b/WinPieGestures/SettingsWindow.xaml.cs
@@ -327,6 +327,12 @@ public partial class SettingsWindow : Window
 
 	private bool _isClosingForRelease;
 
+	private bool _rawMouseInputHookAttached;
+
+	private bool _rawKeyboardInputHookAttached;
+
+	private volatile bool _resourcesReleased;
+
 	public static bool IsSilentLaunch()
 	{
 		return Environment.GetCommandLineArgs().Any((string a) =>
@@ -2463,9 +2469,22 @@ public partial class SettingsWindow : Window
 
 	private void ReleaseWindowResources()
 	{
-		_deferredCloseTimer?.Stop();
-		_deferredCloseTimer = null;
+		if (_resourcesReleased)
+		{
+			return;
+		}
+		_resourcesReleased = true;
+
+		if (_deferredCloseTimer != null)
+		{
+			_deferredCloseTimer.Stop();
+			_deferredCloseTimer.Tick -= DeferredCloseTimer_Tick;
+			_deferredCloseTimer = null;
+		}
 		_isClosingForRelease = true;
+
+		UnhookRawInputForSensorAndRecorder();
+
 		_lifetimeCts.Cancel();
 		_lifetimeCts.Dispose();
 
@@ -6437,30 +6456,70 @@ public partial class SettingsWindow : Window
 
 	private void HookRawInputForSensorAndRecorder()
 	{
-		if (App.MainMouseHook != null)
-		{
-			App.MainMouseHook.OnRawMouseButtonEvent += delegate(object? s, RawMouseEventArgs e)
-			{
-				if (e.IsButtonDown)
-				{
-					((DispatcherObject)this).Dispatcher.BeginInvoke((Delegate)(Action)delegate
-					{
-						ProcessRawMouseButton(e.MouseButton, e.MouseData);
-					}, Array.Empty<object>());
-				}
-			};
-		}
-		if (App.MainKeyboardHook == null)
+		if (_resourcesReleased)
 		{
 			return;
 		}
-		App.MainKeyboardHook.OnRawKeyEvent += delegate(object? s, GlobalKeyEventArgs e)
+		if (!_rawMouseInputHookAttached && App.MainMouseHook != null)
 		{
-			((DispatcherObject)this).Dispatcher.BeginInvoke((Delegate)(Action)delegate
+			App.MainMouseHook.OnRawMouseButtonEvent += MainMouseHook_OnRawMouseButtonEvent;
+			_rawMouseInputHookAttached = true;
+		}
+		if (!_rawKeyboardInputHookAttached && App.MainKeyboardHook != null)
+		{
+			App.MainKeyboardHook.OnRawKeyEvent += MainKeyboardHook_OnRawKeyEvent;
+			_rawKeyboardInputHookAttached = true;
+		}
+	}
+
+	private void MainMouseHook_OnRawMouseButtonEvent(object? sender, RawMouseEventArgs e)
+	{
+		if (_resourcesReleased || !e.IsButtonDown)
+		{
+			return;
+		}
+		((DispatcherObject)this).Dispatcher.BeginInvoke((Delegate)(Action)delegate
+		{
+			if (!_resourcesReleased)
+			{
+				ProcessRawMouseButton(e.MouseButton, e.MouseData);
+			}
+		}, Array.Empty<object>());
+	}
+
+	private void MainKeyboardHook_OnRawKeyEvent(object? sender, GlobalKeyEventArgs e)
+	{
+		if (_resourcesReleased)
+		{
+			return;
+		}
+		((DispatcherObject)this).Dispatcher.BeginInvoke((Delegate)(Action)delegate
+		{
+			if (!_resourcesReleased)
 			{
 				ProcessRawKeyEvent(e);
-			}, Array.Empty<object>());
-		};
+			}
+		}, Array.Empty<object>());
+	}
+
+	private void UnhookRawInputForSensorAndRecorder()
+	{
+		if (_rawMouseInputHookAttached)
+		{
+			if (App.MainMouseHook != null)
+			{
+				App.MainMouseHook.OnRawMouseButtonEvent -= MainMouseHook_OnRawMouseButtonEvent;
+			}
+			_rawMouseInputHookAttached = false;
+		}
+		if (_rawKeyboardInputHookAttached)
+		{
+			if (App.MainKeyboardHook != null)
+			{
+				App.MainKeyboardHook.OnRawKeyEvent -= MainKeyboardHook_OnRawKeyEvent;
+			}
+			_rawKeyboardInputHookAttached = false;
+		}
 	}
 
 	private void UpdateTriggerBadgeDisplay()


### PR DESCRIPTION
## 修改概述

完善 `SettingsWindow` 的生命周期清理逻辑，修复原始鼠标和键盘事件持续持有已关闭设置窗口的问题，同时避免配置重新加载时重复注册输入事件。

## 问题原因

`LoadConfigToUi()` 会调用 `HookRawInputForSensorAndRecorder()`，用于支持：

- 设置页面中的鼠标、键盘实时输入状态显示
- 轮盘唤醒触发键及组合键录制

修改前，原始输入事件通过匿名委托订阅：

- `MouseHook.OnRawMouseButtonEvent`
- `KeyboardHook.OnRawKeyEvent`

由于 `MouseHook` 和 `KeyboardHook` 是由 `App` 持有的进程级对象，而匿名委托捕获了当前 `SettingsWindow`，因此形成了以下引用链：

`App → MouseHook / KeyboardHook → 原始输入事件委托 → SettingsWindow`

即使窗口关闭后执行 `App.MainSettingsWindow = null` 和 `Application.Current.MainWindow = null`，旧窗口仍可能被 Hook 事件委托持有，无法进入 GC 可回收状态。

此外，`HookRawInputForSensorAndRecorder()` 位于 `LoadConfigToUi()` 中，导入配置时也会再次调用 `LoadConfigToUi()`，可能导致同一个窗口重复订阅原始输入事件。

## 修改内容

### 1. 将匿名委托改为命名事件处理器

新增可解除的命名处理器：

- `MainMouseHook_OnRawMouseButtonEvent`
- `MainKeyboardHook_OnRawKeyEvent`

避免匿名委托无法准确解除的问题。

### 2. 窗口释放时解除原始输入事件

新增 `UnhookRawInputForSensorAndRecorder()`，在 `ReleaseWindowResources()` 中解除：

- `MouseHook.OnRawMouseButtonEvent`
- `KeyboardHook.OnRawKeyEvent`

使进程级 Hook 不再持有已经关闭的旧设置窗口。

### 3. 防止重复订阅

新增独立订阅状态：

- `_rawMouseInputHookAttached`
- `_rawKeyboardInputHookAttached`

重复调用 `LoadConfigToUi()` 或导入配置时，如果对应事件已经订阅，则不会再次添加处理器。

### 4. 增加资源释放幂等保护

新增 `_resourcesReleased` 状态，确保 `ReleaseWindowResources()` 重复调用时直接返回，避免重复：

- 取消和释放 `CancellationTokenSource`
- 停止计时器
- 解除事件订阅
- 释放 `SlotViewModel`

### 5. 防止已排队回调继续访问旧窗口

原始输入事件在投递 Dispatcher 前，以及 Dispatcher 实际执行时，都会检查 `_resourcesReleased`。

窗口开始释放后，不再执行：

- `ProcessRawMouseButton()`
- `ProcessRawKeyEvent()`

避免已关闭窗口继续访问控件和界面状态。

### 6. 完善延迟关闭计时器清理

释放 `_deferredCloseTimer` 时，同时解除其 `Tick` 事件，进一步完善计时器与窗口之间的生命周期管理。

## 修改后的生命周期

`SettingsWindow` 创建后注册一次原始输入事件；重复加载配置不会重复注册。

用户关闭设置窗口后，窗口先隐藏并保留 30 秒。30 秒内重新打开时复用原窗口；超过 30 秒后真正关闭窗口，依次解除原始输入事件、取消窗口任务、停止计时器、释放 ViewModel，并清空 `App.MainSettingsWindow` 与 `Application.Current.MainWindow` 引用。

## 影响范围

本次修改仅涉及 `SettingsWindow` 的原始输入监听和资源释放逻辑，不修改：

- `MouseHook` 和 `KeyboardHook` 的底层捕获逻辑
- `GestureController` 的轮盘唤起逻辑
- 轮盘触发键的录制格式
- 配置文件结构
- 30 秒窗口复用策略
- 托盘与后台核心生命周期

设置窗口打开期间，实时输入传感器和触发键录制功能保持不变。