### PR TITLE
ci: 添加标签触发的 GitHub Release 自动发布工作流

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,129 @@
+name: Build and Publish Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and Publish StarPie Release
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag points to latest main commit
+        shell: pwsh
+        run: |
+          git fetch origin main
+
+          $tagCommit = (git rev-list -n 1 $env:GITHUB_REF_NAME).Trim()
+          $mainCommit = (git rev-parse origin/main).Trim()
+
+          if ($tagCommit -ne $mainCommit) {
+            throw "Release tag must point to the latest origin/main commit. Tag=$tagCommit Main=$mainCommit"
+          }
+
+          Write-Host "Verified release commit: $tagCommit"
+
+      - name: Verify compiled version fields
+        shell: pwsh
+        run: |
+          $tag = $env:GITHUB_REF_NAME
+          if ($tag -notmatch '^v(?<version>\d+\.\d+\.\d+)$') {
+            throw "Release tag must use the vX.Y.Z format: $tag"
+          }
+
+          $tagVersion = $Matches.version
+          $expectedFourPartVersion = "${tagVersion}.0"
+          [xml]$project = Get-Content "WinPieGestures/WinPieGestures.csproj"
+
+          $projectVersion = [string]$project.Project.PropertyGroup.Version
+          $assemblyVersion = [string]$project.Project.PropertyGroup.AssemblyVersion
+          $fileVersion = [string]$project.Project.PropertyGroup.FileVersion
+
+          if ($projectVersion -ne $tagVersion) {
+            throw "Version mismatch: tag=$tagVersion Version=$projectVersion"
+          }
+          if ($assemblyVersion -ne $expectedFourPartVersion) {
+            throw "AssemblyVersion mismatch: expected=$expectedFourPartVersion actual=$assemblyVersion"
+          }
+          if ($fileVersion -ne $expectedFourPartVersion) {
+            throw "FileVersion mismatch: expected=$expectedFourPartVersion actual=$fileVersion"
+          }
+
+          Write-Host "Verified Version=$projectVersion AssemblyVersion=$assemblyVersion FileVersion=$fileVersion"
+
+      - name: Setup .NET SDK 8.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore WinPieGestures/WinPieGestures.csproj -r win-x64
+
+      - name: Build Release
+        run: dotnet build WinPieGestures/WinPieGestures.csproj -c Release --no-restore
+
+      - name: Publish Lightweight package
+        run: >
+          dotnet publish WinPieGestures/WinPieGestures.csproj
+          -c Release
+          -r win-x64
+          --no-self-contained
+          --no-restore
+          -o publish/Lightweight
+
+      - name: Publish Standalone package
+        run: >
+          dotnet publish WinPieGestures/WinPieGestures.csproj
+          -c Release
+          -r win-x64
+          --self-contained true
+          --no-restore
+          -p:PublishSingleFile=true
+          -p:IncludeNativeLibrariesForSelfExtract=true
+          -o publish/Standalone
+
+      - name: Package release assets
+        shell: pwsh
+        run: |
+          $tag = $env:GITHUB_REF_NAME
+          New-Item -ItemType Directory -Force -Path "dist" | Out-Null
+
+          $lightweightArchive = "dist/StarPie-$tag-Lightweight-win-x64.zip"
+          $standaloneArchive = "dist/StarPie-$tag-Standalone-win-x64.zip"
+
+          Compress-Archive -Path "publish/Lightweight/*" -DestinationPath $lightweightArchive -Force
+          Compress-Archive -Path "publish/Standalone/*" -DestinationPath $standaloneArchive -Force
+
+          $checksums = Get-ChildItem "dist/*.zip" | Sort-Object Name | ForEach-Object {
+            $hash = Get-FileHash $_.FullName -Algorithm SHA256
+            "$($hash.Hash.ToLowerInvariant())  $($_.Name)"
+          }
+          $checksums | Set-Content "dist/SHA256SUMS.txt" -Encoding utf8
+
+          if (-not (Test-Path "publish/Lightweight/StarPie.exe")) {
+            throw "Lightweight package does not contain StarPie.exe"
+          }
+          if (-not (Test-Path "publish/Standalone/StarPie.exe")) {
+            throw "Standalone package does not contain StarPie.exe"
+          }
+
+      - name: Create GitHub Release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $assets = Get-ChildItem "dist/*.zip", "dist/SHA256SUMS.txt" |
+            Sort-Object Name |
+            Select-Object -ExpandProperty FullName
+
+          gh release create $env:GITHUB_REF_NAME @assets --verify-tag --generate-notes --title "StarPie $env:GITHUB_REF_NAME"


### PR DESCRIPTION
## 修改概述

新增 GitHub Actions Release workflow，实现推送正式版本标签后自动编译、打包并创建 GitHub Release。

## 触发条件

当向远端推送符合以下格式的标签时触发：

`vX.Y.Z`

示例：

`v1.7.1`

该 workflow 不响应普通分支推送，也不响应 PR 创建或更新。

## 发布前校验

### 1. 标签必须指向 main 最新提交

workflow 会获取 `origin/main`，并比较：

- 标签实际指向的提交
- 当前 `origin/main` 最新提交

只有两者完全一致时才允许发布。

因此推荐的发布顺序是：

1. 创建功能分支并开发
2. 创建 PR
3. 通过检查并合并 PR
4. 更新本地 `main`
5. 在最新 `main` 提交上创建版本标签
6. 推送标签触发 Release workflow

如果标签来自功能分支、旧的 main 提交或尚未合并的 PR，workflow 会停止发布。

### 2. 校验最终编译版本

仅检查会影响最终程序程序集版本的三个项目字段：

- `Version`
- `AssemblyVersion`
- `FileVersion`

例如标签为 `v1.7.1` 时，要求：

- `Version` 为 `1.7.1`
- `AssemblyVersion` 为 `1.7.1.0`
- `FileVersion` 为 `1.7.1.0`

不检查 README、CHANGELOG、设置窗口显示文字或其他展示性版本信息。

## 自动构建流程

workflow 按以下顺序执行：

1. 检出完整 Git 历史
2. 验证标签指向最新 `origin/main`
3. 验证标签格式和程序集版本字段
4. 安装 .NET 8 SDK
5. 还原 `win-x64` 依赖
6. 执行 Release 编译
7. 发布 Lightweight 版本
8. 发布 Standalone 自包含单文件版本
9. 检查两个发布目录中都存在 `StarPie.exe`
10. 压缩发布文件
11. 生成 SHA256 校验文件
12. 创建 GitHub Release
13. 自动生成 Release Notes
14. 上传发布资产

## 发布资产

以标签 `v1.7.1` 为例，Release 将包含：

- `StarPie-v1.7.1-Lightweight-win-x64.zip`
- `StarPie-v1.7.1-Standalone-win-x64.zip`
- `SHA256SUMS.txt`

其中：

- Lightweight 版本依赖目标系统已安装 .NET 运行时
- Standalone 版本自带运行时，可直接作为独立程序运行

## 权限

workflow 使用：

`permissions: contents: write`

用于允许 GitHub Actions 创建 Release 并上传发布资产。

## 影响范围

本次只新增：

`.github/workflows/release.yml`

不修改现有的：

`.github/workflows/build-and-test.yml`

原有 Build and Test workflow 继续负责：

- main 分支推送检查
- PR 检查
- Release 编译
- 构建 Artifact 上传

新增 workflow 专门负责正式版本标签发布。

## 本地验证结果

已使用与 workflow 一致的命令进行本地验证：

- win-x64 依赖还原成功
- Release 编译成功
- Lightweight 发布成功
- Standalone 发布成功
- 版本字段校验成功
- Lightweight 包包含 `StarPie.exe`
- Standalone 包包含 `StarPie.exe`
- 编译错误：0