### PR TITLE
fix: 修复 SettingsWindow 生命周期引用泄漏

### DIFF
--- a/WinPieGestures/SettingsWindow.xaml.cs
+++ b/WinPieGestures/SettingsWindow.xaml.cs
@@ -331,6 +331,8 @@ public partial class SettingsWindow : Window
 
 	private bool _rawKeyboardInputHookAttached;
 
+	private bool _exclusiveKeyboardHookAttached;
+
 	private volatile bool _resourcesReleased;
 
 	public static bool IsSilentLaunch()
@@ -401,12 +403,7 @@ public partial class SettingsWindow : Window
 			UpdateLogoTheme(isDark);
 			App.ApplyTrayTheme(isDark);
 
-			if (App.MainKeyboardHook != null)
-			{
-				App.MainKeyboardHook.OnExclusiveRecordCompleted += MainKeyboardHook_OnExclusiveRecordCompleted;
-				App.MainKeyboardHook.OnExclusiveRecordCancelled += MainKeyboardHook_OnExclusiveRecordCancelled;
-				App.MainKeyboardHook.OnExclusiveRecordModifiersChanged += MainKeyboardHook_OnExclusiveRecordModifiersChanged;
-			}
+			HookExclusiveKeyboardRecordingEvents();
 			if (FocusHotkeyRecorder != null)
 			{
 				FocusHotkeyRecorder.HotkeyChanged += FocusHotkeyRecorder_HotkeyChanged;
@@ -2495,14 +2492,40 @@ public partial class SettingsWindow : Window
 		_downloadCts?.Dispose();
 		_downloadCts = null;
 
-		if (_isUiInitialized && App.MainKeyboardHook != null)
+		UnhookExclusiveKeyboardRecordingEvents();
+		CancelExclusiveRecordingIfActive();
+		DetachTileCycleItems();
+		DisposeSlotViewModels();
+	}
+
+	// 使用独立订阅状态，不依赖 _isUiInitialized，确保初始化中途异常时也能解除全局 Hook 引用。
+	private void HookExclusiveKeyboardRecordingEvents()
+	{
+		if (_exclusiveKeyboardHookAttached || App.MainKeyboardHook == null)
+		{
+			return;
+		}
+
+		App.MainKeyboardHook.OnExclusiveRecordCompleted += MainKeyboardHook_OnExclusiveRecordCompleted;
+		App.MainKeyboardHook.OnExclusiveRecordCancelled += MainKeyboardHook_OnExclusiveRecordCancelled;
+		App.MainKeyboardHook.OnExclusiveRecordModifiersChanged += MainKeyboardHook_OnExclusiveRecordModifiersChanged;
+		_exclusiveKeyboardHookAttached = true;
+	}
+
+	private void UnhookExclusiveKeyboardRecordingEvents()
+	{
+		if (!_exclusiveKeyboardHookAttached)
+		{
+			return;
+		}
+
+		if (App.MainKeyboardHook != null)
 		{
 			App.MainKeyboardHook.OnExclusiveRecordCompleted -= MainKeyboardHook_OnExclusiveRecordCompleted;
 			App.MainKeyboardHook.OnExclusiveRecordCancelled -= MainKeyboardHook_OnExclusiveRecordCancelled;
 			App.MainKeyboardHook.OnExclusiveRecordModifiersChanged -= MainKeyboardHook_OnExclusiveRecordModifiersChanged;
 		}
-		CancelExclusiveRecordingIfActive();
-		DisposeSlotViewModels();
+		_exclusiveKeyboardHookAttached = false;
 	}
 
 	private void ProfilesListBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -13722,12 +13745,27 @@ public partial class SettingsWindow : Window
 				items.Add(item);
 			}
 		}
+		DetachTileCycleItems();
 		_cycleItems = items;
 		if (TileCycleListBox != null)
 		{
 			TileCycleListBox.ItemsSource = null;
 			TileCycleListBox.ItemsSource = _cycleItems;
 		}
+	}
+
+	// WPF 默认集合视图可能延长 ItemsSource 生命周期；必须先解除项事件，避免其反向保活整个窗口。
+	private void DetachTileCycleItems()
+	{
+		if (TileCycleListBox != null)
+		{
+			TileCycleListBox.ItemsSource = null;
+		}
+		foreach (LayoutCycleItem item in _cycleItems)
+		{
+			item.PropertyChanged -= LayoutCycleItem_PropertyChanged;
+		}
+		_cycleItems.Clear();
 	}
 
 	/// <summary>勾选/取消任意一项立即持久化（循环范围即时生效）。</summary>


### PR DESCRIPTION
## 变更说明

本 PR 修复设置窗口完成初始化并关闭后，仍可能被事件委托和 WPF 集合视图间接引用、导致无法被 GC 回收的问题。

### 循环布局列表资源释放

- 新增统一的 `DetachTileCycleItems()` 清理入口。
- 解除所有 `LayoutCycleItem.PropertyChanged` 事件订阅。
- 清空 `TileCycleListBox.ItemsSource`，切断 WPF 默认集合视图的引用链。
- 清空旧的 `_cycleItems` 列表。
- 在刷新循环布局列表时，先完整构造新列表，再释放并替换旧列表，避免构造失败时破坏当前界面状态。
- 在 `ReleaseWindowResources()` 中执行最终清理，防止窗口关闭后继续被循环布局项反向保活。

### 独占键盘录制事件生命周期

- 新增 `_exclusiveKeyboardHookAttached` 订阅状态。
- 将订阅和解绑逻辑封装为 `HookExclusiveKeyboardRecordingEvents()` 与 `UnhookExclusiveKeyboardRecordingEvents()`。
- 解绑逻辑不再依赖 `_isUiInitialized`。
- 即使 UI 初始化在事件订阅后中途失败，也能在窗口释放时正确解除全局键盘 Hook 事件。
- 防止初始化重试造成重复订阅。

## 修复的引用链

修复前可能存在以下强引用链：

    WPF 默认集合视图
      → List<LayoutCycleItem>
        → LayoutCycleItem.PropertyChanged
          → SettingsWindow.LayoutCycleItem_PropertyChanged
            → SettingsWindow

修复后，窗口关闭时会主动解除事件、解绑集合并清空列表，从而允许完整的设置窗口视觉树被 GC 回收。

## 验证结果

- 弱引用与强制 GC 回归审计：
  - 完整 `EnsureUiInitialized()` 路径关闭后，`SettingsWindow` 可被回收
  - 循环布局列表初始化后，窗口可被回收
  - Raw Mouse 事件残留：0
  - Raw Keyboard 事件残留：0
  - `I18n.LanguageChanged` 事件残留：0
  - UI 未完成初始化时的独占键盘事件解绑验证通过
  - `Application.Windows.Count` 最终为 0

## 变更范围

仅修改：

- `WinPieGestures/SettingsWindow.xaml.cs`