### PR TITLE
ci: 支持 beta 标签触发预发布流程

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,20 +37,22 @@ jobs:
         shell: pwsh
         run: |
           $tag = $env:GITHUB_REF_NAME
-          if ($tag -notmatch '^v(?<version>\d+\.\d+\.\d+)$') {
-            throw "Release tag must use the vX.Y.Z format: $tag"
+          if ($tag -notmatch '^v(?<baseVersion>\d+\.\d+\.\d+)(?<prerelease>-beta\d+)?$') {
+            throw "Release tag must use vX.Y.Z or vX.Y.Z-betaN format: $tag"
           }
 
-          $tagVersion = $Matches.version
-          $expectedFourPartVersion = "${tagVersion}.0"
+          $baseVersion = $Matches.baseVersion
+          $prereleaseSuffix = $Matches.prerelease
+          $expectedProjectVersion = "${baseVersion}${prereleaseSuffix}"
+          $expectedFourPartVersion = "${baseVersion}.0"
           [xml]$project = Get-Content "WinPieGestures/WinPieGestures.csproj"
 
           $projectVersion = [string]$project.Project.PropertyGroup.Version
           $assemblyVersion = [string]$project.Project.PropertyGroup.AssemblyVersion
           $fileVersion = [string]$project.Project.PropertyGroup.FileVersion
 
-          if ($projectVersion -ne $tagVersion) {
-            throw "Version mismatch: tag=$tagVersion Version=$projectVersion"
+          if ($projectVersion -ne $expectedProjectVersion) {
+            throw "Version mismatch: tag=$expectedProjectVersion Version=$projectVersion"
           }
           if ($assemblyVersion -ne $expectedFourPartVersion) {
             throw "AssemblyVersion mismatch: expected=$expectedFourPartVersion actual=$assemblyVersion"
@@ -126,4 +128,16 @@ jobs:
             Sort-Object Name |
             Select-Object -ExpandProperty FullName
 
-          gh release create $env:GITHUB_REF_NAME @assets --verify-tag --generate-notes --title "StarPie $env:GITHUB_REF_NAME"
+          $releaseArguments = @("release", "create", $env:GITHUB_REF_NAME)
+          $releaseArguments += $assets
+          $releaseArguments += @("--verify-tag", "--generate-notes", "--title", "StarPie $env:GITHUB_REF_NAME")
+
+          if ($env:GITHUB_REF_NAME -match '^v\d+\.\d+\.\d+-beta\d+$') {
+            $releaseArguments += "--prerelease"
+            Write-Host "Publishing GitHub pre-release: $env:GITHUB_REF_NAME"
+          }
+
+          & gh @releaseArguments
+          if ($LASTEXITCODE -ne 0) {
+            throw "GitHub Release creation failed with exit code $LASTEXITCODE"
+          }

--- a/WinPieGestures/WinPieGestures.csproj
+++ b/WinPieGestures/WinPieGestures.csproj
@@ -14,7 +14,7 @@
     <Product>StarPie</Product>
     <Company>StarPie Studio</Company>
     <Description>StarPie - 现代化高颜值 Windows 鼠标轮盘笔势与效率管理系统</Description>
-    <Version>1.7.0</Version>
+    <Version>1.7.0-beta1</Version>
     <AssemblyVersion>1.7.0.0</AssemblyVersion>
     <FileVersion>1.7.0.0</FileVersion>
     <ServerGarbageCollection>false</ServerGarbageCollection>


### PR DESCRIPTION
# ci: 支持 beta 标签触发预发布流程

## 修改概述

扩展现有 GitHub Release 自动发布工作流，使其在保持正式版本发布能力的同时，支持使用 `vX.Y.Z-betaN` 标签编译并创建 GitHub Pre-release。

同时将当前项目版本调整为 `1.7.0-beta1`，用于发布首个 Beta 预发布版本。

## 支持的标签格式

工作流现在接受以下两类标签：

| 标签类型 | 格式 | 示例 | GitHub Release 类型 |
| --- | --- | --- | --- |
| 正式版本 | `vX.Y.Z` | `v1.7.0` | 普通 Release |
| Beta 版本 | `vX.Y.Z-betaN` | `v1.7.0-beta1` | Pre-release |

以下标签仍会被拒绝：

- `v1.7.0.dev1`
- `v1.7.0-beta`
- `v1.7`
- `1.7.0-beta1`

Beta 后缀必须使用 `-beta` 加数字的格式。

## 版本一致性校验

### 正式版本

推送 `v1.7.0` 标签时，项目文件必须包含：

    <Version>1.7.0</Version>
    <AssemblyVersion>1.7.0.0</AssemblyVersion>
    <FileVersion>1.7.0.0</FileVersion>

### Beta 预发布版本

推送 `v1.7.0-beta1` 标签时，项目文件必须包含：

    <Version>1.7.0-beta1</Version>
    <AssemblyVersion>1.7.0.0</AssemblyVersion>
    <FileVersion>1.7.0.0</FileVersion>

`Version` 保留完整预发布后缀，用于表示最终编译产物的预发布版本。

`AssemblyVersion` 和 `FileVersion` 继续使用纯数字四段格式，因为这两个字段不接受 `-beta1` 预发布后缀。

## 当前项目版本

已将 `WinPieGestures/WinPieGestures.csproj` 中的项目版本修改为：

    <Version>1.7.0-beta1</Version>
    <AssemblyVersion>1.7.0.0</AssemblyVersion>
    <FileVersion>1.7.0.0</FileVersion>

对应的预发布标签为：

`v1.7.0-beta1`

## Pre-release 创建逻辑

创建 GitHub Release 前，workflow 会再次识别当前标签。

当标签匹配 `vX.Y.Z-betaN` 时，向 GitHub CLI 添加：

`--prerelease`

因此 `v1.7.0-beta1` 创建的 Release 会在 GitHub 中显示为 Pre-release，不会被标记为正式稳定版本。

正式版本标签不会添加该参数，原有正式发布行为保持不变。

## GitHub CLI 调用改进

Release 创建参数现在通过 PowerShell 参数数组统一构造，包括：

- 标签名称
- Lightweight ZIP
- Standalone ZIP
- SHA256 校验文件
- 标签存在性验证
- 自动生成 Release Notes
- Release 标题
- Beta 版本的 Pre-release 标记

调用完成后会检查 GitHub CLI 的退出状态。如果创建 Release 失败，workflow 会明确抛出异常并标记为失败，避免命令失败后任务仍被误认为成功。

## 标签与 main 校验

现有的发布安全限制保持不变：

`Release 标签必须指向当前 origin/main 的最新提交。`

因此推荐发布流程为：

1. 在功能分支中更新代码和版本号
2. 创建并合并 PR
3. 确认合并提交是当前 `main` 最新提交
4. 在该提交上创建 `v1.7.0-beta1` 标签
5. 推送标签
6. GitHub Actions 自动编译并创建 Pre-release

## 自动发布资产

以 `v1.7.0-beta1` 为例，工作流将生成并上传：

- `StarPie-v1.7.0-beta1-Lightweight-win-x64.zip`
- `StarPie-v1.7.0-beta1-Standalone-win-x64.zip`
- `SHA256SUMS.txt`

## 兼容性

本次修改保留原有正式版本发布功能：

- `v1.7.0` 仍创建普通 Release
- `v1.7.0-beta1` 创建 Pre-release
- Lightweight 和 Standalone 构建参数保持不变
- 标签必须指向最新 `main` 的限制保持不变
- Release Assets 和 SHA256 校验文件生成逻辑保持不变

## 修改文件

- `.github/workflows/release.yml`
- `WinPieGestures/WinPieGestures.csproj`
