### PR TITLE
Feature/volume drag adjust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ $RECYCLE.BIN/
 .DS_Store
 
 
+*.bak
+build-out-*/

--- a/WinPieGestures/AppConfig.cs
+++ b/WinPieGestures/AppConfig.cs
@@ -72,6 +72,14 @@ public class AppConfig
 	public double SubWheelRadiusRatio { get; set; } = 1.55;
 
 	public double SubWheelTriggerDistance { get; set; } = 95.0;
+	/// <summary>音量拖距调音：缩回中心取消的迟滞系数（触发距离 × 该系数）。越大需缩回越多才取消，防止边缘抖动误取消。</summary>
+	public double VolumeCancelHysteresisRatio { get; set; } = 0.6;
+
+	/// <summary>音量拖距调音：甩出取消的距离下限（px）。低于此距离即使快速移动也不视为甩出。</summary>
+	public double VolumeFlickFarDistance { get; set; } = 360.0;
+
+	/// <summary>音量拖距调音：甩出取消的单帧距离跳变阈值（px）。超过此值视为快速甩动。</summary>
+	public double VolumeFlickCancelDistance { get; set; } = 120.0;
 
 	public double SubWheelOuterRadius { get; set; } = 210.0;
 

--- a/WinPieGestures/GestureController.cs
+++ b/WinPieGestures/GestureController.cs
@@ -103,6 +103,42 @@ public class GestureController
 
 	private long _pendingGestureVersion;
 
+	// ---- 音量"拖距调音"（次级轮盘）：音量加/减扇区越过子轮盘触发距离后，
+	//      以拖出距离增量映射系统音量并实时写盘；外甩取消恢复基准音量 ----
+	private bool _volumeAdjustActive;
+
+	private bool _volumeGestureTookOver;
+
+	private float _volumeBaseline = -1f;
+
+	private double _volumeBaselineDist;
+
+	private float _volumeLastPercent = -1f;
+
+	// Last system OSD (volume flyout) refresh tick; throttled to avoid flicker on fast drags
+	private long _volumeLastOsdTick;
+
+	// Sector locked at the moment the volume adjust takes over. Once active, small angle
+	// drift into a neighbouring (non-volume) sector must never cancel the ongoing adjust.
+	private int _volumeLockedSector = -1;
+	// Distance of the previous processed frame while adjusting. A sudden large
+	// positive jump is treated as an intentional flick-out and cancels to baseline.
+	private double _volumeFlickPrevDist = -1.0;
+	// Latches true when this gesture was cancelled by a flick-out. A cancelled gesture
+	// must not re-enter adjust while the trigger button is still held, otherwise the
+	// volume snaps back to baseline and is immediately dragged again in the same press.
+	private bool _volumeFlickCancelled;
+	// Over-travel past a pinned 0%/100% volume: -1.0 while not pinned. Once the clamp
+	// kicks in this stores the travel at that instant, so a continued outward drag
+	// beyond the over-travel cancel distance aborts the gesture and restores baseline.
+	private double _volumeMaxedOutDist = -1.0;
+
+	private bool _volumePreviewScheduled;
+
+	private int _pendingVolumePercent = -1;
+
+	private long _pendingVolumePreviewVersion;
+
 	[DllImport("user32.dll")]
 	[return: MarshalAs(UnmanagedType.Bool)]
 	private static extern bool GetCursorPos(out POINT lpPoint);
@@ -141,6 +177,20 @@ public class GestureController
 			_selectedSubSectorIndex = -1;
 			_lastEscapedState = false;
 			_lastShowSubTier = false;
+			_volumeAdjustActive = false;
+			_volumeGestureTookOver = false;
+			_volumeBaseline = -1f;
+			_volumeBaselineDist = 0.0;
+			_volumeLastPercent = -1f;
+			_volumeLastOsdTick = 0L;
+			_volumeLastOsdTick = 0L;
+			_volumeLockedSector = -1;
+			_volumeFlickPrevDist = -1.0;
+			_volumeFlickCancelled = false;
+			_volumeMaxedOutDist = -1.0;
+			_volumePreviewScheduled = false;
+			_pendingVolumePercent = -1;
+			_pendingVolumePreviewVersion = 0L;
 			return _gestureVersion;
 		}
 	}
@@ -279,6 +329,269 @@ public class GestureController
 		}
 		radialWindow.SetOuterEscapeState(targetEscape);
 		radialWindow.HighlightSector(targetSector, targetSubSector, targetShowSubTier);
+	}
+
+	// 判断指定扇区是否为系统音量加/减动作（用于外甩豁免：音量扇区在任意拖距都可调音）
+	private bool IsVolumeSector(int sectorIndex)
+	{
+		if (_activeProfile == null || sectorIndex < 0 || sectorIndex >= _activeProfile.Actions.Count)
+		{
+			return false;
+		}
+		ActionItem? action = _activeProfile.Actions[sectorIndex];
+		if (action == null)
+		{
+			return false;
+		}
+		bool isSystem = string.Equals(action.Type, "System", StringComparison.OrdinalIgnoreCase);
+		return isSystem && (string.Equals(action.Parameter, "volumeup", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(action.Parameter, "volumedown", StringComparison.OrdinalIgnoreCase));
+	}
+	// 音量"拖距调音"：当前扇区为音量加/减且拖距越过子轮盘触发距离时接管为距离映射调音。
+	// 以进入时的系统音量为基准，拖出距离增量映射音量（加音量向外=升，减音量向外=降），
+	// 实时写系统音量；外甩取消或缩回触发距离内恢复基准音量。
+	// 返回 true 表示本帧已接管音量调节（调用方应屏蔽二级子轮盘）。
+	private bool ProcessVolumeAdjust(double dist, int sectorIndex, bool isEscaped, double subWheelTriggerDistance)
+	{
+		// Sector lock: once adjusting, keep the sector that started the adjust so angle drift
+		// into a neighbouring non-volume sector cannot cancel a long drag. The cancel rule
+		// below (escape or return inside the hysteresis radius) is the only way out.
+		int refSector = (_volumeAdjustActive && _volumeLockedSector >= 0) ? _volumeLockedSector : sectorIndex;
+		if (refSector < 0)
+		{
+			if (_volumeAdjustActive)
+			{
+				_volumeAdjustActive = false;
+				_volumeLockedSector = -1;
+				_volumeFlickPrevDist = -1.0;
+				QueueVolumePreview(-1, GetCurrentGestureVersion());
+			}
+		return false;
+		}
+		ActionItem? action = (_activeProfile != null && refSector < _activeProfile.Actions.Count)
+			? _activeProfile.Actions[refSector]
+			: null;
+		bool isSystem = action != null && string.Equals(action.Type, "System", StringComparison.OrdinalIgnoreCase);
+		bool isUp = isSystem && string.Equals(action.Parameter, "volumeup", StringComparison.OrdinalIgnoreCase);
+		bool isDown = isSystem && string.Equals(action.Parameter, "volumedown", StringComparison.OrdinalIgnoreCase);
+		if (!isUp && !isDown)
+		{
+			if (_volumeAdjustActive)
+			{
+				_volumeAdjustActive = false;
+				_volumeFlickPrevDist = -1.0;
+				QueueVolumePreview(-1, GetCurrentGestureVersion());
+			}
+			return false;
+		}
+		int direction = isUp ? 1 : -1;
+		// 距离判定阈值来自设置界面（外观 → 音量拖距调音），带默认值兜底以防配置损坏：
+		// cancelRatio = 缩回取消迟滞系数；flickFar = 甩出取消距离下限；flickJump = 单帧跳变阈值。
+		double cancelRatio = (ConfigManager.CurrentConfig.VolumeCancelHysteresisRatio > 0.0
+			&& ConfigManager.CurrentConfig.VolumeCancelHysteresisRatio < 1.0)
+			? ConfigManager.CurrentConfig.VolumeCancelHysteresisRatio
+			: 0.6;
+		double flickFar = (ConfigManager.CurrentConfig.VolumeFlickFarDistance > 0.0)
+			? ConfigManager.CurrentConfig.VolumeFlickFarDistance
+			: 360.0;
+		double flickJump = (ConfigManager.CurrentConfig.VolumeFlickCancelDistance > 0.0)
+			? ConfigManager.CurrentConfig.VolumeFlickCancelDistance
+			: 120.0;
+		// Cancel rule: outer-swipe escape, or return inside the trigger radius. Once adjusting,
+		// a tighter 60% hysteresis radius applies so small returns or edge jitter never snap volume back.
+		bool insideCancelRadius = _volumeAdjustActive
+			? dist < subWheelTriggerDistance * cancelRatio
+			: dist < subWheelTriggerDistance;
+		// Intentional flick-out: while adjusting, a single-frame distance jump beyond
+		// the configured jump threshold while already past the configured far distance
+		// counts as flicking away to cancel. Steady drags never trip it, preserving the
+		// check8 immunity to angle drift that used to kill long drags.
+		bool volumeFlickOut = false;
+		if (_volumeAdjustActive && _volumeFlickPrevDist >= 0.0)
+		{
+			volumeFlickOut = dist > flickFar
+			    && dist - _volumeFlickPrevDist > flickJump;
+			_volumeFlickPrevDist = dist;
+		}
+		// A flick-out / over-travel cancel latched this gesture. Re-arm it only once
+		// the pointer clearly returns (back inside 2x the trigger radius): the user can
+		// then keep adjusting on the way back out. While the pointer stays far out the
+		// latch holds, so the volume cannot snap back and re-drag around the cancel point.
+		if (!_volumeAdjustActive && _volumeFlickCancelled && dist < subWheelTriggerDistance * 2.0)
+		{
+			_volumeFlickCancelled = false;
+			_volumeMaxedOutDist = -1.0;
+		}
+		if (isEscaped || insideCancelRadius || volumeFlickOut)
+		{
+			// 外甩取消或缩回触发距离内：恢复基准音量并退出调音模式（本手势仍视为已接管，松手不再执行单步动作）
+			if (_volumeAdjustActive)
+			{
+				_volumeAdjustActive = false;
+				_volumeGestureTookOver = true;
+				if (volumeFlickOut)
+				{
+					_volumeFlickCancelled = true;
+				}
+				_volumeFlickPrevDist = -1.0;
+				_volumeLockedSector = -1;
+				_volumeMaxedOutDist = -1.0;
+				if (_volumeBaseline >= 0f)
+				{
+					SystemVolume.SetVolume(_volumeBaseline);
+				}
+				QueueVolumePreview(-1, GetCurrentGestureVersion());
+			}
+			return false;
+		}
+		if (!_volumeAdjustActive && !_volumeFlickCancelled)
+		{
+			// 首次越过触发距离：记录基准音量与基准拖距，进入调音模式
+			if (!SystemVolume.TryGetVolume(out _volumeBaseline))
+			{
+				return false;
+			}
+			// 基线拖距固定为触发距离：从越过触发距离那一刻起算拖距，首帧不额外吃掉拖距
+			_volumeBaselineDist = dist; // first enter (dist~trigger) matches the old fixed baseline; a mid-return re-enter starts from travel=0
+			_volumeGestureTookOver = true;
+			_volumeAdjustActive = true;
+			_volumeLastPercent = -1f;
+			_volumeLastOsdTick = 0L;
+			_volumeLockedSector = sectorIndex;
+			_volumeFlickPrevDist = dist;
+			_volumeMaxedOutDist = -1.0;
+			// Wake the native volume flyout so the system OSD shows while this gesture adjusts
+			SystemVolume.ShowOsd(_volumeBaseline, isUp);
+		}
+		// A cancelled or latched gesture must not fall through into the incremental map:
+		// active is already false here, so bail out instead of dragging on stale baseline.
+		if (!_volumeAdjustActive)
+		{
+			return false;
+		}
+		// 增量映射：满程 200px 拖距映射 ±100%（约 2px/1%），灵敏度为原 285px 的约 1.4 倍；
+		// 按整数百分比写盘，避免高频 COM 调用
+		double travel = Math.Max(0.0, dist - _volumeBaselineDist);
+		double fullTravel = 200.0;
+		double delta = Math.Clamp(travel / fullTravel, 0.0, 1.0);
+		int baselinePercent = (int)Math.Round(_volumeBaseline * 100.0, MidpointRounding.AwayFromZero);
+		int targetPercent = Math.Clamp(baselinePercent + (int)Math.Round(delta * 100.0, MidpointRounding.AwayFromZero) * direction, 0, 100);
+		// Volume pinned at 0%/100% while still dragging outward: meter the over-travel
+		// and cancel the whole gesture (restore baseline) once it passes the threshold.
+		bool pinnedAtEdge = (targetPercent <= 0 && direction < 0) || (targetPercent >= 100 && direction > 0);
+		if (pinnedAtEdge)
+		{
+			if (_volumeMaxedOutDist < 0.0)
+			{
+				_volumeMaxedOutDist = travel;
+			}
+			else if (travel - _volumeMaxedOutDist > 150.0)
+			{
+				_volumeAdjustActive = false;
+				_volumeFlickCancelled = true;
+				_volumeFlickPrevDist = -1.0;
+				_volumeLockedSector = -1;
+				_volumeMaxedOutDist = -1.0;
+				if (_volumeBaseline >= 0f)
+				{
+					SystemVolume.SetVolume(_volumeBaseline);
+				}
+				QueueVolumePreview(-1, GetCurrentGestureVersion());
+				return false;
+			}
+		}
+		else
+		{
+			_volumeMaxedOutDist = -1.0;
+		}
+		if (targetPercent != _volumeLastPercent)
+		{
+			_volumeLastPercent = targetPercent;
+			SystemVolume.SetVolume(targetPercent / 100f);
+			// Throttled OSD refresh: at most one key inject per 180ms keeps the flyout from strobing
+			long nowTick = Environment.TickCount64;
+			if (nowTick - _volumeLastOsdTick >= 180L)
+			{
+				_volumeLastOsdTick = nowTick;
+				SystemVolume.ShowOsd(targetPercent / 100f, isUp);
+			}
+			QueueVolumePreview(targetPercent, GetCurrentGestureVersion());
+		}
+		return true;
+	}
+
+	// 音量预览节流：与高亮更新同锁、同 Render 优先级，覆盖式单挂起（模式见 QueueHighlightUpdate）
+	private void QueueVolumePreview(int percent, long gestureVersion)
+	{
+		bool shouldSchedule;
+		lock (_uiUpdateSync)
+		{
+			if (!_isGestureActive || gestureVersion != _gestureVersion)
+			{
+				return;
+			}
+			if (percent == _pendingVolumePercent)
+			{
+				return;
+			}
+			_pendingVolumePercent = percent;
+			_pendingVolumePreviewVersion = gestureVersion;
+			shouldSchedule = !_volumePreviewScheduled;
+			_volumePreviewScheduled = true;
+		}
+
+		if (!shouldSchedule)
+		{
+			return;
+		}
+
+		try
+		{
+			Application.Current.Dispatcher.BeginInvoke((Action)ApplyVolumePreview, DispatcherPriority.Render);
+		}
+		catch
+		{
+			lock (_uiUpdateSync)
+			{
+				if (_pendingVolumePreviewVersion == gestureVersion)
+				{
+					_volumePreviewScheduled = false;
+				}
+			}
+		}
+	}
+
+	private void ApplyVolumePreview()
+	{
+		int percent;
+		long previewVersion;
+		RadialWindow? radialWindow;
+		lock (_uiUpdateSync)
+		{
+			if (!_volumePreviewScheduled)
+			{
+				return;
+			}
+			percent = _pendingVolumePercent;
+			previewVersion = _pendingVolumePreviewVersion;
+			if (!_isGestureActive || previewVersion != _gestureVersion)
+			{
+				_volumePreviewScheduled = false;
+				return;
+			}
+			radialWindow = _radialWindow;
+			if (radialWindow == null)
+			{
+				return;
+			}
+			_volumePreviewScheduled = false;
+		}
+
+		if (!IsCurrentGesture(previewVersion) || !ReferenceEquals(_radialWindow, radialWindow))
+		{
+			return;
+		}
+		radialWindow.SetVolumePreview(percent, percent >= 0);
 	}
 
 	private bool CheckIsIsolated(out string processName)
@@ -799,6 +1112,7 @@ public class GestureController
 					if (ShowRadialUI(startPoint, profile, gestureVersion))
 					{
 						ApplyPendingHighlight();
+					ApplyVolumePreview();
 					}
 				}
 				catch (Exception ex)
@@ -867,9 +1181,37 @@ public class GestureController
 			WheelProfile? finalProfile = finalState.Profile;
 			RadialWindow? endedWindow = finalState.Window;
 			bool isEscaped = finalState.IsEscaped;
+			bool volumeTookOver = _volumeGestureTookOver;
+			float volumeBaseline = _volumeBaseline;
+			// 手势结束：同步复位音量接管状态，杜绝 took/active/baseline 残留污染下一手势
+			// （BeginGestureTracking 也已复位，双保险覆盖所有触发路径）
+			_volumeAdjustActive = false;
+			_volumeGestureTookOver = false;
+			_volumeBaseline = -1f;
+			_volumeBaselineDist = 0.0;
+			_volumeLastPercent = -1f;
+			_volumeLastOsdTick = 0L;
+			_volumeLockedSector = -1;
+			_volumeFlickPrevDist = -1.0;
+			_volumeFlickCancelled = false;
+			_volumeMaxedOutDist = -1.0;
 			((DispatcherObject)Application.Current).Dispatcher.BeginInvoke((Delegate)(Action)delegate
 			{
+				if (volumeTookOver)
+				{
+					// 本手势已接管音量调节：外甩取消则恢复基准音量，正常松手保持最终音量；
+					// 隐藏音量预览并跳过全部动作执行（不再注入单键音量键）
+					if (isEscaped && volumeBaseline >= 0f)
+					{
+						SystemVolume.SetVolume(volumeBaseline);
+					}
+					endedWindow?.SetVolumePreview(-1, isActive: false);
+				}
 				CloseGestureWindow(endedWindow);
+				if (volumeTookOver)
+				{
+					return;
+				}
 				ActionItem? targetAction = null;
 				if (!isEscaped)
 				{
@@ -1026,9 +1368,25 @@ public class GestureController
 			WheelProfile? finalProfile = finalState.Profile;
 			RadialWindow? endedWindow = finalState.Window;
 			bool isEscaped = finalState.IsEscaped;
+			bool volumeTookOver = _volumeGestureTookOver;
+			float volumeBaseline = _volumeBaseline;
 			((DispatcherObject)Application.Current).Dispatcher.BeginInvoke((Delegate)(Action)delegate
 			{
+				if (volumeTookOver)
+				{
+					// 本手势已接管音量调节：外甩取消则恢复基准音量，正常松手保持最终音量；
+					// 隐藏音量预览并跳过全部动作执行（不再注入单键音量键）
+					if (isEscaped && volumeBaseline >= 0f)
+					{
+						SystemVolume.SetVolume(volumeBaseline);
+					}
+					endedWindow?.SetVolumePreview(-1, isActive: false);
+				}
 				CloseGestureWindow(endedWindow);
+				if (volumeTookOver)
+				{
+					return;
+				}
 				ActionItem? targetAction = null;
 				if (!isEscaped)
 				{
@@ -1147,6 +1505,7 @@ public class GestureController
 						if (ShowRadialUI(center, profile, gestureVersion))
 						{
 							ApplyPendingHighlight();
+						ApplyVolumePreview();
 						}
 					}
 					catch (Exception ex)
@@ -1189,7 +1548,22 @@ public class GestureController
 			bool enableMultiTier = ConfigManager.CurrentConfig.EnableMultiTier;
 			double num8 = ((ConfigManager.CurrentConfig.SubWheelOuterRadius > 0.0) ? ConfigManager.CurrentConfig.SubWheelOuterRadius : (wheelRadius * 1.55));
 			double num9 = (enableMultiTier ? (num8 + 20.0) : wheelRadius);
-			if (ConfigManager.CurrentConfig.EnableOuterEscapeCancel)
+			// 角度与初判扇区提前到外甩判定之前：外甩短路需要知道当前指向扇区；
+			// 音量加/减扇区豁免外甩短路，保证"拖距调音"在任意拖距都可调（外甩不再吞掉音量手势）。
+			double num11 = Math.Atan2(num2, num) * (180.0 / Math.PI);
+			if (num11 < 0.0)
+			{
+				num11 += 360.0;
+			}
+			int num12 = _activeProfile?.SectorCount ?? 8;
+			if (num12 <= 0)
+			{
+				num12 = 8;
+			}
+			double num13 = 360.0 / (double)num12;
+			num4 = (int)Math.Floor((num11 + num13 / 2.0) / num13) % num12;
+			bool isVolumeSector = IsVolumeSector(num4) || _volumeAdjustActive;
+			if (ConfigManager.CurrentConfig.EnableOuterEscapeCancel && !isVolumeSector)
 			{
 				double num10 = ((ConfigManager.CurrentConfig.OuterEscapeDistance > 0.0) ? ConfigManager.CurrentConfig.OuterEscapeDistance : (num9 * 1.5));
 				if (num3 > num10)
@@ -1201,19 +1575,6 @@ public class GestureController
 			}
 			if (!flag)
 			{
-				double num11 = Math.Atan2(num2, num) * (180.0 / Math.PI);
-				if (num11 < 0.0)
-				{
-					num11 += 360.0;
-				}
-				int num12 = _activeProfile?.SectorCount ?? 8;
-				if (num12 <= 0)
-				{
-					num12 = 8;
-				}
-				double num13 = 360.0 / (double)num12;
-				num4 = (int)Math.Floor((num11 + num13 / 2.0) / num13) % num12;
-
 				bool isFan = ConfigManager.CurrentConfig.SubmenuStyle == "Fan";
 
 				// 蜂窝扇二级轮盘防抖与扇区保持锁定 (Hysteresis & Parent Sector Lock)
@@ -1277,6 +1638,12 @@ public class GestureController
 					}
 				}
 			}
+		}
+		// 音量"拖距调音"：音量加/减扇区越过子轮盘触发距离即接管为距离映射调音，屏蔽二级子轮盘
+		if (ProcessVolumeAdjust(num3, num4, flag, num7))
+		{
+			flag2 = false;
+			num5 = -1;
 		}
 		QueueHighlightUpdate(num4, num5, flag, flag2, GetCurrentGestureVersion());
 	}

--- a/WinPieGestures/I18n.cs
+++ b/WinPieGestures/I18n.cs
@@ -318,6 +318,62 @@ public static class I18n
 			[LanguageCode.En] = "Enable Outer Escape Cancel (Recommended)",
 			[LanguageCode.Ja] = "外側スワイプキャンセルを有効化 (推奨)"
 		};
+		dictionary["VolumeDragTitle"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "音量拖距调音 (Volume Drag-Adjust)",
+			[LanguageCode.ZhTw] = "音量拖距調音 (Volume Drag-Adjust)",
+			[LanguageCode.En] = "Volume Drag-Adjust",
+			[LanguageCode.Ja] = "音量ドラッグ調整 (Volume Drag-Adjust)"
+		};
+		dictionary["VolumeDragDesc"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "长按音量加/减扇区向外拖出可连续调音，以下距离参数实时生效，无需重启。",
+			[LanguageCode.ZhTw] = "長按音量加/減扇區向外拖出可連續調音，以下距離參數即時生效，無需重啟。",
+			[LanguageCode.En] = "Drag outward from a volume +/- sector to adjust continuously; the distance options below apply live without restart.",
+			[LanguageCode.Ja] = "音量+/-セクターから外側へドラッグして連続調整。以下の距離パラメータは再起動不要で即時反映されます。"
+		};
+		dictionary["VolumeCancelRatioTitle"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "缩回取消系数 (Cancel Hysteresis):",
+			[LanguageCode.ZhTw] = "縮回取消係數 (Cancel Hysteresis):",
+			[LanguageCode.En] = "Return-to-center cancel ratio (Hysteresis):",
+			[LanguageCode.Ja] = "中心復帰キャンセル係数 (Hysteresis):"
+		};
+		dictionary["VolumeCancelRatioDesc"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "调音时缩回到触发距离的百分之多少以下即取消并恢复原音量。值越大越不易被边缘抖动误回收（默认 60%）。",
+			[LanguageCode.ZhTw] = "調音時縮回到觸發距離的百分之多少以下即取消並恢復原音量。值越大越不易被邊緣抖動誤回收（預設 60%）。",
+			[LanguageCode.En] = "Cancel and restore the original volume once you drag back below this share of the trigger distance. Higher resists edge jitter (default 60%).",
+			[LanguageCode.Ja] = "トリガー距離のこの割合まで戻すとキャンセルして元の音量に戻します。値が大きいほど端の揺れによる誤収斂ににくくなります（既定60%）。"
+		};
+		dictionary["VolumeFlickFarTitle"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "甩出取消距离下限 (Flick Far):",
+			[LanguageCode.ZhTw] = "甩出取消距離下限 (Flick Far):",
+			[LanguageCode.En] = "Flick-out cancel distance floor (Flick Far):",
+			[LanguageCode.Ja] = "スワイプキャンセル距離下限 (Flick Far):"
+		};
+		dictionary["VolumeFlickFarDesc"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "仅当光标已远于该距离时，快速甩动才会取消调音，防止近距离拖动被误判为甩出。",
+			[LanguageCode.ZhTw] = "僅當光標已遠於該距離時，快速甩動才會取消調音，防止近距離拖動被誤判為甩出。",
+			[LanguageCode.En] = "A fast flick only cancels once the pointer is beyond this distance, avoiding short drags being read as a flick.",
+			[LanguageCode.Ja] = "カーソルがこの距離を超えて初めて高速スワイプでキャンセル。近距離ドラッグの誤判定を防ぎます。"
+		};
+		dictionary["VolumeFlickJumpTitle"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "甩动跳变阈值 (Flick Jump):",
+			[LanguageCode.ZhTw] = "甩動跳變閾值 (Flick Jump):",
+			[LanguageCode.En] = "Per-frame flick jump threshold (Flick Jump):",
+			[LanguageCode.Ja] = "フレームあたりスワイプ跳変閾値 (Flick Jump):"
+		};
+		dictionary["VolumeFlickJumpDesc"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "一帧之内光标移动超过该距离才算快速甩动。值越大越不容易触发甩出取消。",
+			[LanguageCode.ZhTw] = "一幀之內光標移動超過該距離才算快速甩動。值越大越不容易觸發甩出取消。",
+			[LanguageCode.En] = "Movement beyond this distance within one frame counts as a fast flick. Larger values make flick-cancel less likely.",
+			[LanguageCode.Ja] = "1フレーム内の移動がこの距離を超えると高速スワイプと判定。値が大きいほどスワイプキャンセルは起きにくくなります。"
+		};
 		dictionary["IconPickerImport"] = new Dictionary<LanguageCode, string>
 		{
 			[LanguageCode.ZhCn] = "➕ 导入自定义图标...",

--- a/WinPieGestures/RadialWindow.xaml
+++ b/WinPieGestures/RadialWindow.xaml
@@ -53,6 +53,7 @@
         <StackPanel Name="CoreSelectionTextPanel" Width="150" Margin="6" HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="Collapsed" IsHitTestVisible="False">
           <TextBlock Name="CoreSelectionText" Foreground="#FFFFFFFF" FontSize="13" FontWeight="SemiBold" HorizontalAlignment="Center" TextAlignment="Center" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" MaxHeight="54" Effect="{StaticResource TextShadow}" />
         </StackPanel>
+        <TextBlock Name="CoreVolumeText" Text="🔊 50%" Foreground="#FFFFFFFF" FontSize="15" FontWeight="Bold" HorizontalAlignment="Center" VerticalAlignment="Center" TextAlignment="Center" TextWrapping="NoWrap" Margin="6" Visibility="Collapsed" IsHitTestVisible="False" Effect="{StaticResource TextShadow}" />
       </Grid>
     </Canvas>
   </Grid>

--- a/WinPieGestures/RadialWindow.xaml.cs
+++ b/WinPieGestures/RadialWindow.xaml.cs
@@ -715,6 +715,7 @@ public partial class RadialWindow : Window
 			? ConfigManager.CurrentConfig.CoreFontSize
 			: Math.Max(8.0, Math.Min(16.0, coreRadius / 4.0));
 		CoreSelectionText.FontSize = coreFontSize;
+		CoreVolumeText.FontSize = coreFontSize;
 		if (!string.IsNullOrEmpty(ConfigManager.CurrentConfig?.CoreFontFamily))
 		{
 			try
@@ -1268,6 +1269,26 @@ public partial class RadialWindow : Window
 		}
 		((Freezable)streamGeometry).Freeze();
 		return streamGeometry;
+	}
+
+	/// <summary>音量"拖距调音"实时预览：isActive=true 显示中心百分比，否则隐藏并恢复选中动作文字。</summary>
+	public void SetVolumePreview(int percent, bool isActive)
+	{
+		if (isActive)
+		{
+			CoreVolumeText.Text = "🔊 " + percent + "%";
+			CoreVolumeText.Visibility = Visibility.Visible;
+			Panel.SetZIndex(CoreVolumeText, 22);
+			// 调音期间隐藏选中动作遮罩层，避免与音量百分比重叠
+			CoreSelectionTextPanel.Visibility = Visibility.Collapsed;
+			CoreSelectionOverlay.Visibility = Visibility.Collapsed;
+			return;
+		}
+		CoreVolumeText.Visibility = Visibility.Collapsed;
+		if (_currentHighlightedSector >= 0)
+		{
+			UpdateCoreSelectionDisplay(_currentHighlightedSector, _currentHighlightedSubSector);
+		}
 	}
 
 	public void SetOuterEscapeState(bool isEscaped)

--- a/WinPieGestures/SettingsWindow.xaml
+++ b/WinPieGestures/SettingsWindow.xaml
@@ -804,6 +804,36 @@
                     <Slider Name="SubWheelTriggerDistanceSlider" Minimum="30" Maximum="260" SmallChange="1" LargeChange="5" Value="95" ValueChanged="SubWheelTriggerDistanceSlider_ValueChanged" />
                     <TextBlock Name="SubWheelTriggerDistDesc" Text="调节光标划出距离中心多远时展开二级级联菜单。数值较小时轻划即可展开，数值较大时需向外划出更远距离才展开二级，防止快速触发一级动作时产生视觉干扰。" FontSize="10.5" Foreground="{DynamicResource TextMutedBrush}" TextWrapping="Wrap" Margin="0,2,0,0" />
                   </StackPanel>
+                  <Border Background="{DynamicResource CardBackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="12" Padding="16" Margin="0,8,0,0" SnapsToDevicePixels="True" UseLayoutRounding="True">
+                    <StackPanel>
+                      <TextBlock Name="VolumeDragTitleText" Text="音量拖距调音 (Volume Drag-Adjust)" FontSize="13" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
+                      <TextBlock Name="VolumeDragDescText" Text="长按音量加/减扇区向外拖出可连续调音，以下距离参数实时生效，无需重启。" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,2,0,8" TextWrapping="Wrap" />
+                      <StackPanel Name="VolumeCancelRatioPanel" Margin="0,2,0,0">
+                        <Grid Margin="0,0,0,4">
+                          <TextBlock Name="VolumeCancelRatioLabel" Text="缩回取消系数 (Cancel Hysteresis):" FontSize="11.5" Foreground="{DynamicResource TextSecondaryBrush}" />
+                          <TextBlock Name="VolumeCancelRatioValueText" Text="60%" FontSize="11.5" FontWeight="SemiBold" Foreground="{DynamicResource AccentPrimaryBrush}" HorizontalAlignment="Right" />
+                        </Grid>
+                        <Slider Name="VolumeCancelRatioSlider" Minimum="0.2" Maximum="0.9" SmallChange="0.05" LargeChange="0.1" Value="0.6" ValueChanged="VolumeCancelRatioSlider_ValueChanged" />
+                        <TextBlock Name="VolumeCancelRatioDesc" Text="调音时缩回到触发距离的百分之多少以下即取消并恢复原音量。值越大越不易被边缘抖动误回收（默认 60%）。" FontSize="10.5" Foreground="{DynamicResource TextMutedBrush}" TextWrapping="Wrap" Margin="0,2,0,0" />
+                      </StackPanel>
+                      <StackPanel Name="VolumeFlickFarPanel" Margin="0,10,0,0">
+                        <Grid Margin="0,0,0,4">
+                          <TextBlock Name="VolumeFlickFarLabel" Text="甩出取消距离下限 (Flick Far):" FontSize="11.5" Foreground="{DynamicResource TextSecondaryBrush}" />
+                          <TextBlock Name="VolumeFlickFarValueText" Text="360 px" FontSize="11.5" FontWeight="SemiBold" Foreground="{DynamicResource AccentPrimaryBrush}" HorizontalAlignment="Right" />
+                        </Grid>
+                        <Slider Name="VolumeFlickFarSlider" Minimum="200" Maximum="800" SmallChange="10" LargeChange="50" Value="360" ValueChanged="VolumeFlickFarSlider_ValueChanged" />
+                        <TextBlock Name="VolumeFlickFarDesc" Text="仅当光标已远于该距离时，快速甩动才会取消调音，防止近距离拖动被误判为甩出。" FontSize="10.5" Foreground="{DynamicResource TextMutedBrush}" TextWrapping="Wrap" Margin="0,2,0,0" />
+                      </StackPanel>
+                      <StackPanel Name="VolumeFlickJumpPanel" Margin="0,10,0,0">
+                        <Grid Margin="0,0,0,4">
+                          <TextBlock Name="VolumeFlickJumpLabel" Text="甩动跳变阈值 (Flick Jump):" FontSize="11.5" Foreground="{DynamicResource TextSecondaryBrush}" />
+                          <TextBlock Name="VolumeFlickJumpValueText" Text="120 px" FontSize="11.5" FontWeight="SemiBold" Foreground="{DynamicResource AccentPrimaryBrush}" HorizontalAlignment="Right" />
+                        </Grid>
+                        <Slider Name="VolumeFlickJumpSlider" Minimum="60" Maximum="300" SmallChange="5" LargeChange="20" Value="120" ValueChanged="VolumeFlickJumpSlider_ValueChanged" />
+                        <TextBlock Name="VolumeFlickJumpDesc" Text="一帧之内光标移动超过该距离才算快速甩动。值越大越不容易触发甩出取消。" FontSize="10.5" Foreground="{DynamicResource TextMutedBrush}" TextWrapping="Wrap" Margin="0,2,0,0" />
+                      </StackPanel>
+                    </StackPanel>
+                  </Border>
                 </StackPanel>
               </Border>
               <Border Background="{DynamicResource CardBackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="12" Padding="20" Margin="0,0,0,14" SnapsToDevicePixels="True" UseLayoutRounding="True" RenderOptions.ClearTypeHint="Enabled">

--- a/WinPieGestures/SettingsWindow.xaml.cs
+++ b/WinPieGestures/SettingsWindow.xaml.cs
@@ -797,6 +797,33 @@ public partial class SettingsWindow : Window
 			}
 		}
 
+		if (VolumeCancelRatioSlider != null)
+		{
+			VolumeCancelRatioSlider.Value = ((ConfigManager.CurrentConfig.VolumeCancelHysteresisRatio > 0.0) ? ConfigManager.CurrentConfig.VolumeCancelHysteresisRatio : 0.6);
+			if (VolumeCancelRatioValueText != null)
+			{
+				VolumeCancelRatioValueText.Text = $"{VolumeCancelRatioSlider.Value * 100.0:0}%";
+			}
+		}
+
+		if (VolumeFlickFarSlider != null)
+		{
+			VolumeFlickFarSlider.Value = ((ConfigManager.CurrentConfig.VolumeFlickFarDistance > 0.0) ? ConfigManager.CurrentConfig.VolumeFlickFarDistance : 360.0);
+			if (VolumeFlickFarValueText != null)
+			{
+				VolumeFlickFarValueText.Text = $"{VolumeFlickFarSlider.Value:0} px";
+			}
+		}
+
+		if (VolumeFlickJumpSlider != null)
+		{
+			VolumeFlickJumpSlider.Value = ((ConfigManager.CurrentConfig.VolumeFlickCancelDistance > 0.0) ? ConfigManager.CurrentConfig.VolumeFlickCancelDistance : 120.0);
+			if (VolumeFlickJumpValueText != null)
+			{
+				VolumeFlickJumpValueText.Text = $"{VolumeFlickJumpSlider.Value:0} px";
+			}
+		}
+
 		// Shapes & Layouts
 		SetComboBoxSelectedValue(ShapeComboBox, ConfigManager.CurrentConfig.Shape);
 		RefreshLayoutOptionsUi();
@@ -1535,6 +1562,38 @@ public partial class SettingsWindow : Window
 		if (OuterEscapeDistanceDescText != null)
 		{
 			OuterEscapeDistanceDescText.Text = I18n.T("OuterEscapeDistanceDesc");
+		}
+		if (VolumeDragTitleText != null)
+		{
+			VolumeDragTitleText.Text = I18n.T("VolumeDragTitle");
+		}
+		if (VolumeDragDescText != null)
+		{
+			VolumeDragDescText.Text = I18n.T("VolumeDragDesc");
+		}
+		if (VolumeCancelRatioLabel != null)
+		{
+			VolumeCancelRatioLabel.Text = I18n.T("VolumeCancelRatioTitle");
+		}
+		if (VolumeCancelRatioDesc != null)
+		{
+			VolumeCancelRatioDesc.Text = I18n.T("VolumeCancelRatioDesc");
+		}
+		if (VolumeFlickFarLabel != null)
+		{
+			VolumeFlickFarLabel.Text = I18n.T("VolumeFlickFarTitle");
+		}
+		if (VolumeFlickFarDesc != null)
+		{
+			VolumeFlickFarDesc.Text = I18n.T("VolumeFlickFarDesc");
+		}
+		if (VolumeFlickJumpLabel != null)
+		{
+			VolumeFlickJumpLabel.Text = I18n.T("VolumeFlickJumpTitle");
+		}
+		if (VolumeFlickJumpDesc != null)
+		{
+			VolumeFlickJumpDesc.Text = I18n.T("VolumeFlickJumpDesc");
 		}
 		if (NewCustomColorPresetButton != null)
 		{
@@ -8206,6 +8265,39 @@ public partial class SettingsWindow : Window
 			double num = Math.Round(e.NewValue);
 			ConfigManager.CurrentConfig.SubWheelTriggerDistance = num;
 			SubWheelTriggerDistanceValueText.Text = $"{num:0} px";
+			ScheduleAutoSave();
+		}
+	}
+
+	private void VolumeCancelRatioSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+	{
+		if (VolumeCancelRatioValueText != null && ConfigManager.CurrentConfig != null && !_isUpdatingUi)
+		{
+			double num = ((e.NewValue >= 0.2) ? e.NewValue : 0.6);
+			ConfigManager.CurrentConfig.VolumeCancelHysteresisRatio = num;
+			VolumeCancelRatioValueText.Text = $"{num * 100.0:0}%";
+			ScheduleAutoSave();
+		}
+	}
+
+	private void VolumeFlickFarSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+	{
+		if (VolumeFlickFarValueText != null && ConfigManager.CurrentConfig != null && !_isUpdatingUi)
+		{
+			double num = Math.Round(e.NewValue);
+			ConfigManager.CurrentConfig.VolumeFlickFarDistance = num;
+			VolumeFlickFarValueText.Text = $"{num:0} px";
+			ScheduleAutoSave();
+		}
+	}
+
+	private void VolumeFlickJumpSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+	{
+		if (VolumeFlickJumpValueText != null && ConfigManager.CurrentConfig != null && !_isUpdatingUi)
+		{
+			double num = Math.Round(e.NewValue);
+			ConfigManager.CurrentConfig.VolumeFlickCancelDistance = num;
+			VolumeFlickJumpValueText.Text = $"{num:0} px";
 			ScheduleAutoSave();
 		}
 	}

--- a/WinPieGestures/SystemVolume.cs
+++ b/WinPieGestures/SystemVolume.cs
@@ -1,0 +1,321 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace WinPieGestures;
+
+/// <summary>
+/// 系统主音量读写（CoreAudio IAudioEndpointVolume）。
+/// 相比向系统注入硬件音量键（单次 ≈±1~2%），这里可直接把主音量连续设置为 0~1 的任意值，即时生效，
+/// 供"拖距调音"（音量加/减扇区按鼠标拖动距离映射音量）使用。
+/// </summary>
+public static class SystemVolume
+{
+	[ComImport]
+	[Guid("BCDE0395-E52F-467C-8E3D-C4579291692E")]
+	private class MMDeviceEnumeratorComObject
+	{
+	}
+
+	[ComImport]
+	[Guid("A95664D2-9614-4F35-A746-DE8DB63617E6")]
+	[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+	private interface IMMDeviceEnumerator
+	{
+		[PreserveSig]
+		int EnumAudioEndpoints(int dataFlow, int dwStateMask, out IMMDeviceCollection ppDevices);
+
+		[PreserveSig]
+		int GetDefaultAudioEndpoint(int dataFlow, int role, out IMMDevice ppDevice);
+
+		[PreserveSig]
+		int GetDevice([MarshalAs(UnmanagedType.LPWStr)] string pwstrId, out IMMDevice ppDevice);
+
+		[PreserveSig]
+		int RegisterEndpointNotificationCallback(IntPtr pClient);
+
+		[PreserveSig]
+		int UnregisterEndpointNotificationCallback(IntPtr pClient);
+	}
+
+	[ComImport]
+	[Guid("0BD7A1BE-7A1A-44DB-8397-CC5392387B5E")]
+	[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+	private interface IMMDeviceCollection
+	{
+	}
+
+	[ComImport]
+	[Guid("D666063F-1587-4E43-81F1-B948E807363F")]
+	[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+	private interface IMMDevice
+	{
+		[PreserveSig]
+		int Activate(ref Guid iid, uint dwClsCtx, IntPtr pActivationParams, out IAudioEndpointVolume ppInterface);
+
+		[PreserveSig]
+		int OpenPropertyStore(uint stgmAccess, IntPtr ppProperties);
+
+		[PreserveSig]
+		int GetId([MarshalAs(UnmanagedType.LPWStr)] out string ppstrId);
+
+		[PreserveSig]
+		int GetState(out uint pdwState);
+	}
+
+	[ComImport]
+	[Guid("5CDF2C82-841E-4546-9722-0CF74078229A")]
+	[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+	private interface IAudioEndpointVolume
+	{
+		[PreserveSig]
+		int RegisterControlChangeNotify(IntPtr pNotify);
+
+		[PreserveSig]
+		int UnregisterControlChangeNotify(IntPtr pNotify);
+
+		[PreserveSig]
+		int GetChannelCount(out uint pnChannelCount);
+
+		[PreserveSig]
+		int SetMasterVolumeLevel(float fLevelDB, IntPtr pguidEventContext);
+
+		[PreserveSig]
+		int SetMasterVolumeLevelScalar(float fLevel, IntPtr pguidEventContext);
+
+		[PreserveSig]
+		int GetMasterVolumeLevel(out float pfLevelDB);
+
+		[PreserveSig]
+		int GetMasterVolumeLevelScalar(out float pfLevel);
+
+		[PreserveSig]
+		int SetChannelVolumeLevel(uint nChannel, float fLevelDB, IntPtr pguidEventContext);
+
+		[PreserveSig]
+		int SetChannelVolumeLevelScalar(uint nChannel, float fLevel, IntPtr pguidEventContext);
+
+		[PreserveSig]
+		int GetChannelVolumeLevel(uint nChannel, out float pfLevelDB);
+
+		[PreserveSig]
+		int GetChannelVolumeLevelScalar(uint nChannel, out float pfLevel);
+
+		[PreserveSig]
+		int SetMute(int bMute, IntPtr pguidEventContext);
+
+		[PreserveSig]
+		int GetMute(out int pbMute);
+
+		[PreserveSig]
+		int SetVolumeStep(IntPtr pguidEventContext);
+
+		[PreserveSig]
+		int GetVolumeStep(out uint pnStep);
+
+		[PreserveSig]
+		int QueryHardwareSupport(out uint pdwHardwareSupportMask);
+
+		[PreserveSig]
+		int GetVolumeRange(out float pflMinVolumeDB, out float pflMaxVolumeDB, out float pflIncrementDB);
+	}
+
+	// Native volume flyout wake-up: inject a system volume key then correct to the exact target.
+	private const uint KEYEVENTF_KEYUP = 2u;
+	private const ushort VK_VOLUME_DOWN = 174;
+	private const ushort VK_VOLUME_UP = 175;
+
+	[DllImport("user32.dll")]
+	private static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, nint dwExtraInfo);
+
+	private static readonly object _endpointLock = new object();
+
+	private static IMMDevice? _device;
+
+	private static IAudioEndpointVolume? _endpointVolume;
+
+	// Set when the endpoint object is built; GetEndpointVolume rebuilds the
+	// COM objects when the system default play device switches.
+	private static string? _endpointId;
+
+	/// <summary>读取系统主音量（0.0~1.0）。失败返回 false。</summary>
+	public static bool TryGetVolume(out float percent)
+	{
+		percent = 0f;
+		IAudioEndpointVolume? volume = GetEndpointVolume();
+		if (volume == null)
+		{
+			return false;
+		}
+		try
+		{
+			if (volume.GetMasterVolumeLevelScalar(out percent) != 0)
+			{
+				ResetEndpoint();
+				return false;
+			}
+			return true;
+		}
+		catch
+		{
+			ResetEndpoint();
+			return false;
+		}
+	}
+
+	/// <summary>设置系统主音量（0.0~1.0，越界自动夹取）。失败返回 false。</summary>
+	public static bool SetVolume(float percent)
+	{
+		float clamped = Math.Clamp(percent, 0f, 1f);
+		IAudioEndpointVolume? volume = GetEndpointVolume();
+		if (volume == null)
+		{
+			return false;
+		}
+		try
+		{
+			if (volume.SetMasterVolumeLevelScalar(clamped, IntPtr.Zero) != 0)
+			{
+				ResetEndpoint();
+				return false;
+			}
+			return true;
+		}
+		catch
+		{
+			ResetEndpoint();
+			return false;
+		}
+	}
+
+	/// <summary>Wake the native volume flyout and correct system volume to the exact target.</summary>
+	/// <remarks>Injecting a system volume key makes the OS pop the volume OSD; the trailing
+	/// SetVolume immediately re-aligns the real volume so the flyout reflects the target.</remarks>
+	public static void ShowOsd(float targetPercent, bool directionUp)
+	{
+		try
+		{
+			ushort vk = directionUp ? VK_VOLUME_UP : VK_VOLUME_DOWN;
+			keybd_event((byte)vk, 0, 0, 0);
+			keybd_event((byte)vk, 0, KEYEVENTF_KEYUP, 0);
+			SetVolume(targetPercent);
+		}
+		catch
+		{
+		}
+	}
+
+	/// <summary>Resolve current default render endpoint id; null on failure.</summary>
+	private static string? ResolveDefaultEndpointId()
+	{
+		try
+		{
+			IMMDeviceEnumerator enumerator = (IMMDeviceEnumerator)(object)new MMDeviceEnumeratorComObject();
+			if (enumerator.GetDefaultAudioEndpoint(0, 0, out IMMDevice device) != 0)
+			{
+				Marshal.ReleaseComObject(enumerator);
+				return null;
+			}
+			string? id = null;
+			try
+			{
+				device.GetId(out string sid);
+				id = sid;
+			}
+			catch
+			{
+			}
+			Marshal.ReleaseComObject(device);
+			Marshal.ReleaseComObject(enumerator);
+			return id;
+		}
+		catch
+		{
+			return null;
+		}
+	}
+
+	private static IAudioEndpointVolume? GetEndpointVolume()
+	{
+		lock (_endpointLock)
+		{
+			string? currentEndpointId = ResolveDefaultEndpointId();
+			if (_endpointVolume != null && currentEndpointId != null && string.Equals(_endpointId, currentEndpointId, StringComparison.OrdinalIgnoreCase))
+			{
+				return _endpointVolume;
+			}
+			// Default play device switched (or first access): rebuild cached endpoint objects
+			if (_endpointVolume != null)
+			{
+				ResetEndpoint();
+			}
+			try
+			{
+				IMMDeviceEnumerator enumerator = (IMMDeviceEnumerator)(object)new MMDeviceEnumeratorComObject();
+				// 默认播放设备 + 控制台角色（eRender/eConsole）
+				if (enumerator.GetDefaultAudioEndpoint(0, 0, out IMMDevice device) != 0)
+				{
+					Marshal.ReleaseComObject(enumerator);
+					return null;
+				}
+				Guid iid = new Guid("5CDF2C82-841E-4546-9722-0CF74078229A");
+				// CLSCTX_ALL = 23
+				if (device.Activate(ref iid, 23u, IntPtr.Zero, out IAudioEndpointVolume volume) != 0)
+				{
+					Marshal.ReleaseComObject(device);
+					Marshal.ReleaseComObject(enumerator);
+					return null;
+				}
+				_device = device;
+				_endpointVolume = volume;
+				Marshal.ReleaseComObject(enumerator);
+				string dbgEndpointId = "(unknown)";
+				try
+				{
+					if (device.GetId(out string dbgSid) == 0)
+					{
+						dbgEndpointId = dbgSid;
+					}
+				}
+				catch
+				{
+				}
+				_endpointId = dbgEndpointId;
+				return volume;
+			}
+			catch
+			{
+				return null;
+			}
+		}
+	}
+
+	private static void ResetEndpoint()
+	{
+		lock (_endpointLock)
+		{
+			_endpointId = null;
+			if (_endpointVolume != null)
+			{
+				try
+				{
+					Marshal.ReleaseComObject(_endpointVolume);
+				}
+				catch
+				{
+				}
+				_endpointVolume = null;
+			}
+			if (_device != null)
+			{
+				try
+				{
+					Marshal.ReleaseComObject(_device);
+				}
+				catch
+				{
+				}
+				_device = null;
+			}
+		}
+	}
+}


### PR DESCRIPTION
背景 / 目的
长按音量加/减扇区向外拖动时，希望像专业工具一样按拖出距离连续调音量，且甩出/顶到上下限能取消恢复、取消后原路返回还能接着调。
实现
新增 SystemVolume.cs：CoreAudio IAudioEndpointVolume 直接读写主音量（0~1），替代逐帧注入音量多媒体键。
GestureController 音量状态机：拖距线性映射 0~100%；缩回中心迟滞 / 外甩 / 超程三类取消均恢复基准音量；取消锁存后指针返回 2× 触发半径内自动重新武装，重进用动态基线避免跳变。
RadialWindow 中心音量 OSD；AppConfig + SettingsWindow 三个阈值可实时调节，含中/繁/英/日 I18n 翻译。
测试
本地 dotnet build -c Release 0 error。
python -m pytest tests/test_settings.py：音量相关用例通过；整套连跑有 1–2 项 flaky（profile 按钮查找、真联网"检查更新"时序），单独重跑即绿，与本改动无交集。


https://github.com/user-attachments/assets/228f0e2e-a0c9-4555-b559-b2fe7704097e
<img width="889" height="169" alt="image" src="https://github.com/user-attachments/assets/928f80e7-fc16-4b23-96f4-41987ad7b410" />


