### PR TITLE
fix: 键盘触发键改为穿透模式，轻点完全还原原生输入

### DIFF
--- a/WinPieGestures/GestureController.cs
+++ b/WinPieGestures/GestureController.cs
@@ -43,6 +43,16 @@ public class GestureController
 
 	private bool _mouseTriggerDown;
 
+	// ---- 键盘触发穿透模式 ----
+	// 触发键 KeyDown/KeyUp 一律原生放行，仅用持握时长+拖动阈值唤出轮盘。
+	// _kbTriggerWaiting 区分"键盘触发正在等待阈值"与鼠标触发的等待态（后者仍需吞键）。
+	private volatile bool _kbTriggerWaiting;
+
+	// 触发键按下时刻（Environment.TickCount64），用于 200ms 持握门槛，防止快速敲击+甩动误唤轮盘。
+	private long _kbTriggerDownTick;
+
+	private const int KeyboardTriggerMinHoldMs = 200;
+
 	// ---- 鼠标手势（画轨迹识别；延迟分段缓冲：短段过滤 + 相邻同向合并 + 完全匹配才触发）----
 	private bool _gestureMode;
 
@@ -148,6 +158,7 @@ public class GestureController
 
 	private void CancelGestureTracking()
 	{
+		_kbTriggerWaiting = false;
 		lock (_uiUpdateSync)
 		{
 			_gestureVersion++;
@@ -1013,9 +1024,21 @@ public class GestureController
 		ModifierKeys modifiers = e.Modifiers;
 		if ((!triggerConfig.RequireCtrl || ((((int)modifiers & 2))) != 0) && (!triggerConfig.RequireShift || ((((int)modifiers & 4))) != 0) && (!triggerConfig.RequireAlt || ((((int)modifiers & 1))) != 0) && (!triggerConfig.RequireWin || ((((int)modifiers & 8))) != 0) && (triggerConfig.VkCode == 0 || IsModifierKey(triggerConfig.VkCode) || e.VkCode == triggerConfig.VkCode))
 		{
-			if (_isWaitingForThreshold || _isGestureActive)
+			if (_isGestureActive)
 			{
+				// 轮盘激活期间吞掉触发键的自动重复，防止连发漏进前台应用。
 				e.Handled = true;
+				return;
+			}
+			if (_isWaitingForThreshold && !_kbTriggerWaiting)
+			{
+				// 鼠标触发正在等待阈值，保持原有吞键语义。
+				e.Handled = true;
+				return;
+			}
+			if (_kbTriggerWaiting)
+			{
+				// 键盘触发等待期（含自动重复）：穿透放行，原生输入零干扰。
 				return;
 			}
 			if (CheckIsIsolated(out string _))
@@ -1034,7 +1057,9 @@ public class GestureController
 			BeginGestureTracking();
 			_isWaitingForThreshold = true;
 			_isGestureActive = false;
-			e.Handled = true;
+			_kbTriggerWaiting = true;
+			_kbTriggerDownTick = Environment.TickCount64;
+			// 穿透模式：不吞键，原生 KeyDown 立即到达前台应用。
 		}
 	}
 
@@ -1072,25 +1097,17 @@ public class GestureController
 		}
 		if (_isWaitingForThreshold)
 		{
+			// 穿透模式：轻点（未达拖动阈值）时 Down/Up 均已原生放行，
+			// 直接取消跟踪即可，无需吞键补发。
 			CancelGestureTracking();
 			_isWaitingForThreshold = false;
-			uint vk = ((triggerConfig.VkCode != 0) ? triggerConfig.VkCode : e.VkCode);
-			((DispatcherObject)Application.Current).Dispatcher.BeginInvoke((Delegate)(Action)delegate
-			{
-				_keyboardHook?.ReplayKeyPress(vk);
-			}, DispatcherPriority.Normal, Array.Empty<object>());
-			e.Handled = true;
 		}
 		else
 		{
 			if (!_isGestureActive)
 			{
-				uint vk = ((triggerConfig.VkCode != 0) ? triggerConfig.VkCode : e.VkCode);
-				((DispatcherObject)Application.Current).Dispatcher.BeginInvoke((Delegate)(Action)delegate
-				{
-					_keyboardHook?.ReplayKeyPress(vk);
-				}, DispatcherPriority.Normal, Array.Empty<object>());
-				e.Handled = true;
+				// 穿透模式：无手势进行，Down 从未被吞，KeyUp 原生放行。
+				_kbTriggerWaiting = false;
 				return;
 			}
 			var finalState = EndActiveGesture();
@@ -1146,7 +1163,9 @@ public class GestureController
 					ActionExecutor.EnqueueAction(targetAction);
 				}
 			}, DispatcherPriority.Normal, Array.Empty<object>());
-			e.Handled = true;
+			// 穿透模式：激活前的 Down 已原生放行，KeyUp 放行与其配对，
+			// 避免前台应用按键状态卡死。
+			e.Handled = false;
 		}
 	}
 
@@ -1197,6 +1216,13 @@ public class GestureController
 			double dragThreshold = ConfigManager.CurrentConfig.DragThreshold;
 			if (num3 >= dragThreshold * dragThreshold)
 			{
+				if (_kbTriggerWaiting && Environment.TickCount64 - _kbTriggerDownTick < KeyboardTriggerMinHoldMs)
+				{
+					// 穿透模式持握门槛：触发键按下未满 200ms 不唤出轮盘，
+					// 快速敲击/甩动按普通按键处理；位移持续累积，满门槛后自然激活。
+					return;
+				}
+				_kbTriggerWaiting = false;
 				_isWaitingForThreshold = false;
 				_isGestureActive = true;
 				CancelLongPressTimer(); // 拖动先于长按触发
@@ -1227,6 +1253,7 @@ public class GestureController
 						AppLogger.LogError("ShowRadialUI failed in Hook_OnMouseMove", ex);
 						_isWaitingForThreshold = true;
 						_isGestureActive = false;
+						_kbTriggerWaiting = false;
 					}
 				}, DispatcherPriority.Normal, Array.Empty<object>());
 			}


### PR DESCRIPTION
## 背景

键盘触发键（空格/Tab/回车/退格/方向键等）原实现为"吞键-补发"：按下时吞掉原生
KeyDown 进入等待，未成手势时在松开后经 Dispatcher 异步 SendInput 补发一对 Down/Up。该架构存在若干不可修的固有缺陷：

1. 轻点有可感知延迟，且补发与用户后续按键存在竞态（快速打字时乱序/丢字）；
2. 补发经 SendInput 注入，在管理员权限程序中受 UIPI 拦截静默失败；
3. 注入键对 raw input 类游戏不可见；
4. 补发路径异常时产生孤儿 Down/Up，前台应用按键状态卡死；
5. 上游 v1.7.1-beta9 仅增加"建议避免常用按键绑定为触发按键"的文字提示， 未在代码层面解决。

## 修改内容

仅改 `WinPieGestures/GestureController.cs`（+42/−15），KeyboardHook.cs 与 ActionExecutor.cs 零改动：

1. **KeyDown 全原生放行**：触发键 KeyDown 不再吞键，立即到达前台应用； 同时记录 `_startPoint`/按下时刻进入等待态（`_kbTriggerWaiting`）。
2. **200ms 持握门槛**：按下未满 200ms 不唤出轮盘，快速敲击/甩动按普通 按键处理；位移持续累积，满门槛后拖动超阈值自然激活（`KeyboardTriggerMinHoldMs`）。
3. **等待期自动重复放行**：键盘触发等待期的重复 KeyDown 穿透，长按打字 连发不丢；鼠标触发等待态保持原吞键语义不变。
4. **KeyUp 全原生放行**：等待期轻点直接取消跟踪，删除两处 `ReplayKeyPress` 补发调用；轮盘激活态松开仍走原"结束手势→执行扇区动作"链路，仅将 KeyUp 由吞改为放行，与已放行的 Down 配对，避免前台按键状态卡死。
5. **轮盘激活期间仍吞触发键自动重复**（原语义保留），防止连发漏进前台应用。

被根治的缺陷类：补发竞态乱序、UIPI 静默失败、raw input 不可见、孤儿 Up、
钩子线程内 SendInput 互卡导致的轻点无反应。已知代价：轮盘唤出瞬间该键已
原生生效一次（用户已接受）。

## 验证

- `dotnet build -c Release` 0 错误 0 警告（无运行实例锁时直接构建； 本机验证时因旧实例占用输出改用独立输出目录，编译结果一致）。
- 手工验收清单（8 项）：
1. 空格/回车/Tab/退格/方向键绑定触发键，轻点 → 原生功能立即生效；
2. 连续打字夹空格 → 无丢字乱序；
3. 管理员权限程序内轻点 → 原生生效；
4. 持握 ≥200ms 拖动 → 轮盘唤出，选扇区松开 → 动作执行；
5. 轮盘激活期间按住触发键 → 前台无连发；
6. 持握 <200ms 快速甩动 → 不唤轮盘；
7. 鼠标触发回归：长按拖动、轻点回放不受影响；
8. 多层方案 Tab 层切换键照常工作。

## AI 自查声明

本 PR 由 AI 辅助完成，已完成以下自查：确认改动仅涉及 GestureController.cs 且不触碰 KeyboardHook/ActionExecutor 公共接口；确认 v1.7.1-beta8 的 HotkeyStep 步进引擎与按键注入链路（SendInput 均带 StarPieExtraInfo 标记、 钩子回调 423–430 行对注入键先行放行）与本改动无耦合；确认 `ReplayKeyPress` 成为无调用点的保留方法；确认鼠标触发、层切换、长按定时器路径未被改动。
自查报告如下
| 检查项 | 结果 |
| --- | --- |
| 改动文件范围 | 仅 GestureController.cs (+42/−15) |
| 构建结果 | 0 错误 / 0 警告 |
| KeyboardHook.cs / ActionExecutor.cs | 未改动 |
| 鼠标触发路径回归 | 逻辑未触碰 |
| 层切换 / 长按定时器 | 逻辑未触碰 |
| 触发键 Down/Up 配对 | 全原生，无补发 |