### PR TITLE
ci: 完善 Beta 预发布识别与 Release 自动清理策略

### DIFF
--- a/.github/workflows/release-retention.yml
+++ b/.github/workflows/release-retention.yml
@@ -1,0 +1,115 @@
+name: Clean Up Beta Releases
+
+on:
+  schedule:
+    # Every Sunday at 04:00 UTC (12:00 Asia/Hong_Kong).
+    - cron: '0 4 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-retention
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Retain Final Beta After Stable Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Remove superseded beta releases
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          $releaseJson = (& gh release list --repo $env:GH_REPO --limit 1000 --json tagName,isDraft,isPrerelease,publishedAt | Out-String)
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to list GitHub releases (exit code $LASTEXITCODE)"
+          }
+
+          $releases = @($releaseJson | ConvertFrom-Json)
+          $cutoff = [DateTimeOffset]::UtcNow.AddDays(-7)
+          $stablePattern = '^v(?<baseVersion>\d+\.\d+\.\d+)$'
+          $eligibleStableCount = 0
+          $deletedCount = 0
+          $failures = [System.Collections.Generic.List[string]]::new()
+          $summaryLines = [System.Collections.Generic.List[string]]::new()
+          $summaryLines.Add("## Beta release retention")
+          $summaryLines.Add("")
+          $summaryLines.Add("Cutoff: $($cutoff.ToString('u'))")
+          $summaryLines.Add("")
+
+          $stableReleases = @($releases | Where-Object {
+            -not $_.isDraft -and
+            -not $_.isPrerelease -and
+            $_.tagName -match $stablePattern -and
+            -not [string]::IsNullOrWhiteSpace($_.publishedAt)
+          })
+
+          foreach ($stable in $stableReleases) {
+            $stableMatch = [regex]::Match($stable.tagName, $stablePattern)
+            if (-not $stableMatch.Success) {
+              continue
+            }
+
+            $publishedAt = [DateTimeOffset]::Parse($stable.publishedAt).ToUniversalTime()
+            if ($publishedAt -gt $cutoff) {
+              continue
+            }
+
+            $eligibleStableCount++
+            $baseVersion = $stableMatch.Groups['baseVersion'].Value
+            $betaPattern = "^v$([regex]::Escape($baseVersion))-beta\.(?<number>\d+)$"
+            $betaReleases = [System.Collections.Generic.List[object]]::new()
+
+            foreach ($release in $releases) {
+              if ($release.isDraft -or -not $release.isPrerelease) {
+                continue
+              }
+
+              $betaMatch = [regex]::Match($release.tagName, $betaPattern)
+              if ($betaMatch.Success) {
+                $betaReleases.Add([pscustomobject]@{
+                  TagName = $release.tagName
+                  Number = [long]$betaMatch.Groups['number'].Value
+                })
+              }
+            }
+
+            $orderedBetas = @($betaReleases | Sort-Object Number -Descending)
+            if ($orderedBetas.Count -eq 0) {
+              $summaryLines.Add("- $($stable.tagName): no matching beta releases")
+              continue
+            }
+
+            $finalBeta = $orderedBetas[0]
+            $summaryLines.Add("- $($stable.tagName): retained final beta $($finalBeta.TagName)")
+
+            foreach ($beta in @($orderedBetas | Select-Object -Skip 1)) {
+              Write-Host "Deleting beta release $($beta.TagName); Git tag will be retained."
+              & gh release delete $beta.TagName --repo $env:GH_REPO --yes
+              if ($LASTEXITCODE -eq 0) {
+                $deletedCount++
+                $summaryLines.Add("  - Deleted release $($beta.TagName); retained tag")
+              }
+              else {
+                $failures.Add($beta.TagName)
+                $summaryLines.Add("  - Failed to delete release $($beta.TagName)")
+              }
+            }
+          }
+
+          if ($eligibleStableCount -eq 0) {
+            $summaryLines.Add("No stable releases have been published for at least 7 days.")
+          }
+
+          $summaryLines.Add("")
+          $summaryLines.Add("Deleted beta releases: $deletedCount")
+          $summaryLines | Add-Content $env:GITHUB_STEP_SUMMARY
+
+          if ($failures.Count -gt 0) {
+            throw "Failed to delete beta releases: $($failures -join ', ')"
+          }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,22 +37,27 @@ jobs:
         shell: pwsh
         run: |
           $tag = $env:GITHUB_REF_NAME
-          if ($tag -notmatch '^v(?<baseVersion>\d+\.\d+\.\d+)(?<prerelease>-beta\d+)?$') {
-            throw "Release tag must use vX.Y.Z or vX.Y.Z-betaN format: $tag"
+          if ($tag -notmatch '^v(?<baseVersion>\d+\.\d+\.\d+)(?<prerelease>-beta\.\d+)?$') {
+            throw "Release tag must use vX.Y.Z or vX.Y.Z-beta.N format: $tag"
           }
 
           $baseVersion = $Matches.baseVersion
           $prereleaseSuffix = $Matches.prerelease
-          $expectedProjectVersion = "${baseVersion}${prereleaseSuffix}"
           $expectedFourPartVersion = "${baseVersion}.0"
           [xml]$project = Get-Content "WinPieGestures/WinPieGestures.csproj"
 
           $projectVersion = [string]$project.Project.PropertyGroup.Version
+          $projectBaseVersion = ($projectVersion -split '-', 2)[0]
           $assemblyVersion = [string]$project.Project.PropertyGroup.AssemblyVersion
           $fileVersion = [string]$project.Project.PropertyGroup.FileVersion
 
-          if ($projectVersion -ne $expectedProjectVersion) {
-            throw "Version mismatch: tag=$expectedProjectVersion Version=$projectVersion"
+          if ([string]::IsNullOrEmpty($prereleaseSuffix)) {
+            if ($projectVersion -ne $baseVersion) {
+              throw "Version mismatch: stable tag=$baseVersion Version=$projectVersion"
+            }
+          }
+          elseif ($projectBaseVersion -ne $baseVersion) {
+            throw "Version mismatch: beta tag base=$baseVersion Version=$projectVersion"
           }
           if ($assemblyVersion -ne $expectedFourPartVersion) {
             throw "AssemblyVersion mismatch: expected=$expectedFourPartVersion actual=$assemblyVersion"
@@ -132,7 +137,7 @@ jobs:
           $releaseArguments += $assets
           $releaseArguments += @("--verify-tag", "--generate-notes", "--title", "StarPie $env:GITHUB_REF_NAME")
 
-          if ($env:GITHUB_REF_NAME -match '^v\d+\.\d+\.\d+-beta\d+$') {
+          if ($env:GITHUB_REF_NAME -match '^v\d+\.\d+\.\d+-beta\.\d+$') {
             $releaseArguments += "--prerelease"
             Write-Host "Publishing GitHub pre-release: $env:GITHUB_REF_NAME"
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,3 +146,61 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
             throw "GitHub Release creation failed with exit code $LASTEXITCODE"
           }
+
+      - name: Retain latest three beta releases
+        if: ${{ contains(github.ref_name, '-beta.') }}
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          if ($env:GITHUB_REF_NAME -notmatch '^v(?<baseVersion>\d+\.\d+\.\d+)-beta\.\d+$') {
+            throw "Unexpected beta tag format: $env:GITHUB_REF_NAME"
+          }
+
+          $baseVersion = $Matches.baseVersion
+          $betaPattern = "^v$([regex]::Escape($baseVersion))-beta\.(?<number>\d+)$"
+          $releaseJson = (& gh release list --repo $env:GH_REPO --limit 1000 --json tagName,isDraft,isPrerelease | Out-String)
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to list GitHub releases (exit code $LASTEXITCODE)"
+          }
+
+          $releases = @($releaseJson | ConvertFrom-Json)
+          $betaReleases = [System.Collections.Generic.List[object]]::new()
+
+          foreach ($release in $releases) {
+            if ($release.isDraft -or -not $release.isPrerelease) {
+              continue
+            }
+
+            $betaMatch = [regex]::Match($release.tagName, $betaPattern)
+            if ($betaMatch.Success) {
+              $betaReleases.Add([pscustomobject]@{
+                TagName = $release.tagName
+                Number = [long]$betaMatch.Groups['number'].Value
+              })
+            }
+          }
+
+          $orderedBetas = @($betaReleases | Sort-Object Number -Descending)
+          $retainedBetas = @($orderedBetas | Select-Object -First 3)
+          $expiredBetas = @($orderedBetas | Select-Object -Skip 3)
+
+          Write-Host "Retaining beta releases: $($retainedBetas.TagName -join ', ')"
+          if ($expiredBetas.Count -eq 0) {
+            Write-Host "No superseded beta releases need to be deleted."
+            exit 0
+          }
+
+          $failures = [System.Collections.Generic.List[string]]::new()
+          foreach ($beta in $expiredBetas) {
+            Write-Host "Deleting beta release $($beta.TagName); Git tag will be retained."
+            & gh release delete $beta.TagName --repo $env:GH_REPO --yes
+            if ($LASTEXITCODE -ne 0) {
+              $failures.Add($beta.TagName)
+            }
+          }
+
+          if ($failures.Count -gt 0) {
+            throw "Failed to delete beta releases: $($failures -join ', ')"
+          }


### PR DESCRIPTION
# ci: 完善 Beta 预发布识别与 Release 自动清理策略

## 修改概述

本 PR 汇总最近两个 CI 提交，完善 StarPie 的 Beta 预发布流程与 Release 生命周期管理：

1. 将 Beta 标签统一调整为 `vX.Y.Z-beta.N` 格式，并优化版本一致性校验
2. 为 Beta Release 增加分阶段自动清理策略，控制历史预发布附件数量，同时保留 Git Tag 以便追溯

## Beta 标签格式

工作流现在支持：

- 正式版本：`vX.Y.Z`
- Beta 版本：`vX.Y.Z-beta.N`

示例：

- `v1.7.1`
- `v1.7.1-beta.1`
- `v1.7.1-beta.10`

以下格式不会被识别为有效 Beta 发布标签：

- `v1.7.1-beta1`
- `v1.7.1-beta`
- `v1.7.1.dev1`
- `1.7.1-beta.1`

## 版本一致性校验

### 正式版本

正式标签仍要求项目 `Version` 完全一致。

例如标签为 `v1.7.1` 时，要求：

    <Version>1.7.1</Version>
    <AssemblyVersion>1.7.1.0</AssemblyVersion>
    <FileVersion>1.7.1.0</FileVersion>

带有预发布后缀的项目不能通过正式版本校验，避免将 Beta 程序误发布为稳定版。

### Beta 版本

Beta 标签只要求项目 `Version` 的 `X.Y.Z` 主版本一致，不要求 Beta 序号完全相同。

例如标签为 `v1.7.1-beta.10` 时，以下项目版本均可通过主版本校验：

- `1.7.1`
- `1.7.1-beta.1`
- `1.7.1-beta.10`
- 其他主版本为 `1.7.1` 的预发布版本

以下版本不能通过：

- `1.7.0-beta.10`
- `1.7.2-beta.10`
- `2.0.0`

`AssemblyVersion` 和 `FileVersion` 仍需要严格匹配标签主版本：

    <AssemblyVersion>1.7.1.0</AssemblyVersion>
    <FileVersion>1.7.1.0</FileVersion>

## GitHub Pre-release 创建

当标签匹配 `vX.Y.Z-beta.N` 时，发布工作流会向 GitHub CLI 添加 `--prerelease` 参数。

因此：

- `v1.7.1` 创建普通 GitHub Release
- `v1.7.1-beta.10` 创建 GitHub Pre-release

现有的发布安全检查保持不变，标签仍必须指向当前 `origin/main` 的最新提交。

## Beta 发布阶段的保留策略

每次成功创建新的 Beta Release 后，`.github/workflows/release.yml` 会：

1. 查询相同 `X.Y.Z` 下的全部 Beta Pre-release
2. 排除正式版和 Draft Release
3. 提取 `beta.N` 中的数字序号
4. 按数字从大到小排序
5. 保留最近3个 Beta Release
6. 删除更早的 Beta Release 及其附件
7. 保留所有对应的 Git Tag

例如发布 `v1.7.1-beta.10` 后，存在：

- `v1.7.1-beta.1`
- `v1.7.1-beta.2`
- `v1.7.1-beta.8`
- `v1.7.1-beta.9`
- `v1.7.1-beta.10`

工作流将保留：

- `v1.7.1-beta.10`
- `v1.7.1-beta.9`
- `v1.7.1-beta.8`

并删除以下 Release 及其附件：

- `v1.7.1-beta.2`
- `v1.7.1-beta.1`

对应 Git Tag 不会被删除。

## 正式版发布后的保留策略

新增 `.github/workflows/release-retention.yml`，用于在正式版发布后进一步清理相同版本系列的 Beta Release。

处理流程：

1. 查询所有 GitHub Release
2. 查找符合 `vX.Y.Z` 格式的正式 Release
3. 根据 `publishedAt` 判断正式版是否发布满7天
4. 查找相同 `X.Y.Z` 下的所有 `vX.Y.Z-beta.N`
5. 保留 Beta 数字最大的最终 Beta Release
6. 删除其余 Beta Release 及其附件
7. 保留所有对应 Git Tag

例如正式版 `v1.7.1` 发布满7天后，存在：

- `v1.7.1-beta.8`
- `v1.7.1-beta.9`
- `v1.7.1-beta.10`

工作流最终只保留：

- `v1.7.1-beta.10`

并删除：

- `v1.7.1-beta.8`
- `v1.7.1-beta.9`

## 定时和手动执行

Release 保留工作流每周执行一次：

同时保留 `workflow_dispatch` 手动执行入口，可以从 GitHub Actions 页面主动运行。

手动运行不会绕过7天限制，仍然只处理已经发布满7天的正式版本。

由于每周检查一次，Beta 的实际保留时间约为7至14天。

## 清理安全限制

自动清理仅处理同时满足以下条件的 Release：

- Release 被标记为 Pre-release
- Release 不是 Draft
- 标签严格符合 `vX.Y.Z-beta.N`
- Beta 的 `X.Y.Z` 与当前处理的正式版本一致

因此处理 `v1.7.1-beta.N` 时不会影响：

- `v1.7.0-beta.N`
- `v1.7.2-beta.N`
- 正式 Release
- Draft Release
- 其他标签格式的 Release

## Git Tag 保留策略

清理命令不会使用 `--cleanup-tag`。

自动清理只会删除：

- GitHub Release
- Lightweight ZIP
- Standalone ZIP
- SHA256 校验文件
- Release 下的其他附件

不会删除：

- Git Tag
- 标签指向的提交
- Git 提交历史
- 对应版本的源码定位

旧 Beta 的二进制附件被清理后，仍然可以通过 Git Tag 查看、比较或重新构建对应源码。

## 失败处理

如果 Release 列表获取失败，工作流会立即停止并报告错误。

删除多个旧 Beta 时会收集失败项；如果存在删除失败的 Release，工作流会列出对应标签并标记为失败。

新 Beta Release 会在清理步骤之前创建。因此旧版本清理失败时：

- 新 Beta 已经成功发布
- 旧 Beta 可能暂时继续保留
- 工作流会明确显示清理阶段失败
- 不会回滚或误删新发布版本

## 定时清理摘要

定时清理工作流会向 GitHub Actions Step Summary 写入：

- 本次清理截止时间
- 已发布满7天的正式版本
- 每个正式版保留的最终 Beta
- 已删除的旧 Beta Release
- 删除失败的 Beta Release
- 本次删除数量

如果没有正式版本发布满7天，也会明确记录本次无需清理。

## 修改文件

- `.github/workflows/release.yml`
- `.github/workflows/release-retention.yml`