### PR TITLE
fix: 完善更新器的预发布版本比较策略

### DIFF
--- a/WinPieGestures/UpdateManager.cs
+++ b/WinPieGestures/UpdateManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -15,11 +16,122 @@ using System.Xml.Linq;
 
 namespace WinPieGestures;
 
+internal sealed class ReleaseVersion : IComparable<ReleaseVersion>
+{
+	private readonly string[] _prereleaseIdentifiers;
+
+	private ReleaseVersion(int major, int minor, int patch, string[] prereleaseIdentifiers)
+	{
+		Major = major;
+		Minor = minor;
+		Patch = patch;
+		_prereleaseIdentifiers = prereleaseIdentifiers;
+	}
+
+	public int Major { get; }
+	public int Minor { get; }
+	public int Patch { get; }
+	public bool IsPrerelease => _prereleaseIdentifiers.Length > 0;
+	public Version CoreVersion => new Version(Major, Minor, Patch);
+
+	public static bool TryParse(string? value, out ReleaseVersion? version)
+	{
+		version = null;
+		if (string.IsNullOrWhiteSpace(value)) return false;
+
+		string clean = value.Trim().TrimStart('v', 'V');
+		int metadataIndex = clean.IndexOf('+');
+		if (metadataIndex >= 0) clean = clean.Substring(0, metadataIndex);
+
+		string[] versionParts = clean.Split(new[] { '-' }, 2, StringSplitOptions.None);
+		string[] coreParts = versionParts[0].Split('.');
+		if (coreParts.Length != 3 ||
+			!int.TryParse(coreParts[0], NumberStyles.None, CultureInfo.InvariantCulture, out int major) ||
+			!int.TryParse(coreParts[1], NumberStyles.None, CultureInfo.InvariantCulture, out int minor) ||
+			!int.TryParse(coreParts[2], NumberStyles.None, CultureInfo.InvariantCulture, out int patch))
+		{
+			return false;
+		}
+
+		string[] prereleaseIdentifiers = Array.Empty<string>();
+		if (versionParts.Length == 2)
+		{
+			if (string.IsNullOrWhiteSpace(versionParts[1])) return false;
+			prereleaseIdentifiers = versionParts[1].Split('.');
+			if (prereleaseIdentifiers.Any(string.IsNullOrWhiteSpace)) return false;
+		}
+
+		version = new ReleaseVersion(major, minor, patch, prereleaseIdentifiers);
+		return true;
+	}
+
+	public static ReleaseVersion FromAssemblyVersion(Version version)
+	{
+		return new ReleaseVersion(
+			Math.Max(version.Major, 0),
+			Math.Max(version.Minor, 0),
+			Math.Max(version.Build, 0),
+			Array.Empty<string>());
+	}
+
+	public int CompareTo(ReleaseVersion? other)
+	{
+		if (other == null) return 1;
+
+		int comparison = Major.CompareTo(other.Major);
+		if (comparison == 0) comparison = Minor.CompareTo(other.Minor);
+		if (comparison == 0) comparison = Patch.CompareTo(other.Patch);
+		if (comparison != 0) return comparison;
+
+		if (!IsPrerelease && !other.IsPrerelease) return 0;
+		if (!IsPrerelease) return 1;
+		if (!other.IsPrerelease) return -1;
+
+		int sharedLength = Math.Min(_prereleaseIdentifiers.Length, other._prereleaseIdentifiers.Length);
+		for (int i = 0; i < sharedLength; i++)
+		{
+			string left = _prereleaseIdentifiers[i];
+			string right = other._prereleaseIdentifiers[i];
+			bool leftIsNumber = long.TryParse(left, NumberStyles.None, CultureInfo.InvariantCulture, out long leftNumber);
+			bool rightIsNumber = long.TryParse(right, NumberStyles.None, CultureInfo.InvariantCulture, out long rightNumber);
+
+			if (leftIsNumber && rightIsNumber)
+			{
+				comparison = leftNumber.CompareTo(rightNumber);
+			}
+			else if (leftIsNumber)
+			{
+				comparison = -1;
+			}
+			else if (rightIsNumber)
+			{
+				comparison = 1;
+			}
+			else
+			{
+				comparison = string.Compare(left, right, StringComparison.OrdinalIgnoreCase);
+			}
+
+			if (comparison != 0) return comparison;
+		}
+
+		return _prereleaseIdentifiers.Length.CompareTo(other._prereleaseIdentifiers.Length);
+	}
+
+	public override string ToString()
+	{
+		string core = $"{Major}.{Minor}.{Patch}";
+		return IsPrerelease ? $"{core}-{string.Join(".", _prereleaseIdentifiers)}" : core;
+	}
+}
+
 public class ReleaseInfo
 {
 	public string TagName { get; set; } = "";
 
 	public Version? ParsedVersion { get; set; }
+
+	internal ReleaseVersion? ComparableVersion { get; set; }
 
 	public string Title { get; set; } = "";
 
@@ -105,6 +217,21 @@ public class UpdateManager
 		return Assembly.GetExecutingAssembly().GetName().Version ?? new Version(1, 6, 8);
 	}
 
+	private ReleaseVersion GetCurrentReleaseVersion()
+	{
+		Assembly assembly = Assembly.GetExecutingAssembly();
+		string? informationalVersion = assembly
+			.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+			.InformationalVersion;
+
+		if (ReleaseVersion.TryParse(informationalVersion, out ReleaseVersion? parsedVersion) && parsedVersion != null)
+		{
+			return parsedVersion;
+		}
+
+		return ReleaseVersion.FromAssemblyVersion(GetCurrentVersion());
+	}
+
 	public string GetProxiedDownloadUrl(string rawUrl, string proxySource, string customProxy = "")
 	{
 		if (string.IsNullOrWhiteSpace(rawUrl)) return "";
@@ -167,7 +294,7 @@ public class UpdateManager
 							ReleaseInfo? rel = ParseReleaseElement(item);
 							if (rel == null) continue;
 
-							if (bestRelease == null || (rel.ParsedVersion != null && bestRelease.ParsedVersion != null && rel.ParsedVersion > bestRelease.ParsedVersion))
+							if (IsBetterRelease(rel, bestRelease))
 							{
 								bestRelease = rel;
 							}
@@ -177,7 +304,7 @@ public class UpdateManager
 					else if (root.ValueKind == JsonValueKind.Object)
 					{
 						ReleaseInfo? rel = ParseReleaseElement(root);
-						if (rel != null) return rel;
+						if (rel != null && (isBetaChannel || !rel.IsPrerelease)) return rel;
 					}
 				}
 				catch (Exception ex)
@@ -266,7 +393,7 @@ public class UpdateManager
 			if (entries == null) return null;
 
 			ReleaseInfo? bestRelease = null;
-			Version currentVer = GetCurrentVersion();
+			ReleaseVersion currentVer = GetCurrentReleaseVersion();
 
 			foreach (var entry in entries)
 			{
@@ -297,10 +424,12 @@ public class UpdateManager
 
 				if (string.IsNullOrEmpty(tag)) continue;
 
-				Version? parsedVer = ParseVersionFromTag(tag);
-				if (parsedVer == null) continue;
+				ReleaseVersion? releaseVersion = ParseReleaseVersionFromTag(tag);
+				if (releaseVersion == null) continue;
+				Version parsedVer = releaseVersion.CoreVersion;
 
-				bool isPrerelease = tag.Contains("beta", StringComparison.OrdinalIgnoreCase) ||
+				bool isPrerelease = releaseVersion.IsPrerelease ||
+					tag.Contains("beta", StringComparison.OrdinalIgnoreCase) ||
 									tag.Contains("alpha", StringComparison.OrdinalIgnoreCase) ||
 									tag.Contains("rc", StringComparison.OrdinalIgnoreCase) ||
 									title.Contains("beta", StringComparison.OrdinalIgnoreCase) ||
@@ -319,23 +448,24 @@ public class UpdateManager
 				string body = ConvertHtmlToMarkdown(contentHtml);
 
 				string htmlUrl = $"https://github.com/{RepoOwner}/{RepoName}/releases/tag/{tag}";
-				bool isNewer = parsedVer > currentVer;
+				bool isNewer = releaseVersion.CompareTo(currentVer) > 0;
 
 				var rel = new ReleaseInfo
 				{
 					TagName = tag,
 					ParsedVersion = parsedVer,
+					ComparableVersion = releaseVersion,
 					Title = string.IsNullOrWhiteSpace(title) ? tag : title,
 					Body = body,
 					PublishedAt = publishedAt != default ? publishedAt : DateTime.Now,
-					IsPrerelease = isPrerelease,
+					IsPrerelease = isPrerelease || releaseVersion?.IsPrerelease == true,
 					HtmlUrl = htmlUrl,
 					IsNewerVersion = isNewer,
 					StandaloneAssetUrl = $"https://github.com/{RepoOwner}/{RepoName}/releases/download/{tag}/StarPie-{tag}-Standalone-win-x64.zip",
 					LightweightAssetUrl = $"https://github.com/{RepoOwner}/{RepoName}/releases/download/{tag}/StarPie-{tag}-Lightweight-win-x64.zip"
 				};
 
-				if (bestRelease == null || (rel.ParsedVersion != null && bestRelease.ParsedVersion != null && rel.ParsedVersion > bestRelease.ParsedVersion))
+				if (IsBetterRelease(rel, bestRelease))
 				{
 					bestRelease = rel;
 				}
@@ -369,18 +499,20 @@ public class UpdateManager
 
 	private ReleaseInfo CreateSynthesizedReleaseInfo(string tag, string sourceTitle)
 	{
-		Version? parsedVer = ParseVersionFromTag(tag);
-		Version currentVer = GetCurrentVersion();
-		bool isNewer = parsedVer != null && parsedVer > currentVer;
+		ReleaseVersion? releaseVersion = ParseReleaseVersionFromTag(tag);
+		Version? parsedVer = releaseVersion?.CoreVersion;
+		ReleaseVersion currentVer = GetCurrentReleaseVersion();
+		bool isNewer = releaseVersion != null && releaseVersion.CompareTo(currentVer) > 0;
 
 		return new ReleaseInfo
 		{
 			TagName = tag,
 			ParsedVersion = parsedVer,
+			ComparableVersion = releaseVersion,
 			Title = $"StarPie {tag}",
 			Body = $"（通过 {sourceTitle} 探测到最新版本，详细更新日志请查看 GitHub Releases 页面）",
 			PublishedAt = DateTime.Now,
-			IsPrerelease = tag.Contains("beta", StringComparison.OrdinalIgnoreCase) || tag.Contains("alpha", StringComparison.OrdinalIgnoreCase),
+			IsPrerelease = releaseVersion?.IsPrerelease == true,
 			HtmlUrl = $"https://github.com/{RepoOwner}/{RepoName}/releases/tag/{tag}",
 			IsNewerVersion = isNewer,
 			StandaloneAssetUrl = $"https://github.com/{RepoOwner}/{RepoName}/releases/download/{tag}/StarPie-{tag}-Standalone-win-x64.zip",
@@ -399,18 +531,20 @@ public class UpdateManager
 			bool isPrerelease = elem.TryGetProperty("prerelease", out JsonElement preElem) && preElem.GetBoolean();
 			DateTime publishedAt = elem.TryGetProperty("published_at", out JsonElement pubElem) && pubElem.TryGetDateTime(out DateTime dt) ? dt : DateTime.Now;
 
-			Version? parsedVer = ParseVersionFromTag(tagName);
-			Version currentVer = GetCurrentVersion();
-			bool isNewer = parsedVer != null && parsedVer > currentVer;
+			ReleaseVersion? releaseVersion = ParseReleaseVersionFromTag(tagName);
+			Version? parsedVer = releaseVersion?.CoreVersion;
+			ReleaseVersion currentVer = GetCurrentReleaseVersion();
+			bool isNewer = releaseVersion != null && releaseVersion.CompareTo(currentVer) > 0;
 
 			ReleaseInfo info = new ReleaseInfo
 			{
 				TagName = tagName,
 				ParsedVersion = parsedVer,
+				ComparableVersion = releaseVersion,
 				Title = string.IsNullOrWhiteSpace(title) ? tagName : title,
 				Body = body,
 				PublishedAt = publishedAt,
-				IsPrerelease = isPrerelease,
+				IsPrerelease = isPrerelease || releaseVersion?.IsPrerelease == true,
 				HtmlUrl = htmlUrl,
 				IsNewerVersion = isNewer
 			};
@@ -445,20 +579,23 @@ public class UpdateManager
 		}
 	}
 
+	private static ReleaseVersion? ParseReleaseVersionFromTag(string tag)
+	{
+		return ReleaseVersion.TryParse(tag, out ReleaseVersion? version) ? version : null;
+	}
+
 	public static Version? ParseVersionFromTag(string tag)
 	{
-		if (string.IsNullOrWhiteSpace(tag)) return null;
-		string clean = tag.Trim().TrimStart('v', 'V');
-		int dashIdx = clean.IndexOf('-');
-		if (dashIdx > 0)
-		{
-			clean = clean.Substring(0, dashIdx);
-		}
-		if (Version.TryParse(clean, out Version? ver))
-		{
-			return ver;
-		}
-		return null;
+		return ParseReleaseVersionFromTag(tag)?.CoreVersion;
+	}
+
+	private static bool IsBetterRelease(ReleaseInfo candidate, ReleaseInfo? currentBest)
+	{
+		if (candidate.ComparableVersion == null) return false;
+		if (currentBest?.ComparableVersion == null) return true;
+
+		int comparison = candidate.ComparableVersion.CompareTo(currentBest.ComparableVersion);
+		return comparison > 0 || (comparison == 0 && candidate.PublishedAt > currentBest.PublishedAt);
 	}
 
 	public async Task DownloadAssetAsync(string downloadUrl, string destinationZipPath, IProgress<UpdateProgressInfo>? progress, CancellationToken ct)


### PR DESCRIPTION
# fix: 完善更新器的预发布版本比较策略

## 修改概述

重构 StarPie 更新器的版本读取、解析和比较逻辑，解决预发布版本号被丢弃，以及测试版无法检测同版本正式版更新的问题。

修改后，更新器能够正确识别并比较：

- 正式版本
- `beta.N` 预发布版本
- 其他点分预发布标识
- 带 Git 提交哈希的构建元数据版本

## 原有问题

原有更新器使用 `AssemblyVersion` 作为当前程序版本：

    Assembly.GetExecutingAssembly().GetName().Version

例如项目版本为：

    <Version>1.7.2-beta.5</Version>
    <AssemblyVersion>1.7.2.0</AssemblyVersion>

更新器实际读取到的是：

    1.7.2.0

本地版本中的 `beta.5` 信息会完全丢失。

远端 GitHub Release 则读取 `tag_name`，但原有解析逻辑会删除第一个连字符及其后面的所有内容：

    v1.7.2-beta.1  → 1.7.2
    v1.7.2-beta.5  → 1.7.2
    v1.7.2-beta.10 → 1.7.2
    v1.7.2         → 1.7.2

因此更新器无法判断：

- `beta.10` 是否高于 `beta.5`
- 同版本正式版是否高于 Beta
- 当前 Beta 是否应该升级到同版本正式版
- 多个同主版本 Release 中哪个才是真正的最新版本

同时，远端解析结果 `1.7.2` 与本地 `AssemblyVersion` 的 `1.7.2.0` 直接使用 `System.Version` 比较时，`1.7.2` 还会被认为小于 `1.7.2.0`，导致同版本正式版无法触发更新。

## 本地版本读取优化

更新器现在优先读取：

    AssemblyInformationalVersion

该字段由项目的 `Version` 生成，因此可以保留完整预发布信息。

例如当前项目：

    <Version>1.7.2-beta.5</Version>

编译后的信息版本为：

    1.7.2-beta.5+5637a6c90df432cbdf3216eb758786f2461b70a0

更新器会去除构建元数据：

    +5637a6c90df432cbdf3216eb758786f2461b70a0

最终使用：

    1.7.2-beta.5

如果程序集信息版本缺失或无法解析，更新器才会回退到原有的 `AssemblyVersion`，避免旧版本或特殊构建环境下无法检查更新。

## 版本比较规则

新的比较逻辑按照完整版本语义排序：

    1.7.2-beta.1
    <
    1.7.2-beta.5
    <
    1.7.2-beta.10
    <
    1.7.2
    <
    1.7.3-beta.1
    <
    1.7.3

## GitHub prerelease 状态处理

更新器会同时参考：

- GitHub API 返回的 `prerelease`
- Release 标签中解析出的预发布信息

即使 GitHub Release 的 Pre-release 标记配置异常，只要标签包含合法预发布后缀，更新器仍能将其识别为预发布版本，避免稳定渠道错误接收 Beta。

## 兼容性

原有公开方法：

    ParseVersionFromTag()

继续保留，并返回不含预发布后缀的核心 `System.Version`，避免影响现有调用者。

完整预发布版本只在更新器内部通过 `ReleaseVersion` 保存和比较。

下载地址选择、更新包下载、PowerShell 覆盖更新和重启流程均未修改。

## 修改文件

- `WinPieGestures/UpdateManager.cs`

已使用模拟 GitHub Atom Feed 验证：

- 测试渠道能够从同版本 Beta 和正式版中选择正式版
- 正式渠道能够检测当前 Beta 对应的同版本正式版
- 测试渠道能够按数字顺序选择更高的 Beta
- 正式渠道会忽略仅包含预发布版的 Feed