### PR TITLE
ci: 修复 Release Notes 标签匹配大小写敏感问题

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
 
             $previousBeta = @(
               foreach ($candidate in $allTags) {
-                $match = [regex]::Match($candidate, $betaPattern)
+                $match = [regex]::Match($candidate, $betaPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
                 if ($match.Success) {
                   $candidateNumber = [long]$match.Groups['number'].Value
                   if ($candidateNumber -lt $betaNumber) {
@@ -158,7 +158,7 @@ jobs:
             else {
               $previousStable = @(
                 foreach ($candidate in $allTags) {
-                  $match = [regex]::Match($candidate, '^v(?<version>\d+\.\d+\.\d+)$')
+                  $match = [regex]::Match($candidate, '^v(?<version>\d+\.\d+\.\d+)$', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
                   if ($match.Success) {
                     $candidateVersion = [version]$match.Groups['version'].Value
                     if ($candidateVersion -lt $baseVersion) {
@@ -180,7 +180,7 @@ jobs:
             $currentVersion = [version]$Matches.version
             $previousStable = @(
               foreach ($candidate in $allTags) {
-                $match = [regex]::Match($candidate, '^v(?<version>\d+\.\d+\.\d+)$')
+                $match = [regex]::Match($candidate, '^v(?<version>\d+\.\d+\.\d+)$', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
                 if ($match.Success) {
                   $candidateVersion = [version]$match.Groups['version'].Value
                   if ($candidateVersion -lt $currentVersion) {


### PR DESCRIPTION
- 历史正式版与 Beta 标签匹配改为忽略大小写
- 同时识别以 v 和 V 开头的版本标签
- 避免因前置标签未匹配而回退到过旧的正式版本