### PR TITLE
feat(settings): 设置控制台支持 80%~200% 全局界面缩放

### DIFF
--- a/WinPieGestures/AppConfig.cs
+++ b/WinPieGestures/AppConfig.cs
@@ -77,6 +77,9 @@ public class AppConfig
 
 	public string AppTheme { get; set; } = "System";
 
+	/// <summary>设置控制台界面整体缩放比例（1.0 = 100%，有效范围 0.8 ~ 2.0，按 5% 步进对齐）。</summary>
+	public double SettingsUiScale { get; set; } = 1.0;
+
 	public string Theme { get; set; } = "System";
 
 	public string UiStyle { get; set; } = "ClassicRing";

--- a/WinPieGestures/I18n.cs
+++ b/WinPieGestures/I18n.cs
@@ -1872,6 +1872,20 @@ public static class I18n
 			[LanguageCode.En] = "Center Font Family:",
 			[LanguageCode.Ja] = "中央フォント:"
 		};
+		dictionary["SettingsUiScale"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "🔍 界面缩放",
+			[LanguageCode.ZhTw] = "🔍 介面縮放",
+			[LanguageCode.En] = "🔍 UI Scale",
+			[LanguageCode.Ja] = "🔍 表示拡大率"
+		};
+		dictionary["SettingsUiScaleTip"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "调节设置控制台界面整体缩放比例 (80% ~ 200%)，高分屏下可放大文字与控件。窗口尺寸保持不变，内容变大后由页面滚动承接；也可随时使用 Ctrl + / Ctrl - 调节，Ctrl 0 复位。",
+			[LanguageCode.ZhTw] = "調整設定控制台介面整體縮放比例 (80% ~ 200%)，高解析度螢幕下可放大文字與控件。視窗尺寸保持不變，內容變大後由頁面捲動承接；亦可隨時使用 Ctrl + / Ctrl - 調整，Ctrl 0 復位。",
+			[LanguageCode.En] = "Scale the whole settings console between 80% and 200% for better readability on high-resolution screens. The window size stays untouched - enlarged content simply scrolls. Ctrl + / Ctrl - adjusts it anytime, and Ctrl 0 resets.",
+			[LanguageCode.Ja] = "設定画面全体の表示拡大率を 80%〜200% で調整できます。高解像度画面での文字・控件の視認性向上に。ウィンドウサイズは変更されず、拡大した内容はスクロールして表示します。Ctrl + / Ctrl - ですぐに調整、Ctrl 0 でリセット。"
+		};
 		dictionary["CoreFontSize"] = new Dictionary<LanguageCode, string>
 		{
 			[LanguageCode.ZhCn] = "中心文字大小 (Core Font Size):",

--- a/WinPieGestures/SettingsWindow.xaml
+++ b/WinPieGestures/SettingsWindow.xaml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Window x:Class="WinPieGestures.SettingsWindow" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:local="clr-namespace:WinPieGestures" Title="StarPie 设置控制台 (Preferences)" Icon="app_icon.ico" Height="740" Width="1220" MinWidth="1060" MinHeight="660" WindowStartupLocation="CenterScreen" Background="{DynamicResource WindowBackgroundBrush}" FontFamily="Segoe UI, Microsoft YaHei UI, Arial" UseLayoutRounding="True" SnapsToDevicePixels="True" TextOptions.TextFormattingMode="Display" TextOptions.TextRenderingMode="ClearType" RenderOptions.ClearTypeHint="Enabled" RenderOptions.BitmapScalingMode="HighQuality" Closing="Window_Closing">
+<Window x:Class="WinPieGestures.SettingsWindow" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:local="clr-namespace:WinPieGestures" Title="StarPie 设置控制台 (Preferences)" Icon="app_icon.ico" Height="740" Width="1220" MinWidth="1060" MinHeight="660" WindowStartupLocation="CenterScreen" Background="{DynamicResource WindowBackgroundBrush}" FontFamily="Segoe UI, Microsoft YaHei UI, Arial" UseLayoutRounding="True" SnapsToDevicePixels="True" TextOptions.TextFormattingMode="Display" TextOptions.TextRenderingMode="ClearType" RenderOptions.ClearTypeHint="Enabled" RenderOptions.BitmapScalingMode="HighQuality" Closing="Window_Closing" PreviewKeyDown="Window_PreviewKeyDown">
   <FrameworkElement.Resources>
     <ResourceDictionary>
       <BooleanToVisibilityConverter x:Key="BoolToVis" />
@@ -552,12 +552,17 @@
     </ResourceDictionary>
   </FrameworkElement.Resources>
   <Grid>
+    <Grid.LayoutTransform>
+      <ScaleTransform x:Name="RootUiScaleTransform" ScaleX="1" ScaleY="1" />
+    </Grid.LayoutTransform>
     <Grid.ColumnDefinitions>
       <ColumnDefinition Name="SidebarColumn" Width="230" />
       <ColumnDefinition Width="*" />
     </Grid.ColumnDefinitions>
     <Border Name="SidebarBorder" Grid.Column="0" Background="{DynamicResource SidebarBackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="0,0,1,0" Padding="16,20,16,15">
-      <Grid>
+      <!-- 缩放后逻辑视口变小，整条侧栏改为可纵向滚动；MinHeight 绑定视口高度以保留底部贴边布局 -->
+      <ScrollViewer Name="SidebarScrollHost" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+      <Grid MinHeight="{Binding ViewportHeight, ElementName=SidebarScrollHost}">
         <Grid.RowDefinitions>
           <RowDefinition Height="Auto" />
           <RowDefinition Height="*" />
@@ -658,6 +663,21 @@
             <TextBlock Name="SidebarThemeCollapsedIcon" Text="🌙" FontSize="15" HorizontalAlignment="Center" VerticalAlignment="Center" />
           </Button>
 
+          <!-- 界面缩放调节器 (展开态: 80%~200% 全局缩放，改善高分屏可读性) -->
+          <Border Name="SidebarScalePanel" Margin="0,0,0,10" Background="{DynamicResource SubtleCardBrush}" BorderBrush="{DynamicResource CardBorderBrush}" BorderThickness="1" CornerRadius="8" Padding="8,6" SnapsToDevicePixels="True">
+            <StackPanel>
+              <Grid>
+                <Grid.ColumnDefinitions>
+                  <ColumnDefinition Width="*" />
+                  <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <TextBlock Name="SidebarScaleTitleText" Text="🔍 界面缩放" FontSize="11" FontWeight="SemiBold" Foreground="{DynamicResource TextSecondaryBrush}" VerticalAlignment="Center" />
+                <TextBlock Name="SidebarScaleValueText" Grid.Column="1" Text="100%" FontSize="11" FontWeight="Bold" Foreground="{DynamicResource AccentPrimaryBrush}" VerticalAlignment="Center" />
+              </Grid>
+              <Slider Name="UiScaleSlider" AutomationProperties.AutomationId="UiScaleSlider" Minimum="80" Maximum="200" SmallChange="5" LargeChange="10" TickFrequency="5" IsSnapToTickEnabled="True" Value="100" Margin="0,2,0,0" VerticalAlignment="Center" ToolTip="设置控制台界面整体缩放比例 (80% ~ 200%)；亦可随时用 Ctrl + / Ctrl - 调节，Ctrl 0 复位" ValueChanged="UiScaleSlider_ValueChanged" PreviewMouseUp="UiScaleSlider_Commit" />
+            </StackPanel>
+          </Border>
+
           <!-- 底部版本与版权信息 (折叠态自动居中展示) -->
           <StackPanel Name="SidebarFooterPanel" Margin="0,0,0,5" ToolTip="StarPie v1.7.2-beta.2&#x0a;© 2026 StarPie">
             <Border Name="SidebarModeBadge" Background="{DynamicResource AccentPrimaryBrush}" CornerRadius="6" Padding="7,3" HorizontalAlignment="Left" Margin="0,0,0,5" Cursor="Hand" ToolTip="点击快速切换简单/高级模式" MouseLeftButtonUp="SidebarModeBadge_Click">
@@ -670,6 +690,7 @@
           </StackPanel>
         </StackPanel>
       </Grid>
+      </ScrollViewer>
     </Border>
     <Grid Column="1" Margin="25,18,25,20">
       <Grid.RowDefinitions>

--- a/WinPieGestures/SettingsWindow.xaml.cs
+++ b/WinPieGestures/SettingsWindow.xaml.cs
@@ -39,6 +39,9 @@ public partial class SettingsWindow : Window
 
 	private bool _isSidebarCollapsed = false;
 
+	/// <summary>设置控制台当前已生效的界面缩放比例，用于按倍率换算窗口尺寸增量。</summary>
+	private double _appliedSettingsUiScale = 1.0;
+
 	private int _selectedLayoutTier = 1; // 1: 主轮盘, 2: 二级级联轮盘
 
 	private int _selectedLayoutSlotIndex = -1;
@@ -527,6 +530,12 @@ public partial class SettingsWindow : Window
 		catch
 		{
 		}
+		double initialUiScale = NormalizeSettingsUiScale(ConfigManager.CurrentConfig?.SettingsUiScale ?? 1.0);
+		if (UiScaleSlider != null)
+		{
+			UiScaleSlider.Value = initialUiScale * 100.0;
+		}
+		ApplySettingsUiScale(initialUiScale);
 		_isUpdatingUi = false;
 
 		// 若为桌面正常呼起或单测环境（非静默参数），立即就绪完整 UI；若为开机自启/静默启动，延迟至首次唤起加载
@@ -579,6 +588,124 @@ public partial class SettingsWindow : Window
 		Opacity = 1.0;
 	}
 
+	/// <summary>把任意缩放取值规范到 0.8 ~ 2.0，并对齐 5% 步进（与滑块 TickFrequency 一致）。</summary>
+	private double NormalizeSettingsUiScale(double scale)
+	{
+		if (double.IsNaN(scale) || double.IsInfinity(scale) || scale <= 0.0)
+		{
+			scale = 1.0;
+		}
+		return Math.Round(Math.Clamp(scale, 0.8, 2.0) * 20.0) / 20.0;
+	}
+
+	/// <summary>
+	/// 应用设置控制台全局缩放：仅给根节点挂 LayoutTransform，等比放大字号/边距与控件尺寸
+	/// （等同浏览器缩放语义）。窗口尺寸一律不代为调整——大小由用户自己决定，
+	/// 内容超出可视区域时交由侧边栏与各页签内部的滚动条承接，Ctrl 0 可随时复位。
+	/// </summary>
+	private void ApplySettingsUiScale(double scale)
+	{
+		scale = NormalizeSettingsUiScale(scale);
+		if (RootUiScaleTransform != null)
+		{
+			RootUiScaleTransform.ScaleX = scale;
+			RootUiScaleTransform.ScaleY = scale;
+		}
+		_appliedSettingsUiScale = scale;
+		if (SidebarScaleValueText != null)
+		{
+			SidebarScaleValueText.Text = string.Format("{0:0}%", scale * 100.0);
+		}
+	}
+
+	/// <summary>统一的缩放写入口：同步滑块与配置、重排界面并落盘（供快捷键复用）。</summary>
+	private void SetSettingsUiScale(double scale)
+	{
+		if (ConfigManager.CurrentConfig == null)
+		{
+			return;
+		}
+		scale = NormalizeSettingsUiScale(scale);
+		_isUpdatingUi = true;
+		if (UiScaleSlider != null)
+		{
+			UiScaleSlider.Value = scale * 100.0;
+		}
+		_isUpdatingUi = false;
+		ConfigManager.CurrentConfig.SettingsUiScale = scale;
+		ApplySettingsUiScale(scale);
+		ScheduleAutoSave();
+	}
+
+	private void UiScaleSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+	{
+		if (_isUpdatingUi || ConfigManager.CurrentConfig == null)
+		{
+			return;
+		}
+		if (UiScaleSlider.IsMouseCaptureWithin)
+		{
+			// 滑块本身也在被缩放的画面里：拖动途中一旦重排，拇指会跑到指针前面，
+			// Slider 再按指针位置反算数值就会往回跳，两者互相追赶表现为持续抖动。
+			// 因此拖动途中只实时回显百分比，真正的重排与落盘留到松手时一次性完成。
+			if (SidebarScaleValueText != null)
+			{
+				SidebarScaleValueText.Text = string.Format("{0:0}%", NormalizeSettingsUiScale(e.NewValue / 100.0) * 100.0);
+			}
+			return;
+		}
+		double scale = NormalizeSettingsUiScale(e.NewValue / 100.0);
+		if (Math.Abs(scale - _appliedSettingsUiScale) < 0.0005)
+		{
+			return;
+		}
+		ConfigManager.CurrentConfig.SettingsUiScale = scale;
+		ApplySettingsUiScale(scale);
+		ScheduleAutoSave();
+	}
+
+	/// <summary>松手后一次性提交缩放，避免拖动途中反复重排造成滑块抖动与指针错位。</summary>
+	private void UiScaleSlider_Commit(object sender, System.Windows.Input.MouseButtonEventArgs e)
+	{
+		if (UiScaleSlider == null)
+		{
+			return;
+		}
+		SetSettingsUiScale(UiScaleSlider.Value / 100.0);
+	}
+
+	private void Window_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+	{
+		if (_isRecordingTrigger || ConfigManager.CurrentConfig == null || (Keyboard.Modifiers & ModifierKeys.Control) != ModifierKeys.Control)
+		{
+			return;
+		}
+		// 热键录入框一拿到键盘焦点就进入录制态，而窗口级 PreviewKeyDown 是先于控件的 tunnel，
+		// 不豁免就会把 Ctrl+0 / Ctrl+加 / Ctrl+减 直接吃掉，导致这三个组合键永远录不进去。
+		if (Keyboard.FocusedElement is HotkeyRecorderBox { IsRecording: true })
+		{
+			return;
+		}
+		switch (e.Key)
+		{
+		case Key.Add:
+		case Key.OemPlus:
+			SetSettingsUiScale(_appliedSettingsUiScale + 0.05);
+			e.Handled = true;
+			break;
+		case Key.Subtract:
+		case Key.OemMinus:
+			SetSettingsUiScale(_appliedSettingsUiScale - 0.05);
+			e.Handled = true;
+			break;
+		case Key.D0:
+		case Key.NumPad0:
+			SetSettingsUiScale(1.0);
+			e.Handled = true;
+			break;
+		}
+	}
+
 	private void SidebarToggleButton_Click(object sender, RoutedEventArgs e)
 	{
 		_isSidebarCollapsed = !_isSidebarCollapsed;
@@ -610,6 +737,10 @@ public partial class SettingsWindow : Window
 		if (SidebarThemeCollapsedButton != null)
 		{
 			SidebarThemeCollapsedButton.Visibility = isCollapsed ? Visibility.Visible : Visibility.Collapsed;
+		}
+		if (SidebarScalePanel != null)
+		{
+			SidebarScalePanel.Visibility = (isCollapsed ? Visibility.Collapsed : Visibility.Visible);
 		}
 
 		// 底部版本与版权信息：折叠时持续展示，自适应居中对齐
@@ -1050,6 +1181,11 @@ public partial class SettingsWindow : Window
 		if (EnableMultiTierCheckBox != null)
 		{
 			EnableMultiTierCheckBox.IsChecked = ConfigManager.CurrentConfig.EnableMultiTier;
+		}
+		ApplySettingsUiScale(ConfigManager.CurrentConfig.SettingsUiScale);
+		if (UiScaleSlider != null)
+		{
+			UiScaleSlider.Value = _appliedSettingsUiScale * 100.0;
 		}
 
 		// Sub Wheel Themes & Colors
@@ -1958,6 +2094,14 @@ public partial class SettingsWindow : Window
 		if (EnableMultiTierCheckBox != null)
 		{
 			EnableMultiTierCheckBox.Content = I18n.T("EnableMultiTier");
+		}
+		if (SidebarScaleTitleText != null)
+		{
+			SidebarScaleTitleText.Text = I18n.T("SettingsUiScale");
+		}
+		if (UiScaleSlider != null)
+		{
+			UiScaleSlider.ToolTip = I18n.T("SettingsUiScaleTip");
 		}
 		
 		if (SubmenuStyleWheelItem != null) SubmenuStyleWheelItem.Content = I18n.T("SubmenuStyleWheel");


### PR DESCRIPTION
# feat(settings): 设置控制台支持 80%\~200% 全局界面缩放

Ref #75（第 1 项）

## 背景

> 目前设置界面阅读起来比较费力，尤其是在高分辨率屏幕下，文字和控件不容易看清。建议支持调整字号、界面缩放和布局，并改善不同分辨率及系统缩放比例下的适配。

`SettingsWindow.xaml` 里有 **567 处硬编码 `FontSize=`**，逐处改成可配置字号会带来巨大的改动面和后续维护成本；而应用已声明 `PerMonitorV2` DPI 感知，所以问题不在 DPI 感知缺失，而是**缺少一个用户可控的整体缩放档位**。

## 实现

* `AppConfig` 新增 `SettingsUiScale`（默认 `1.0`）；UI 层 `NormalizeSettingsUiScale` 把值夹到 `0.8~2.0` 并对齐 5% 步进，兼容手工写入或旧配置残留的异常值。

* 根 `Grid` 挂 `LayoutTransform` + `ScaleTransform`（`RootUiScaleTransform`）：字号、边距、控件尺寸等比放大，语义等同浏览器缩放，**不改动任何一处既有硬编码 `FontSize`**，也不引入与系统缩放重复的第二套字号维度。

* **窗口尺寸不由缩放代为调整**：多大由用户自己定（可以先最大化再放大），内容超出可视区域时交由滚动承接。早期版本曾按缩放比例同步放大窗口，实测会出现「一拉滑块窗口就涨到近全屏」的错误体验，已改为纯内容缩放。

* 侧边栏整体包一层 `ScrollViewer`（`SidebarScrollHost`），内层 `Grid` 绑 `MinHeight = ViewportHeight`：既保留原有的底部贴边布局，又避免大缩放下导航项与底部卡片被裁切。

* 侧边栏底部新增「🔍 界面缩放」滑块卡片（侧栏折叠态自动隐藏），实时回显当前百分比。

* **拖动途中只回显百分比、松手才一次性重排**：滑块自身处在被它缩放的那一层里，边拖边重排会让拇指在物理像素上跑到指针前面、`Slider` 再按指针位置反算数值往回跳，形成持续抖动；`PreviewMouseUp` 提交把这个反馈环断开。

* `Ctrl +` / `Ctrl -` 逐档 5% 调节、`Ctrl 0` 复位，保证任何缩放下都能回退；**触发键录制（`_isRecordingTrigger`）与热键录入框录制态一律豁免** —— 窗口级 `PreviewKeyDown` 是先于控件的 tunnel，不豁免就会把用户正在录的 `Ctrl+0` / `Ctrl+加` / `Ctrl+减` 吃掉，导致这三个组合键永远录不进去。

* `I18n` 补 `SettingsUiScale` / `SettingsUiScaleTip` 四国语言（简中 / 繁中 / 英文 / 日文）。

改动面：`AppConfig.cs` +3、`I18n.cs` +14、`SettingsWindow.xaml` +23/-2、`SettingsWindow.xaml.cs` +144（**纯新增，未删除任何既有逻辑**）。

## 兼容性

* 旧 `config.json` 无 `SettingsUiScale` 字段 → 反序列化取默认 `1.0`，行为与改动前完全一致。

* 缩放只作用于设置控制台，不触碰轮盘渲染与手势路径。

## 验证

* `dotnet build -c Release`：0 error，告警家族与改动前一致。

* 1920×1080 / 系统缩放 105% 实测：`SettingsUiScale=1.35` 时窗口保持用户尺寸不变，侧栏在超过约 120% 后出现纵向滚动条，导航项与底部卡片均可滚到；百分比回显、`Ctrl 0` 复位、滑块拖动无抖动。

* 既有的 `tests/test_settings.py`（22 例）不含任何缩放相关断言，未覆盖本次改动。指南要求的「全量 100% 绿灯」在当前环境拿不到：该套件每个用例都要起一个真实窗口、且部分用例依赖联网检查更新与列表滚动定位，同一份代码多次运行会在**不同**用例上随机失败（`ProfilesListBox` / `AddProfileButton` 需滚动、`ElementAmbiguousError` 同标题窗口定位歧义），因此不能当回归判据。本 PR 的实际判据是：三条分支各自 `dotnet build -c Release` 0 error、告警家族与基线一致，加上上述真机实测。如需我补一组针对缩放的 UIA 用例，可以在这个 PR 里继续加。

## 已知限制（未在本 PR 处理）

1. `Popup` 是独立视觉树，不吃根节点的 `LayoutTransform`：大倍率下 ComboBox 下拉列表、ToolTip、`MessageBox` 仍按 100% 绘制。逐个 Popup 模板同步缩放涉及全站控件样式，工作量和风险都远超本条 PR 的边界，因此先只保证主界面可读。
2. 外观页只有左列有 `ScrollViewer`，右侧实时预览列没有滚动容器；大倍率下预览区会被压缩/裁切。
3. 侧栏 `ScrollViewer` 的纵向滚动条出现会占掉约 17px 宽度，理论上存在「出现 → 文本回退变少 → 不再溢出 → 消失 → 再溢出」的临界振荡。100% / 135% 实测未复现；若某个倍率看到滚动条显隐抖动，改用固定预留滚动条槽位即可。

## 截图
<img width="1270" height="738" alt="image" src="https://github.com/user-attachments/assets/d2891f73-0880-418c-b729-920a9ae893d4" />

## AI 代码审查

<img width="844" height="362" alt="image" src="https://github.com/user-attachments/assets/c7583098-82ff-4fa6-a908-71583f679c36" />

