### PR TITLE
fix(radial): 中心文字自适应配色，修复浅色主题下白字白底

### DIFF
--- a/WinPieGestures/AppConfig.cs
+++ b/WinPieGestures/AppConfig.cs
@@ -211,6 +211,9 @@ public class AppConfig
 
 	public string CoreTextColor { get; set; } = "#FFFFFFFF";
 
+	/// <summary>中心文字是否自动跟随配色主题取对比色；关闭后才使用 CoreTextColor 的手动指定色。</summary>
+	public bool CoreTextColorAuto { get; set; } = true;
+
 	public string CoreTitle { get; set; } = "StarPie";
 
 	public string CoreSubtitle { get; set; } = "RMB Drag";

--- a/WinPieGestures/I18n.cs
+++ b/WinPieGestures/I18n.cs
@@ -1879,6 +1879,13 @@ public static class I18n
 			[LanguageCode.En] = "Center Font Size:",
 			[LanguageCode.Ja] = "中央フォントサイズ:"
 		};
+		dictionary["CoreTextColorAuto"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "自动适应配色主题 (Auto Contrast)",
+			[LanguageCode.ZhTw] = "自動適應配色主題 (Auto Contrast)",
+			[LanguageCode.En] = "Auto Contrast",
+			[LanguageCode.Ja] = "配色テーマに自動追従 (Auto Contrast)"
+		};
 		dictionary["CoreTextColor"] = new Dictionary<LanguageCode, string>
 		{
 			[LanguageCode.ZhCn] = "中心文字颜色 (Core Text Color):",

--- a/WinPieGestures/RadialWindow.xaml.cs
+++ b/WinPieGestures/RadialWindow.xaml.cs
@@ -332,6 +332,8 @@ public partial class RadialWindow : Window
 
 	private Brush _textColorBrush;
 
+	private static readonly Dictionary<string, double> _coreImageLuminanceCache = new Dictionary<string, double>();
+
 	private Brush _coreBgBrush;
 
 	private Brush _coreBorderBrush;
@@ -535,6 +537,93 @@ public partial class RadialWindow : Window
 		UpdateCenterIconVisuals();
 	}
 
+	private static SolidColorBrush TintBrush(Brush brush, byte alpha)
+	{
+		SolidColorBrush solid = brush as SolidColorBrush;
+		Color color = (solid != null) ? solid.Color : Colors.White;
+		return new SolidColorBrush(Color.FromArgb(alpha, color.R, color.G, color.B));
+	}
+
+	private static bool IsBrushDark(Brush brush)
+	{
+		SolidColorBrush solid = brush as SolidColorBrush;
+		if (solid == null)
+		{
+			return false;
+		}
+		Color color = solid.Color;
+		double luminance = 0.2126 * (color.R / 255.0) + 0.7152 * (color.G / 255.0) + 0.0722 * (color.B / 255.0);
+		return luminance < 0.5;
+	}
+
+	/// <summary>中心文字取色：手动模式用配置指定色；自动模式跟随配色主题笔刷，中心铺图时改按图片平均亮度取对比色。</summary>
+	private Brush ResolveCoreTextBrush(double? coreImageLuminance)
+	{
+		AppConfig config = ConfigManager.CurrentConfig;
+		if (config != null && !config.CoreTextColorAuto && !string.IsNullOrWhiteSpace(config.CoreTextColor))
+		{
+			try
+			{
+				return new SolidColorBrush((Color)ColorConverter.ConvertFromString(config.CoreTextColor));
+			}
+			catch
+			{
+			}
+		}
+		if (coreImageLuminance.HasValue)
+		{
+			return (coreImageLuminance.Value < 0.5)
+				? new SolidColorBrush(Color.FromRgb(248, 250, 252))
+				: new SolidColorBrush(Color.FromRgb(15, 23, 42));
+		}
+		return _textColorBrush ?? Brushes.White;
+	}
+
+	/// <summary>缩略解码后取样中心背景图平均亮度(0~1)，按路径+写入时间缓存，避免每次弹出轮盘重复解码。</summary>
+	private static double? GetImageAverageLuminance(string path)
+	{
+		try
+		{
+			string key = path + "|" + File.GetLastWriteTimeUtc(path).Ticks;
+			double cached;
+			if (_coreImageLuminanceCache.TryGetValue(key, out cached))
+			{
+				return cached;
+			}
+			BitmapImage thumb = new BitmapImage();
+			thumb.BeginInit();
+			thumb.UriSource = new Uri(path, UriKind.Absolute);
+			thumb.DecodePixelWidth = 24;
+			thumb.CacheOption = BitmapCacheOption.OnLoad;
+			thumb.EndInit();
+			FormatConvertedBitmap converted = new FormatConvertedBitmap(thumb, PixelFormats.Bgra32, null, 0.0);
+			int width = converted.PixelWidth;
+			int height = converted.PixelHeight;
+			if (width <= 0 || height <= 0)
+			{
+				return null;
+			}
+			byte[] pixels = new byte[width * height * 4];
+			converted.CopyPixels(pixels, width * 4, 0);
+			double sum = 0.0;
+			for (int i = 0; i + 3 < pixels.Length; i += 4)
+			{
+				sum += 0.2126 * (pixels[i + 2] / 255.0) + 0.7152 * (pixels[i + 1] / 255.0) + 0.0722 * (pixels[i] / 255.0);
+			}
+			double luminance = sum / (width * height);
+			if (_coreImageLuminanceCache.Count > 32)
+			{
+				_coreImageLuminanceCache.Clear();
+			}
+			_coreImageLuminanceCache[key] = luminance;
+			return luminance;
+		}
+		catch
+		{
+			return null;
+		}
+	}
+
 	private void InitializeThemeAndStyle()
 	{
 		string text = ConfigManager.CurrentConfig.Theme ?? "System";
@@ -634,6 +723,7 @@ public partial class RadialWindow : Window
 		CoreEllipse.Fill = _coreBgBrush;
 		CoreEllipse.Stroke = _coreBorderBrush;
 		string text = ConfigManager.CurrentConfig.CoreBgImagePath ?? "";
+		double? coreImageLuminance = null;
 		if (!string.IsNullOrEmpty(text) && File.Exists(text))
 		{
 			try
@@ -644,13 +734,17 @@ public partial class RadialWindow : Window
 					Stretch = ParseStretch(ConfigManager.CurrentConfig.CoreBgStretch),
 					Opacity = ConfigManager.CurrentConfig.CoreBgOpacity
 				};
+				coreImageLuminance = GetImageAverageLuminance(text);
 			}
 			catch
 			{
 			}
 		}
-		CoreTitle.Foreground = _textColorBrush;
-		CoreExitIcon.Fill = _textColorBrush;
+		Brush centerTextBrush = ResolveCoreTextBrush(coreImageLuminance);
+		Effect coreTextShadow = IsBrushDark(centerTextBrush) ? null : (Effect)base.Resources["TextShadow"];
+		CoreTitle.Foreground = TintBrush(centerTextBrush, 208);
+		CoreSubtitle.Foreground = TintBrush(centerTextBrush, 128);
+		CoreExitIcon.Fill = centerTextBrush;
 		CoreExitIcon.Width = coreRadius * 0.42;
 		CoreExitIcon.Height = coreRadius * 0.42;
 		CoreTitle.FontSize = Math.Max(8.0, coreRadius / 5.0);
@@ -678,21 +772,10 @@ public partial class RadialWindow : Window
 			{
 			}
 		}
-		if (!string.IsNullOrWhiteSpace(ConfigManager.CurrentConfig?.CoreTextColor))
-		{
-			try
-			{
-				CoreSelectionText.Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString(ConfigManager.CurrentConfig.CoreTextColor));
-			}
-			catch
-			{
-				CoreSelectionText.Foreground = _textColorBrush;
-			}
-		}
-		else
-		{
-			CoreSelectionText.Foreground = _textColorBrush;
-		}
+		CoreSelectionText.Foreground = centerTextBrush;
+		CoreSelectionText.Effect = coreTextShadow;
+		CoreVolumeText.Foreground = centerTextBrush;
+		CoreVolumeText.Effect = coreTextShadow;
 		CoreSelectionOverlay.Fill = CreateFrostedCoreBrush(_coreBgBrush);
 		Panel.SetZIndex(CoreSelectionOverlay, 20);
 		Panel.SetZIndex(CoreSelectionTextPanel, 21);

--- a/WinPieGestures/SettingsWindow.xaml
+++ b/WinPieGestures/SettingsWindow.xaml
@@ -2059,8 +2059,9 @@
                             <Slider Name="CoreFontSizeSlider" Minimum="8" Maximum="24" Value="13.0" SmallChange="0.5" LargeChange="1.0" TickFrequency="0.5" IsSnapToTickEnabled="True" VerticalAlignment="Center" ValueChanged="CoreFontSizeSlider_ValueChanged" />
                             <TextBlock Name="CoreFontSizeLabel" Grid.Column="1" Text="13.0 px" FontWeight="Bold" Foreground="{DynamicResource AccentPrimaryBrush}" FontSize="12" HorizontalAlignment="Right" VerticalAlignment="Center" />
                           </Grid>
+                          <CheckBox Name="CoreTextColorAutoCheckBox" Content="自动适应配色主题 (Auto Contrast)" Style="{StaticResource ToggleSwitchStyle}" Margin="0,0,0,6" Checked="CoreTextColorAutoCheckBox_Changed" Unchecked="CoreTextColorAutoCheckBox_Changed" />
                           <TextBlock Name="CoreTextColorTitleText" Text="中心文字颜色 (Core Text Color):" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,0,0,4" />
-                          <Grid Margin="0,0,0,6">
+                          <Grid Name="CoreTextColorRowGrid" Margin="0,0,0,6">
                             <Grid.ColumnDefinitions>
                               <ColumnDefinition Width="28" />
                               <ColumnDefinition Width="*" />

--- a/WinPieGestures/SettingsWindow.xaml.cs
+++ b/WinPieGestures/SettingsWindow.xaml.cs
@@ -1047,6 +1047,14 @@ public partial class SettingsWindow : Window
 			CoreTextColorTextBox.Text = ConfigManager.CurrentConfig.CoreTextColor ?? "#FFFFFFFF";
 			UpdateColorPreviewBorder(CoreTextColorPreview, CoreTextColorTextBox.Text);
 		}
+		if (CoreTextColorAutoCheckBox != null)
+		{
+			CoreTextColorAutoCheckBox.IsChecked = ConfigManager.CurrentConfig.CoreTextColorAuto;
+		}
+		if (CoreTextColorRowGrid != null)
+		{
+			CoreTextColorRowGrid.IsEnabled = !ConfigManager.CurrentConfig.CoreTextColorAuto;
+		}
 		if (EnableMultiTierCheckBox != null)
 		{
 			EnableMultiTierCheckBox.IsChecked = ConfigManager.CurrentConfig.EnableMultiTier;
@@ -1910,6 +1918,10 @@ public partial class SettingsWindow : Window
 		if (CoreTextColorTitleText != null)
 		{
 			CoreTextColorTitleText.Text = I18n.T("CoreTextColor");
+		}
+		if (CoreTextColorAutoCheckBox != null)
+		{
+			CoreTextColorAutoCheckBox.Content = I18n.T("CoreTextColorAuto");
 		}
 		if (ShowSelectedActionTextCheckBox != null)
 		{
@@ -9769,6 +9781,26 @@ public partial class SettingsWindow : Window
 		ScheduleAutoSave();
 	}
 
+	private void CoreTextColorAutoCheckBox_Changed(object sender, RoutedEventArgs e)
+	{
+		if (_isUpdatingUi || ConfigManager.CurrentConfig == null)
+		{
+			return;
+		}
+		bool auto = CoreTextColorAutoCheckBox != null && CoreTextColorAutoCheckBox.IsChecked == true;
+		ConfigManager.CurrentConfig.CoreTextColorAuto = auto;
+		if (CoreTextColorRowGrid != null)
+		{
+			CoreTextColorRowGrid.IsEnabled = !auto;
+		}
+		Grid appearanceSettingsGrid = AppearanceSettingsGrid;
+		if (appearanceSettingsGrid != null && appearanceSettingsGrid.Visibility == Visibility.Visible)
+		{
+			RenderLiveWheelPreview();
+		}
+		ScheduleAutoSave();
+	}
+
 	private void CoreFontSizeSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
 	{
 		if (CoreFontSizeSlider != null && CoreFontSizeLabel != null && ConfigManager.CurrentConfig != null && !_isUpdatingUi)
@@ -13172,7 +13204,10 @@ public partial class SettingsWindow : Window
 			double previewCoreFontSize = (ConfigManager.CurrentConfig?.CoreFontSize > 0.0)
 				? ConfigManager.CurrentConfig.CoreFontSize
 				: Math.Max(8.0, Math.Min(16.0, num10 / 4.0));
-			Brush previewCoreTextBrush = (!string.IsNullOrWhiteSpace(ConfigManager.CurrentConfig?.CoreTextColor))
+			// 预览与实轮盘共用同一取色规则：自动模式跟随配色主题的文字笔刷，只有关闭自动后才采用手动指定色。
+			// 否则默认值 #FFFFFFFF 非空，预览永远画白字，白底白字会在预览里原样复现。
+			bool previewCoreTextAuto = ConfigManager.CurrentConfig == null || ConfigManager.CurrentConfig.CoreTextColorAuto;
+			Brush previewCoreTextBrush = (!previewCoreTextAuto && !string.IsNullOrWhiteSpace(ConfigManager.CurrentConfig?.CoreTextColor))
 				? CreateBrushFromHexSafe(ConfigManager.CurrentConfig.CoreTextColor, _previewTextBrush)
 				: _previewTextBrush;
 			string previewCoreFontFamily = (!string.IsNullOrWhiteSpace(ConfigManager.CurrentConfig?.CoreFontFamily))


### PR DESCRIPTION
# fix(radial): 中心文字自适应配色，修复浅色主题下白字白底

Ref #75（第 2 项）

## 问题

中心文字的取色逻辑本来是这样：`CoreTextColor` 非空则用配置色，否则用配色主题的自适应笔刷 `_textColorBrush`。但 `AppConfig.CoreTextColor` 的**默认值是 `#FFFFFFFF`（非空）**，自适应分支因此永远走不到 —— 中心文字恒为白色。在浅色模式、冰川透蓝这类中心底色接近白色的主题下就表现为白字白底，完全读不出扇区名与音量数值。此外 `CoreVolumeText` / `CoreTitle` / `CoreSubtitle` 更是在 XAML 里直接写死 `#FFFFFFFF`。

## 实现

新增 `AppConfig.CoreTextColorAuto`（**默认开启**）：

* 自动模式直接取渲染器的主题文字笔刷 —— 它与中心底色出自同一处 `GetDefaultColors`，天然成对，因此不需要另外维护一张「主题 → 文字色」的色值表。

* 中心铺自定义图片时，改按图片平均亮度取近白 / 近黑对比色；亮度按「路径 + 最后写入时间」缓存（上限 32 条），不在每次弹出轮盘的热路径上重复解码（`DecodePixelWidth = 24` 的缩略解码）。

* 手动模式保留原行为；设置面板「中心文字颜色」整行仅在关闭自动后可编辑（`CoreTextColorRowGrid.IsEnabled`）。

* 文字取到深色时撤掉黑色文字投影（白底上投影只会让字发虚），取到浅色时保留。

* 同一支笔刷同步作用于 `CoreSelectionText` / `CoreVolumeText` / `CoreTitle` / `CoreSubtitle` / `CoreExitIcon`，避免中心区域一半自适应一半写死。

* **设置页 60FPS 实时预览走同一取色规则**（`RenderLiveWheelPreview`）：自动模式跟随预览渲染器的 `_previewTextBrush`（主题文字笔刷），只有关闭自动后才采用 `CoreTextColor`。否则默认值 `#FFFFFFFF` 非空会让预览永远画白字 —— 即轮盘修好了，但预览里的白底白字会原样出现在 PR 截图中。（预览仍不复现「中心铺图按图片亮度取色」那一条：预览的中心图可能来自应用图标 / 自定义图等多个源，要拉齐得先给它加一个统一的图片路径字段，超出本 PR 边界。）

* `I18n` 补 `CoreTextColorAuto` 四语文案（简中 / 繁中 / 英文 / 日文）。

改动面：`AppConfig.cs` +3、`I18n.cs` +7、`RadialWindow.xaml.cs` +100/-17、`SettingsWindow.xaml` +2/-1、`SettingsWindow.xaml.cs` +36/-1。

## 兼容性

* 老用户配置里没有 `CoreTextColorAuto` → 默认 `true`，即默认进入自适应。**需要维护者注意的副作用**：曾经手动设过中心文字色（例如存了 `#FF000000`）的老用户，升级后该色会被静默忽略（值仍在 config 里，取消勾选「自动适应配色主题」就恢复）。我们评估过在 `ConfigManager.EnsureConfigHealth` 里做一次性迁移（`CoreTextColor` 非默认白就置 `auto = false`），但这会与「用户后来主动开启 auto」的意图相冲突（下次启动又会被扳回去），要区分「字段缺失」与「用户刚改过」得把原始 JSON 文本传进健康检查，改动面会超出本 PR。鉴于议题反馈的正是默认体验，这里先取默认开启；若维护者倾向另一种取舍，我可以改成只在 `CoreTextColor` 等于默认白时才走自动。

* 取色失败（图片读不出、笔刷为空）全部有兜底：回落到 `Brushes.White`，与改动前一致。

## 验证

* `dotnet build -c Release`：0 error（单独 rebase 到 `main` 后编译，不依赖另外两条 PR）。

* 真机确认（浅色主题下中心文字变深可读；中心铺亮色 / 暗色图片时分别取近黑 / 近白）正在 v1.7.2-beta.2 基线上复测，结果与截图随本 PR 补上。

* 既有 `tests/test_settings.py` 没有覆盖中心文字取色（轮盘渲染不在该套件的断言范围内）。

## 截图

<img width="1266" height="754" alt="image" src="https://github.com/user-attachments/assets/43d08c27-bb97-463a-81a0-8d53135a008a" />


## AI 代码审查
<img width="836" height="354" alt="image" src="https://github.com/user-attachments/assets/72908071-dc95-41a0-b41f-2a407700223e" />

