### PR TITLE
fix(theme): 补回「自定义配色」主题入口，使高级配色真正生效

### DIFF
--- a/WinPieGestures/I18n.cs
+++ b/WinPieGestures/I18n.cs
@@ -1998,6 +1998,13 @@ public static class I18n
 			[LanguageCode.En] = "Console Theme",
 			[LanguageCode.Ja] = "コントロールパネルテーマ"
 		};
+		dictionary["ThemeCustom"] = new Dictionary<LanguageCode, string>
+		{
+			[LanguageCode.ZhCn] = "\ud83c\udfa8 自定义配色 (Custom Colors)",
+			[LanguageCode.ZhTw] = "\ud83c\udfa8 自定義配色 (Custom Colors)",
+			[LanguageCode.En] = "\ud83c\udfa8 Custom Colors",
+			[LanguageCode.Ja] = "\ud83c\udfa8 カスタム配色"
+		};
 		dictionary["ThemeSystem"] = new Dictionary<LanguageCode, string>
 		{
 			[LanguageCode.ZhCn] = "\ud83d\udda5\ufe0f 跟随 Windows 系统 (Auto)",

--- a/WinPieGestures/SettingsWindow.xaml
+++ b/WinPieGestures/SettingsWindow.xaml
@@ -1379,6 +1379,7 @@
                         <ComboBoxItem Content="抹茶森林 (Matcha Forest)" Tag="MatchaForest" />
                         <ComboBoxItem Content="冰川透蓝 (Glacial Ice)" Tag="GlacialIce" />
                         <ComboBoxItem Content="莫兰迪柔灰 (Morandi Muted)" Tag="MorandiMuted" />
+                        <ComboBoxItem Name="ThemeCustomItem" Content="🎨 自定义配色 (Custom Colors)" Tag="Custom" />
                       </ComboBox>
                       <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,0,0,10">
                         <Button Name="NewCustomColorPresetButton" Content="➕ 新建配色" Style="{StaticResource ModernButtonStyle}" Height="28" Padding="10,0" ToolTip="基于当前色彩创建全新的自定义配色方案预设" Click="NewCustomColorPresetButton_Click" />
@@ -1548,6 +1549,7 @@
                             <ComboBoxItem Content="抹茶森林 (Matcha Forest)" Tag="MatchaForest" />
                             <ComboBoxItem Content="冰川透蓝 (Glacial Ice)" Tag="GlacialIce" />
                             <ComboBoxItem Content="莫兰迪柔灰 (Morandi Muted)" Tag="MorandiMuted" />
+                            <ComboBoxItem Name="SubThemeCustomItem" Content="🎨 自定义配色 (Custom Colors)" Tag="Custom" />
                           </ComboBox>
                           <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,0,0,10">
                             <Button Name="NewSubCustomColorPresetButton" Content="➕ 新建配色" Style="{StaticResource ModernButtonStyle}" Height="28" Padding="10,0" ToolTip="基于当前色彩创建全新的自定义配色方案预设" Click="NewSubCustomColorPresetButton_Click" />

--- a/WinPieGestures/SettingsWindow.xaml.cs
+++ b/WinPieGestures/SettingsWindow.xaml.cs
@@ -1847,6 +1847,14 @@ public partial class SettingsWindow : Window
 		{
 			VolumeFlickJumpDesc.Text = I18n.T("VolumeFlickJumpDesc");
 		}
+		if (ThemeCustomItem != null)
+		{
+			ThemeCustomItem.Content = I18n.T("ThemeCustom");
+		}
+		if (SubThemeCustomItem != null)
+		{
+			SubThemeCustomItem.Content = I18n.T("ThemeCustom");
+		}
 		if (NewCustomColorPresetButton != null)
 		{
 			NewCustomColorPresetButton.Content = I18n.T("NewCustomPresetButton");
@@ -8076,6 +8084,10 @@ public partial class SettingsWindow : Window
 		}
 		string text = tag?.ToString() ?? "FollowPrimary";
 		ConfigManager.CurrentConfig.SubWheelTheme = text;
+		if (text == "Custom" && SubCustomColorExpander != null)
+		{
+			SubCustomColorExpander.IsExpanded = true;
+		}
 		ConfigManager.CurrentConfig.UseIndependentSubWheelTheme = text != "FollowPrimary" || ConfigManager.CurrentConfig.SubWheelUiStyle != "FollowPrimary";
 		bool flag = text.StartsWith("CustomPreset_");
 		if (RenameSubCustomColorPresetButton != null)
@@ -8630,6 +8642,10 @@ public partial class SettingsWindow : Window
 		}
 		string text = tag?.ToString() ?? "System";
 		ConfigManager.CurrentConfig.Theme = text;
+		if (text == "Custom" && CustomColorExpander != null)
+		{
+			CustomColorExpander.IsExpanded = true;
+		}
 		bool flag = text.StartsWith("CustomPreset_");
 		if (RenameCustomColorPresetButton != null)
 		{


### PR DESCRIPTION
# fix(theme): 补回「自定义配色」主题入口，使高级配色真正生效

Ref #75（第 3 项）

## 问题

设置面板「🎨 自定义高级配色」的五个色框会把值写进 `config.CustomSectorBg` / `CustomHighlightBg` 等字段，但 `BaseStyleRenderer.Initialize` **只在 `theme == "Custom"` 时才消费它们**（`BaseStyleRenderer.cs` L98-107），而配色下拉实际只有 `System / Dark / Light / MatchaForest / GlacialIce / MorandiMuted` 六项 —— 全仓库没有任何路径能把 `Theme` 设成 `"Custom"`，因此自定义色永远不会被读取。极简扇区（Clean Sectors）的高亮默认色正是绿色 `#059669` / `#10B981`，于是表现为「**改完颜色还是绿色**」。

## 实现

恢复原设计意图，不改任何配色合并契约：在一级 / 二级轮盘的配色下拉各补一个 `Tag="Custom"` 选项，一次激活仓库内**既有但不可达**的多处分支：

* `BaseStyleRenderer.cs` L98 自定义色合并

* `RadialWindow.xaml.cs` L545 子轮盘 `SubWheelCustom*` 独立配色

* `CatPawRenderer.cs` L18 主题判定

* `SettingsWindow.xaml.cs` L873 / L1080 `CustomColorExpander` 自动展开

* `SettingsWindow.xaml.cs` L8094 自定义预设插入锚点

并补 `ThemeCustom` 四语文案（简中 / 繁中 / 英文 / 日文）及其在本地化流程中的赋值；选中「自定义配色」时自动展开高级配色面板，省一步操作。

改动面：`I18n.cs` +7、`SettingsWindow.xaml` +2、`SettingsWindow.xaml.cs` +16 —— 共 25 行纯新增，无删除、无既有逻辑改动。

## 兼容性

* 默认仍选中原有主题项，未主动改变任何用户的现有配色。

* 只有用户显式选择「自定义配色」时才会走 `theme == "Custom"` 分支，因此不影响既有主题呈现。

## 验证

* `dotnet build -c Release`：0 error（单独 rebase 到 `main` 后编译，不依赖另外两条 PR）。

* 相关用例 `test_v136_custom_color_preset_deletion_and_management`（自定义配色预设的增删与管理）在本改动上跑绿；套件里没有任何断言覆盖「配色主题下拉」与 `theme == "Custom"` 的合并结果，愿意的话我可以补一例 UIA 用例。

* 真机确认（极简扇区选「🎨 自定义配色」后改高亮色立即生效、二级轮盘独立配色同样生效）正在 v1.7.2-beta.2 基线上复测，结果与截图随本 PR 补上。

## 已知限制（既有行为，本 PR 未改动）

1. **切到内置主题会覆盖用户自定义色板**：`ThemeComboBox_SelectionChanged` 的非预设分支会把当前主题的五种颜色回填进 `Custom*TextBox`（L8830-8853），随后 `SyncUiToConfigAndSave`（L2660-2668）无条件把文本框写回 `config.Custom*`。于是「选自定义配色 → 调好色 → 切到 Dark → 再切回自定义配色」会把用户色板冲成 Dark 的色。这是上游既有契约（在 `Custom` 入口存在之前不可达，所以一直没暴露），本 PR 只补入口、不改该契约，以免把 25 行纯新增变成一条要动 `SyncUiToConfigAndSave` 的风险 PR。根治方案是把「当前调色板展示」与「用户自定义色板持久化」拆成两份数据，欢迎另开 issue 跟。相关地，二级轮盘与主轮盘的 `CustomPreset_*` 插入位置不一致（一个是插到 `Custom` 项之前，一个是 `Items.Add` 追加），也建议一并整理。

## AI 代码审查

<img width="819" height="248" alt="image" src="https://github.com/user-attachments/assets/a246dcc6-9b24-4aeb-818b-641c03450322" />
