### PR TITLE
fix: 修复复用轮盘呼出闪烁并保留入场动效

### DIFF
--- a/WinPieGestures/RadialWindow.xaml.cs
+++ b/WinPieGestures/RadialWindow.xaml.cs
@@ -508,6 +508,7 @@ public partial class RadialWindow : Window
 		_borderThickness = 1.0;
 		_highlightBorderThickness = 1.5;
 		InitializeComponent();
+		IsHitTestVisible = false;
 		_centerPoint = centerPoint;
 		_profile = profile;
 		_requestedConfigurationRevision = ConfigManager.ConfigurationRevision;
@@ -547,6 +548,8 @@ public partial class RadialWindow : Window
 		PresentationVersion = presentationVersion;
 		ResetPresentationState();
 		ApplyLayoutFromCurrentConfiguration(centerPoint);
+		// 先将入场动画的初始状态写入视觉树，再显示 HWND，避免先绘制完整圆盘后才切换到动画起始帧造成闪烁。
+		PrepareIntroAnimation();
 
 		if (wasLoaded && needsRebuild)
 		{
@@ -555,6 +558,7 @@ public partial class RadialWindow : Window
 
 		if (!IsVisible)
 		{
+			// HWND 只在首次呈现时创建；后续手势不再 Hide/Show 透明窗口，避免 DWM 复用旧合成帧造成闪烁。
 			Show();
 		}
 		PositionWindowOnTargetMonitor();
@@ -566,10 +570,23 @@ public partial class RadialWindow : Window
 			}
 		}), DispatcherPriority.Render);
 
-		if (wasLoaded)
+		// 内容层在上一帧完成前保持隐藏；下一次 Render 回调再显示并启动动效，
+		// 避免复用透明 HWND 时 DWM 先显示旧的完整视觉树。
+		Dispatcher.BeginInvoke(new Action(() =>
 		{
-			StartIntroAnimation();
-		}
+			if (_isDisposed || !IsVisible || PresentationVersion != presentationVersion)
+			{
+				return;
+			}
+			MainGrid.Visibility = Visibility.Visible;
+			Dispatcher.BeginInvoke(new Action(() =>
+			{
+				if (!_isDisposed && IsVisible && PresentationVersion == presentationVersion)
+				{
+					StartIntroAnimation(presentationVersion);
+				}
+			}), DispatcherPriority.Render);
+		}), DispatcherPriority.Render);
 	}
 
 	/// <summary>隐藏当前手势，但保留 Window/HWND 供下一次呼出复用。旧手势的延迟回调不得隐藏新手势。</summary>
@@ -585,12 +602,16 @@ public partial class RadialWindow : Window
 			return;
 		}
 		StopPresentationAnimations();
+		// 保持透明 HWND 常驻，只隐藏内容层；不再 Hide/Show 窗口，避免 DWM 在重新显示时闪出上一帧。
+		Opacity = 1.0;
+		MainGrid.Visibility = Visibility.Hidden;
+		MainGrid.Opacity = 0.0;
+		WindowScale.ScaleX = 0.65;
+		WindowScale.ScaleY = 0.65;
 		ClearSubTier();
 		CoreVolumeText.Visibility = Visibility.Collapsed;
 		CoreSelectionTextPanel.Visibility = Visibility.Collapsed;
 		CoreSelectionOverlay.Visibility = Visibility.Collapsed;
-		Visibility = Visibility.Collapsed;
-		Hide();
 	}
 
 	private void ApplyLayoutFromCurrentConfiguration(Point requestedCenter)
@@ -931,7 +952,6 @@ public partial class RadialWindow : Window
 				CenterOnPhysically(_centerPoint.X, _centerPoint.Y);
 			}
 		}), DispatcherPriority.Render);
-		StartIntroAnimation();
 	}
 
 	private void RebuildVisualsFromCurrentConfiguration(long configurationRevision)
@@ -1008,10 +1028,24 @@ public partial class RadialWindow : Window
 		_hasRenderedContent = true;
 	}
 
-	private void StartIntroAnimation()
+	private void PrepareIntroAnimation()
 	{
 		StopPresentationAnimations();
-		MainGrid.Opacity = 1.0;
+		// 透明 HWND 保持最终不透明度，内容层从透明/缩小状态开始入场，避免窗口级合成帧切换。
+		Opacity = 1.0;
+		MainGrid.Visibility = Visibility.Hidden;
+		MainGrid.Opacity = 0.0;
+		WindowScale.ScaleX = 0.65;
+		WindowScale.ScaleY = 0.65;
+	}
+
+	private void StartIntroAnimation(long presentationVersion)
+	{
+		if (_isDisposed || !IsVisible || PresentationVersion != presentationVersion)
+		{
+			return;
+		}
+
 		BackEase easingFunction = new BackEase
 		{
 			EasingMode = EasingMode.EaseOut,
@@ -1025,10 +1059,10 @@ public partial class RadialWindow : Window
 		{
 			EasingFunction = easingFunction
 		};
-		DoubleAnimation opacity = new DoubleAnimation(0.0, 1.0, new Duration(TimeSpan.FromMilliseconds(90.0)));
+		DoubleAnimation contentOpacity = new DoubleAnimation(0.0, 1.0, new Duration(TimeSpan.FromMilliseconds(90.0)));
 		WindowScale.BeginAnimation(ScaleTransform.ScaleXProperty, scaleX);
 		WindowScale.BeginAnimation(ScaleTransform.ScaleYProperty, scaleY);
-		MainGrid.BeginAnimation(UIElement.OpacityProperty, opacity);
+		MainGrid.BeginAnimation(UIElement.OpacityProperty, contentOpacity);
 	}
 
 	internal void UpdateCenterIconVisuals()
@@ -2027,7 +2061,7 @@ public partial class RadialWindow : Window
 					EasingMode = EasingMode.EaseOut
 				}
 			};
-			BeginAnimation(UIElement.OpacityProperty, animation);
+			MainGrid.BeginAnimation(UIElement.OpacityProperty, animation);
 		}
 	}
 


### PR DESCRIPTION
# fix: 修复复用轮盘呼出闪烁并保留入场动效

## 背景

在复用单个透明 `RadialWindow/HWND` 后，右键重新呼出轮盘时仍会出现快速闪烁。

问题并非配置或视觉树没有更新，而是透明 WPF 窗口在 `Hide()` / `Show()` 以及窗口级 `Opacity` 动画之间存在合成时序竞争。DWM/WPF 可能在新视觉状态完成提交前短暂显示上一轮透明窗口的合成帧。

## 主要修改

### 保持透明 HWND 常驻

- 复用窗口时不再反复调用 Window 级 `Hide()` / `Show()`。
- `RadialWindow` 的 HWND、`HwndSource` 和透明合成通道继续复用。
- 手势结束时只隐藏内容层，避免透明 HWND 重新显示时触发旧合成帧闪现。
- 应用退出时仍然执行最终的 `CloseFast()`，确保窗口资源正常释放。

### 内容层隐藏与延迟揭示

每次呈现轮盘时：

1. 停止上一轮动画；
2. 重置高亮、二级轮盘、中心状态和缩放状态；
3. 将 `MainGrid.Visibility` 设置为 `Hidden`；
4. 在隐藏状态下应用最新配置并按修订号重建视觉树；
5. 更新窗口位置、尺寸和 DPI；
6. 在下一轮 Dispatcher 渲染周期中将 `MainGrid` 设置为 `Visible`；
7. 再启动入场动画。

使用 `Hidden` 而不是 `Collapsed`，可以保留布局尺寸，避免根视觉树重新测量造成额外抖动。

### 保留入场动效

入场动画仍然保留：

- `MainGrid.Opacity`：`0 → 1`
- `WindowScale.ScaleX`：`0.65 → 1`
- `WindowScale.ScaleY`：`0.65 → 1`

但动画只作用于内容层和内容变换，不再作用于透明 Window 本身。

这样可以同时满足：

- 呼出时不显示旧合成帧；
- 保留轮盘缩放和淡入效果；
- 避免窗口级透明度动画触发 DWM 闪烁。

### 外甩状态动画隔离

外甩取消时的透明度变化改为作用于 `MainGrid` 内容层，而不是透明 `RadialWindow`，避免外甩状态动画与窗口级透明合成产生冲突。

### 输入行为保护

透明轮盘窗口设置为不参与鼠标命中测试，由全局 Hook 负责轮盘交互，避免常驻 HWND 影响桌面和前台应用的鼠标输入。

## 修改文件

- `WinPieGestures/RadialWindow.xaml.cs`

## 预期行为

修复后轮盘生命周期如下：

    首次呼出：
    创建透明 HWND
    → 隐藏内容层
    → 显示窗口
    → 渲染完成
    → 内容层淡入并缩放

    后续呼出：
    复用已有 HWND
    → 隐藏内容层
    → 更新最新配置
    → 完成布局与视觉树刷新
    → 下一轮 Render 显示内容层
    → 播放内容层入场动画

    手势结束：
    隐藏内容层
    → 保留 HWND

    应用退出：
    真正关闭 RadialWindow
