### PR TITLE
ci: 放宽版本校验并兼容大小写 V 标签

### DIFF
--- a/.github/workflows/release-retention.yml
+++ b/.github/workflows/release-retention.yml
@@ -32,7 +32,7 @@ jobs:
 
           $releases = @($releaseJson | ConvertFrom-Json)
           $cutoff = [DateTimeOffset]::UtcNow.AddDays(-7)
-          $stablePattern = '^v(?<baseVersion>\d+\.\d+\.\d+)$'
+          $stablePattern = '^[vV](?<baseVersion>\d+\.\d+\.\d+)$'
           $eligibleStableCount = 0
           $deletedCount = 0
           $failures = [System.Collections.Generic.List[string]]::new()
@@ -62,7 +62,7 @@ jobs:
 
             $eligibleStableCount++
             $baseVersion = $stableMatch.Groups['baseVersion'].Value
-            $betaPattern = "^v$([regex]::Escape($baseVersion))-beta\.(?<number>\d+)$"
+            $betaPattern = "^[vV]$([regex]::Escape($baseVersion))-beta\.(?<number>\d+)$"
             $betaReleases = [System.Collections.Generic.List[object]]::new()
 
             foreach ($release in $releases) {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,31 +43,34 @@ jobs:
           }
 
           $baseVersion = $Matches.baseVersion
-          $prereleaseSuffix = $Matches.prerelease
-          $expectedFourPartVersion = "${baseVersion}.0"
           [xml]$project = Get-Content "WinPieGestures/WinPieGestures.csproj"
 
           $projectVersion = [string]$project.Project.PropertyGroup.Version
-          $projectBaseVersion = ($projectVersion -split '-', 2)[0]
           $assemblyVersion = [string]$project.Project.PropertyGroup.AssemblyVersion
           $fileVersion = [string]$project.Project.PropertyGroup.FileVersion
 
-          if ([string]::IsNullOrEmpty($prereleaseSuffix)) {
-            if ($projectVersion -ne $baseVersion) {
-              throw "Version mismatch: stable tag=$baseVersion Version=$projectVersion"
+          function Get-ThreePartVersion([string]$value, [string]$fieldName) {
+            if ($value -notmatch '^(?<baseVersion>\d+\.\d+\.\d+)(?:[.+-].*)?$') {
+              throw "$fieldName must start with a three-part numeric version: $value"
             }
-          }
-          elseif ($projectBaseVersion -ne $baseVersion) {
-            throw "Version mismatch: beta tag base=$baseVersion Version=$projectVersion"
-          }
-          if ($assemblyVersion -ne $expectedFourPartVersion) {
-            throw "AssemblyVersion mismatch: expected=$expectedFourPartVersion actual=$assemblyVersion"
-          }
-          if ($fileVersion -ne $expectedFourPartVersion) {
-            throw "FileVersion mismatch: expected=$expectedFourPartVersion actual=$fileVersion"
+
+            return $Matches.baseVersion
           }
 
-          Write-Host "Verified Version=$projectVersion AssemblyVersion=$assemblyVersion FileVersion=$fileVersion"
+          $versionFields = @(
+            @{ Name = "Version"; Value = $projectVersion }
+            @{ Name = "AssemblyVersion"; Value = $assemblyVersion }
+            @{ Name = "FileVersion"; Value = $fileVersion }
+          )
+
+          foreach ($field in $versionFields) {
+            $fieldBaseVersion = Get-ThreePartVersion $field.Value $field.Name
+            if ($fieldBaseVersion -ne $baseVersion) {
+              throw "$($field.Name) mismatch: tag base=$baseVersion actual=$($field.Value)"
+            }
+          }
+
+          Write-Host "Verified matching three-part version ${baseVersion}: Version=$projectVersion AssemblyVersion=$assemblyVersion FileVersion=$fileVersion"
 
       - name: Setup .NET SDK 8.0
         uses: actions/setup-dotnet@v4


### PR DESCRIPTION
- Release 构建仅校验 Tag 与项目版本的前三段版本号一致
- 允许 Version 的预发布后缀及 AssemblyVersion、FileVersion 第四段不同
- Release Retention 同时识别小写 v 和大写 V 的稳定版及 Beta 标签