### PR TITLE
fix(radial): 修复外部窗口操作后轮盘被压到后台

### DIFF
--- a/WinPieGestures/RadialWindow.xaml.cs
+++ b/WinPieGestures/RadialWindow.xaml.cs
@@ -30,12 +30,14 @@ public partial class RadialWindow : Window
 
 	private const uint MONITOR_DEFAULTTONEAREST = 2;
 	private const uint SWP_NOSIZE = 0x0001;
+	private const uint SWP_NOMOVE = 0x0002;
 	private const uint SWP_NOACTIVATE = 0x0010;
 	private const uint SWP_NOZORDER = 0x0004;
 	private const int WM_DPICHANGED = 0x02E0;
 	private const int GWL_EXSTYLE = -20;
 	private const nint WS_EX_NOACTIVATE = 0x08000000;
 	private const nint WS_EX_TOOLWINDOW = 0x00000080;
+	private static readonly nint HWND_TOPMOST = new(-1);
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct RECT
@@ -152,6 +154,19 @@ public partial class RadialWindow : Window
 			int physicalLeft = (int)Math.Round(_centerPoint.X - physicalWidth / 2.0);
 			int physicalTop = (int)Math.Round(_centerPoint.Y - physicalHeight / 2.0);
 			SetWindowPos(handle, IntPtr.Zero, physicalLeft, physicalTop, physicalWidth, physicalHeight, SWP_NOACTIVATE | SWP_NOZORDER);
+		}
+
+		/// <summary>
+		/// 常驻透明 HWND 在内容隐藏期间可能被新创建的窗口压到后面；每次揭示内容前重新置于最上层窗口带。
+		/// SWP_NOACTIVATE 保证不抢占当前前台应用与键盘焦点。
+		/// </summary>
+		private void EnsureTopmostNoActivate()
+		{
+			nint handle = new WindowInteropHelper(this).Handle;
+			if (handle != IntPtr.Zero)
+			{
+				SetWindowPos(handle, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+			}
 		}
 
 		/// <summary>
@@ -577,6 +592,7 @@ public partial class RadialWindow : Window
 				return;
 			}
 			CenterOnPhysically(_centerPoint.X, _centerPoint.Y);
+			EnsureTopmostNoActivate();
 			MainGrid.Visibility = Visibility.Visible;
 			StartIntroAnimation(presentationVersion);
 		}), DispatcherPriority.Render);


### PR DESCRIPTION
# fix(radial): 修复某些操作后轮盘被压到应用窗口下方

## 问题描述

某些操作可能导致 StarPie 轮盘出现窗口层级异常，本次触发情况在改变 PowerToys Command Palette 的 `Show Command Palette in system tray` 后触发：

- 轮盘在桌面区域能够正常显示；
- 轮盘会被其他应用窗口遮挡；
- 手势识别与动作触发仍然正常；
- 表明轮盘内容已经完成渲染，但常驻 HWND 的 Z-Order 不正确。

## 当前推测

普通程序启动通常只会调整非置顶窗口之间的顺序，不会越过 StarPie 所在的 Topmost 窗口带，因此正常打开或关闭浏览器等程序一般不会触发问题。

PowerToys 的该选项可能涉及 Command Palette 托盘宿主、隐藏工具窗口、NoActivate/Topmost 窗口的创建或窗口层级重排。这一过程可能使长期常驻的 StarPie HWND 离开 Topmost 窗口带，或使其置顶顺序失效。

目前已确认 PowerToys 操作与问题存在稳定的触发关系，但尚未通过 API 级诊断确定它具体修改了哪个窗口属性，因此以上属于根据现象和现有窗口生命周期作出的推测。

单 HWND 复用后，StarPie 只在首次呼出时执行 `Show()`。后续呼出仅显示 `MainGrid`，而窗口定位使用了 `SWP_NOZORDER`，因此一旦 HWND 层级出现异常，后续呼出不会主动恢复。

## 修改内容

### 每次呈现前重新确认最上层状态

新增 `EnsureTopmostNoActivate()`，在轮盘内容真正显示前调用：

    SetWindowPos(
        handle,
        HWND_TOPMOST,
        0,
        0,
        0,
        0,
        SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);

该调用具有以下效果：

- 使用 `HWND_TOPMOST` 将轮盘重新放回最上层窗口带；
- 使用 `SWP_NOMOVE` 避免改变已完成校准的物理位置；
- 使用 `SWP_NOSIZE` 避免改变当前 DPI 对应的窗口尺寸；
- 使用 `SWP_NOACTIVATE` 避免抢占浏览器、Steam 等前台应用的键盘焦点。

### 调整后的呈现顺序

在 `DispatcherPriority.Render` 回调中依次执行：

    CenterOnPhysically(_centerPoint.X, _centerPoint.Y);
    EnsureTopmostNoActivate();
    MainGrid.Visibility = Visibility.Visible;
    StartIntroAnimation(presentationVersion);

因此轮盘会先完成物理位置校准和窗口层级恢复，再揭示内容并播放入场动画。

## 保留的既有行为

本次修改不会改变现有生命周期设计：

- 继续复用单个 `RadialWindow` 和透明 HWND；
- 手势结束后仍然只隐藏 `MainGrid` 内容层；
- 不恢复每次手势都执行 HWND `Hide/Show` 的旧实现；
- 保留淡入和缩放入场动画；
- 保留 `_isPresented` 与 `PresentationVersion` 竞态守卫；
- 不激活轮盘，不影响当前前台应用的输入焦点；
- 不影响轮盘配置变化时的视觉树重建机制。

## 影响范围

仅修改：

- `WinPieGestures/RadialWindow.xaml.cs`
