### PR TITLE
feat(action): 选择启动应用时同步扇区/子动作名称为软件名

### DIFF
--- a/WinPieGestures/SettingsWindow.xaml.cs
+++ b/WinPieGestures/SettingsWindow.xaml.cs
@@ -6240,14 +6240,11 @@ public partial class SettingsWindow : Window
 			item.InheritAppIconPath = programPicker.SelectedPath;
 			item.IconKey = "";
 			item.CustomIconSvg = "";
-			if (string.IsNullOrWhiteSpace(item.Name) || item.Name.StartsWith("快捷动作") || item.Name.StartsWith("启动"))
-			{
-				string autoName = !string.IsNullOrEmpty(programPicker.SelectedName) 
-					? programPicker.SelectedName 
-					: System.IO.Path.GetFileNameWithoutExtension(programPicker.SelectedPath);
-				item.Name = autoName;
-				FocusActionNameTextBox.Text = autoName;
-			}
+			string autoName = !string.IsNullOrEmpty(programPicker.SelectedName) 
+				? programPicker.SelectedName 
+				: System.IO.Path.GetFileNameWithoutExtension(programPicker.SelectedPath);
+			item.Name = autoName;
+			FocusActionNameTextBox.Text = autoName;
 			UpdateFocusEditorUi();
 			RefreshSlots();
 			RenderMappingsWheelPreview();
@@ -6270,14 +6267,11 @@ public partial class SettingsWindow : Window
 			item.InheritAppIconPath = picker.SelectedPath;
 			item.IconKey = "";
 			item.CustomIconSvg = "";
-			if (string.IsNullOrWhiteSpace(item.Name) || item.Name.StartsWith("快捷动作") || item.Name.StartsWith("启动"))
-			{
-				string autoName = !string.IsNullOrEmpty(picker.SelectedTitle)
-					? picker.SelectedTitle
-					: (!string.IsNullOrEmpty(picker.SelectedProcessName) ? picker.SelectedProcessName : System.IO.Path.GetFileNameWithoutExtension(picker.SelectedPath));
-				item.Name = autoName;
-				FocusActionNameTextBox.Text = autoName;
-			}
+			string autoName = !string.IsNullOrEmpty(picker.SelectedTitle)
+				? picker.SelectedTitle
+				: (!string.IsNullOrEmpty(picker.SelectedProcessName) ? picker.SelectedProcessName : System.IO.Path.GetFileNameWithoutExtension(picker.SelectedPath));
+			item.Name = autoName;
+			FocusActionNameTextBox.Text = autoName;
 			UpdateFocusEditorUi();
 			RefreshSlots();
 			RenderMappingsWheelPreview();
@@ -6303,12 +6297,9 @@ public partial class SettingsWindow : Window
 			item.InheritAppIconPath = dlg.FileName;
 			item.IconKey = "";
 			item.CustomIconSvg = "";
-			if (string.IsNullOrWhiteSpace(item.Name) || item.Name.StartsWith("快捷动作") || item.Name.StartsWith("启动"))
-			{
-				string autoName = System.IO.Path.GetFileNameWithoutExtension(dlg.FileName);
-				item.Name = autoName;
-				FocusActionNameTextBox.Text = autoName;
-			}
+			string autoName = System.IO.Path.GetFileNameWithoutExtension(dlg.FileName);
+			item.Name = autoName;
+			FocusActionNameTextBox.Text = autoName;
 			UpdateFocusEditorUi();
 			RefreshSlots();
 			RenderMappingsWheelPreview();

--- a/WinPieGestures/SubActionEditorWindow.xaml.cs
+++ b/WinPieGestures/SubActionEditorWindow.xaml.cs
@@ -209,12 +209,9 @@ public partial class SubActionEditorWindow : Window
 				vm.InheritAppIconPath = programPicker.SelectedPath;
 				vm.IconKey = "";
 				vm.CustomIconSvg = "";
-				if (string.IsNullOrWhiteSpace(vm.Name) || vm.Name.StartsWith("子动作"))
-				{
-					vm.Name = !string.IsNullOrEmpty(programPicker.SelectedName)
-						? programPicker.SelectedName
-						: Path.GetFileNameWithoutExtension(programPicker.SelectedPath);
-				}
+				vm.Name = !string.IsNullOrEmpty(programPicker.SelectedName)
+					? programPicker.SelectedName
+					: Path.GetFileNameWithoutExtension(programPicker.SelectedPath);
 			}
 		}
 	}
@@ -233,12 +230,9 @@ public partial class SubActionEditorWindow : Window
 				vm.InheritAppIconPath = picker.SelectedPath;
 				vm.IconKey = "";
 				vm.CustomIconSvg = "";
-				if (string.IsNullOrWhiteSpace(vm.Name) || vm.Name.StartsWith("子动作"))
-				{
-					vm.Name = !string.IsNullOrEmpty(picker.SelectedTitle)
-						? picker.SelectedTitle
-						: (!string.IsNullOrEmpty(picker.SelectedProcessName) ? picker.SelectedProcessName : Path.GetFileNameWithoutExtension(picker.SelectedPath));
-				}
+				vm.Name = !string.IsNullOrEmpty(picker.SelectedTitle)
+					? picker.SelectedTitle
+					: (!string.IsNullOrEmpty(picker.SelectedProcessName) ? picker.SelectedProcessName : Path.GetFileNameWithoutExtension(picker.SelectedPath));
 			}
 		}
 	}
@@ -258,10 +252,7 @@ public partial class SubActionEditorWindow : Window
 				vm.InheritAppIconPath = dlg.FileName;
 				vm.IconKey = "";
 				vm.CustomIconSvg = "";
-				if (string.IsNullOrWhiteSpace(vm.Name) || vm.Name.StartsWith("子动作"))
-				{
-					vm.Name = Path.GetFileNameWithoutExtension(dlg.FileName);
-				}
+				vm.Name = Path.GetFileNameWithoutExtension(dlg.FileName);
 			}
 		}
 	}


### PR DESCRIPTION
Closes #103（第一项）

## 背景 / 动机
给扇区或子动作设置"启动目标"时，图标会自动继承所选软件图标，但**动作名称仍停留在占位名"动作 N"**，需要手动改名，体验割裂。

## 方案
与既有的"图标自动继承"对齐：在选择程序的落点**无条件把动作名覆盖为所选软件名**，并同步刷新编辑框显示。名称取值优先用程序库/窗口标题给出的显示名，回退到 `Path.GetFileNameWithoutExtension(exe)`。

覆盖只发生在"选程序 / 抓取运行窗口 / 浏览 exe"的那一刻；已存于配置里的旧名字不会被追溯改写，需重新选一次程序触发。

## 改动点（2 文件）
- `SettingsWindow.xaml.cs`：`FocusPickProgramFromLibrary_Click` / `FocusCaptureRunningWindow_Click` / `FocusBrowseLaunchExe_Click` —— 写 `item.Name = autoName` 并同步 `FocusActionNameTextBox.Text`。
- `SubActionEditorWindow.xaml.cs`：`SubPickProgramFromLibrary_Click` / `SubCaptureRunningWindow_Click` / `SubBrowseProgram_Click` —— 写 `vm.Name`（其 setter 自刷新绑定）。
- 仅"继承图标"按钮（`FocusInheritIcon*` / `SubInheritFrom*`）语义是只换图标不换名，**保持不变**。

## 测试
Release 构建 0 error；实测在带自定义名的扇区重新选程序后，扇区名与轮盘显示随之更新；子动作同。

## 兼容性
无配置字段变更、无序列化改动；纯 UI 行为增强，向后兼容。